### PR TITLE
Simple cache implementation

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -44,7 +44,7 @@ type Cache interface {
 	ConfigWatcher
 
 	// SetResource sets a response for a node group and a type.
-	SetResource(CacheKey, ResponseType, []proto.Message)
+	SetResource(Key, ResponseType, []proto.Message)
 }
 
 // Watch is a dedicated stream of configuration resources produced by the
@@ -93,12 +93,12 @@ const (
 	ListenerResponse
 )
 
-// CacheKey is the node group identifier
-type CacheKey string
+// Key is the node group identifier
+type Key string
 
 // NodeGroup aggregates configuration resources by a hash of the node.
 type NodeGroup interface {
 	// Hash returns a string identifier for the proxy nodes.
 	// Must be a thread-safe function.
-	Hash(*api.Node) CacheKey
+	Hash(*api.Node) Key
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -64,6 +64,17 @@ type Response struct {
 	Canary bool
 }
 
+// ResponseType is an enumeration of cache response types.
+type ResponseType int
+
+// xDS response types
+const (
+	EndpointResponse ResponseType = iota
+	ClusterResponse
+	RouteResponse
+	ListenerResponse
+)
+
 // Cancel cancels the watch. Watch must be cancelled to release resources in the cache.
 // Cancel can be called multiple times.
 func (watch Watch) Cancel() {
@@ -73,8 +84,11 @@ func (watch Watch) Cancel() {
 	}
 }
 
+// CacheKey is the node group identifier
+type CacheKey string
+
 // NodeGroup aggregates configuration resources by a hash of the node.
 type NodeGroup interface {
 	// Hash returns a string identifier for the proxy nodes.
-	Hash(*api.Node) string
+	Hash(*api.Node) CacheKey
 }

--- a/pkg/cache/simple.go
+++ b/pkg/cache/simple.go
@@ -1,0 +1,38 @@
+// Copyright 2017 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package cache
+
+import "github.com/golang/protobuf/proto"
+
+// SimpleCache is a snapshot-based cache that maintains a single version per
+// xDS response, node group tuple.
+type SimpleCache struct {
+	responses map[CacheKey][ResponseType]proto.Message
+	versions  map[CacheKey][ResponseType]int
+}
+
+func (cache *SimpleCache) SetResource(key CacheKey, typ ResponseType) {
+	// update the existing entry
+
+	// trigger watches
+}
+
+type SimpleWatcher struct {
+}
+
+func (watcher *SimpleWatcher) WatchEndpoints(*api.Node, string, []string) {
+	return watcher.Watch(EndpointType, node, version, 
+}
+

--- a/pkg/cache/simple.go
+++ b/pkg/cache/simple.go
@@ -26,16 +26,16 @@ import (
 // xDS response, node group tuple, with no canary updates.
 type SimpleCache struct {
 	// responses are cached resources
-	responses map[CacheKey]map[ResponseType][]proto.Message
+	responses map[Key]map[ResponseType][]proto.Message
 
 	// versions must have the same key set as responses
-	versions map[CacheKey]map[ResponseType]int
+	versions map[Key]map[ResponseType]int
 
 	// watches keeps track of open watches
-	watches map[CacheKey]map[ResponseType]map[int64]Watch
+	watches map[Key]map[ResponseType]map[int64]Watch
 
 	// callback requests missing responses
-	callback func(CacheKey, ResponseType)
+	callback func(Key, ResponseType)
 
 	// watchCount is the ID generator for watches
 	watchCount int64
@@ -49,18 +49,18 @@ type SimpleCache struct {
 // MakeSimpleCache initializes a simple cache.
 // callback function is called on every new cache key and response type if there is no response available.
 // callback is executed in a go-routine.
-func MakeSimpleCache(groups NodeGroup, callback func(CacheKey, ResponseType)) Cache {
+func MakeSimpleCache(groups NodeGroup, callback func(Key, ResponseType)) Cache {
 	return &SimpleCache{
-		responses:  make(map[CacheKey]map[ResponseType][]proto.Message),
-		versions:   make(map[CacheKey]map[ResponseType]int),
-		watches:    make(map[CacheKey]map[ResponseType]map[int64]Watch),
+		responses:  make(map[Key]map[ResponseType][]proto.Message),
+		versions:   make(map[Key]map[ResponseType]int),
+		watches:    make(map[Key]map[ResponseType]map[int64]Watch),
 		callback:   callback,
 		watchCount: 0,
 		groups:     groups,
 	}
 }
 
-func (cache *SimpleCache) SetResource(group CacheKey, typ ResponseType, resources []proto.Message) {
+func (cache *SimpleCache) SetResource(group Key, typ ResponseType, resources []proto.Message) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -128,38 +128,42 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, impl
 			if closed {
 				return status.Errorf(codes.Unavailable, "endpoints watch failed")
 			}
-			if nonce, err := send(resp, EndpointType); err != nil {
+			nonce, err := send(resp, EndpointType)
+			if err != nil {
 				return err
-			} else {
-				values.endpointNonce = nonce
 			}
+			values.endpointNonce = nonce
+
 		case resp, closed := <-values.clusters.Value:
 			if closed {
 				return status.Errorf(codes.Unavailable, "clusters watch failed")
 			}
-			if nonce, err := send(resp, ClusterType); err != nil {
+			nonce, err := send(resp, ClusterType)
+			if err != nil {
 				return err
-			} else {
-				values.clusterNonce = nonce
 			}
+			values.clusterNonce = nonce
+
 		case resp, closed := <-values.routes.Value:
 			if closed {
 				return status.Errorf(codes.Unavailable, "routes watch failed")
 			}
-			if nonce, err := send(resp, RouteType); err != nil {
+			nonce, err := send(resp, RouteType)
+			if err != nil {
 				return err
-			} else {
-				values.routeNonce = nonce
 			}
+			values.routeNonce = nonce
+
 		case resp, closed := <-values.listeners.Value:
 			if closed {
 				return status.Errorf(codes.Unavailable, "listeners watch failed")
 			}
-			if nonce, err := send(resp, ListenerType); err != nil {
+			nonce, err := send(resp, ListenerType)
+			if err != nil {
 				return err
-			} else {
-				values.listenerNonce = nonce
 			}
+			values.listenerNonce = nonce
+
 		case req, closed := <-reqCh:
 			switch {
 			case closed:


### PR DESCRIPTION
Implement a cache of responses with a callback function.
The cache is protected by a single lock, keeps track of watches and versions.
The cache responds to open watches on every update, and increments a version per request type.