### PR TITLE
Validate xDS server implementation manually

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,9 +1,12 @@
-hash: 4a93d137997e9460155cee1f14ed622ec79af78d581368328f6580b77adec9ab
-updated: 2017-10-24T15:47:15.479300833-07:00
+hash: a1c33016f72e58edd25e7e7b363104f5cf7922a4acb843a348abfd64932df3aa
+updated: 2017-11-06T16:44:42.564473884-08:00
 imports:
+- name: github.com/golang/glog
+  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
 - name: github.com/golang/protobuf
   version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
   subpackages:
+  - jsonpb
   - proto
   - protoc-gen-go/descriptor
   - ptypes
@@ -35,7 +38,7 @@ imports:
   - googleapis/api/annotations
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: f7bf885db0b7479a537ec317c6e48ce53145f3db
+  version: 5ffe3083946d5603a0578721101dc8165b1d5b5f
   subpackages:
   - balancer
   - codes

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,3 +16,4 @@ import:
   - googleapis/api/annotations
 - package: google.golang.org/grpc
   version: ^1.7.0
+- package: github.com/golang/glog

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -72,7 +72,7 @@ type Watch struct {
 
 // Cancel cancels the watch. Watch must be cancelled to release resources in the cache.
 // Cancel can be called multiple times.
-func (watch Watch) Cancel() {
+func (watch *Watch) Cancel() {
 	if watch.stop != nil {
 		watch.stop()
 		watch.stop = nil

--- a/pkg/cache/simple.go
+++ b/pkg/cache/simple.go
@@ -30,6 +30,11 @@ import (
 // part of the request. It is expected that the CDS response names all EDS
 // clusters, and the LDS response names all RDS routes in a snapshot, to ensure
 // that Envoy makes the request for all EDS clusters or RDS routes eventually.
+//
+// SimpleCache can also be used as a config cache for distinct xDS requests.
+// The snapshots are required to contain only the responses for the particular
+// type of the xDS service that the cache serves. Synchronization of multiple
+// caches for different response types is left to the configuration producer.
 type SimpleCache struct {
 	// snapshots are cached resources
 	snapshots map[Key]Snapshot

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -95,7 +95,7 @@ func (values watches) cancel() {
 // process handles a bi-di stream request
 func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defaultTypeURL string) error {
 	// increment stream count
-	streamId := atomic.AddInt64(&s.streamCount, 1)
+	streamID := atomic.AddInt64(&s.streamCount, 1)
 
 	// unique nonce generator for req-resp pairs per xDS stream; the server
 	// ignores stale nonces. nonce is only modified within send() function.
@@ -122,7 +122,7 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 			}
 		}
 		nonce := strconv.FormatInt(streamNonce, 10)
-		glog.V(10).Infof("[%d] respond %s with nonce %q version %q", streamId, typeURL, nonce, resp.Version)
+		glog.V(10).Infof("[%d] respond %s with nonce %q version %q", streamID, typeURL, nonce, resp.Version)
 		out := &api.DiscoveryResponse{
 			VersionInfo: resp.Version,
 			Resources:   resources,
@@ -133,7 +133,7 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 		return nonce, stream.Send(out)
 	}
 
-	glog.V(10).Infof("[%d] open stream for %q", streamId, defaultTypeURL)
+	glog.V(10).Infof("[%d] open stream for %q", streamID, defaultTypeURL)
 	for {
 		select {
 		// config watcher can send the requested resources types in any order
@@ -180,7 +180,7 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 		case req, more := <-reqCh:
 			// input stream ended or errored out
 			if !more {
-				glog.V(10).Infof("[%d] stream closed", streamId)
+				glog.V(10).Infof("[%d] stream closed", streamID)
 				return nil
 			}
 
@@ -192,7 +192,7 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 				return fmt.Errorf("unexpected resource requested, want %q got %q", defaultTypeURL, req.TypeUrl)
 			}
 
-			glog.V(10).Infof("[%d] request %s%v with nonce %q from version %q", streamId, req.TypeUrl,
+			glog.V(10).Infof("[%d] request %s%v with nonce %q from version %q", streamID, req.TypeUrl,
 				req.GetResourceNames(), nonce, req.GetVersionInfo())
 
 			// cancel existing watches to (re-)request a newer version

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -16,16 +16,16 @@
 package server
 
 import (
+	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"sync/atomic"
 
 	"github.com/envoyproxy/go-control-plane/api"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
-	context "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -53,6 +53,9 @@ func NewServer(config cache.ConfigWatcher) Server {
 
 type server struct {
 	config cache.ConfigWatcher
+
+	// streamCount for counting bi-di streams
+	streamCount int64
 }
 
 func (s *server) Register(srv *grpc.Server) {
@@ -89,10 +92,16 @@ func (values watches) cancel() {
 	values.listeners.Cancel()
 }
 
+// process handles a bi-di stream request
 func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defaultTypeURL string) error {
-	// unique nonce for req-resp pairs per xDS stream; the server ignores stale nonces.
-	// nonce is only modified within send() function.
+	// increment stream count
+	streamId := atomic.AddInt64(&s.streamCount, 1)
+
+	// unique nonce generator for req-resp pairs per xDS stream; the server
+	// ignores stale nonces. nonce is only modified within send() function.
 	var streamNonce int64
+
+	// a collection of watches per request type
 	var values watches
 	defer func() {
 		values.cancel()
@@ -113,6 +122,7 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 			}
 		}
 		nonce := strconv.FormatInt(streamNonce, 10)
+		glog.V(10).Infof("[%d] respond %s with nonce %q version %q", streamId, typeURL, nonce, resp.Version)
 		out := &api.DiscoveryResponse{
 			VersionInfo: resp.Version,
 			Resources:   resources,
@@ -123,6 +133,7 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 		return nonce, stream.Send(out)
 	}
 
+	glog.V(10).Infof("[%d] open stream for %q", streamId, defaultTypeURL)
 	for {
 		select {
 		// config watcher can send the requested resources types in any order
@@ -169,7 +180,7 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 		case req, more := <-reqCh:
 			// input stream ended or errored out
 			if !more {
-				log.Printf("stream closed")
+				glog.V(10).Infof("[%d] stream closed", streamId)
 				return nil
 			}
 
@@ -181,7 +192,8 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 				return fmt.Errorf("unexpected resource requested, want %q got %q", defaultTypeURL, req.TypeUrl)
 			}
 
-			log.Printf("request %s%v with nonce %q from version %q", req.TypeUrl, req.GetResourceNames(), nonce, req.GetVersionInfo())
+			glog.V(10).Infof("[%d] request %s%v with nonce %q from version %q", streamId, req.TypeUrl,
+				req.GetResourceNames(), nonce, req.GetVersionInfo())
 
 			// cancel existing watches to (re-)request a newer version
 			switch {
@@ -202,8 +214,8 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 	}
 }
 
+// handler converts a blocking read call to channels and initiates stream processing
 func (s *server) handler(stream stream, typeURL string) error {
-	log.Printf("handle stream for %q", typeURL)
 	// a channel for receiving incoming requests
 	reqCh := make(chan *api.DiscoveryRequest, 0)
 	reqStop := int32(0)
@@ -211,11 +223,9 @@ func (s *server) handler(stream stream, typeURL string) error {
 		for {
 			req, err := stream.Recv()
 			if atomic.LoadInt32(&reqStop) != 0 {
-				log.Printf("reqStop termination")
 				return
 			}
 			if err != nil {
-				log.Printf("req error %v", err)
 				close(reqCh)
 				return
 			}

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -217,7 +217,7 @@ func (s *server) process(stream stream, reqCh <-chan *api.DiscoveryRequest, defa
 // handler converts a blocking read call to channels and initiates stream processing
 func (s *server) handler(stream stream, typeURL string) error {
 	// a channel for receiving incoming requests
-	reqCh := make(chan *api.DiscoveryRequest, 0)
+	reqCh := make(chan *api.DiscoveryRequest)
 	reqStop := int32(0)
 	go func() {
 		for {

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -16,19 +16,15 @@
 package main
 
 import (
+	"context"
 	"flag"
-	"fmt"
-	"net"
-	"net/http"
+	"os"
+	"os/exec"
 	"time"
 
-	"github.com/envoyproxy/go-control-plane/api"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
-	xds "github.com/envoyproxy/go-control-plane/pkg/grpc"
 	"github.com/envoyproxy/go-control-plane/pkg/test"
 	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"google.golang.org/grpc"
 )
 
 var (
@@ -36,7 +32,6 @@ var (
 	listenPort   uint
 	xdsPort      uint
 	interval     time.Duration
-	node         string
 )
 
 func init() {
@@ -44,80 +39,41 @@ func init() {
 	flag.UintVar(&listenPort, "listen", 9000, "Listener port")
 	flag.UintVar(&xdsPort, "xds", 18000, "xDS server port")
 	flag.DurationVar(&interval, "interval", 30*time.Second, "Interval between cache refresh")
-	flag.StringVar(&node, "node", "node", "Node group name")
 }
 
 func main() {
 	flag.Parse()
+	ctx := context.Background()
+
 	// start upstream
-	go runHTTP()
+	go test.RunHTTP(ctx, upstreamPort)
 
 	// create a cache
-	config := cache.NewSimpleCache(hasher{}, nil)
+	config := cache.NewSimpleCache(test.Hasher{}, nil)
 
 	// update the cache at a regular interval
-	go func() {
-		i := 0
-		for {
-			version := fmt.Sprintf("version%d", i)
-			clusterName := fmt.Sprintf("cluster%d", i)
-			routeName := fmt.Sprintf("route%d", i)
-			// listener name must be same since ports are shared and previous listener is drained
-			listenerName := "listener"
-
-			endpoint := test.MakeEndpoint(clusterName, uint32(upstreamPort))
-			cluster := test.MakeCluster(clusterName)
-			route := test.MakeRoute(routeName, clusterName)
-			listener := test.MakeListener(listenerName, uint32(listenPort), routeName)
-
-			glog.Infof("updating cache with %d-labelled responses", i)
-			snapshot := cache.NewSnapshot(version,
-				[]proto.Message{endpoint},
-				[]proto.Message{cluster},
-				[]proto.Message{route},
-				[]proto.Message{listener})
-			config.SetSnapshot(cache.Key(node), snapshot)
-
-			time.Sleep(interval)
-			i++
-		}
-	}()
+	go test.RunCacheUpdate(ctx, config, interval, upstreamPort, listenPort)
 
 	// start the xDS server
-	server := xds.NewServer(config)
-	grpcServer := grpc.NewServer()
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", xdsPort))
-	if err != nil {
-		glog.Fatalf("failed to listen: %v", err)
-	}
-	server.Register(grpcServer)
-	glog.Infof("xDS server listening on %d", xdsPort)
-	if err = grpcServer.Serve(lis); err != nil {
-		glog.Error(err)
-	}
-}
+	go test.RunXDS(ctx, config, xdsPort)
 
-type hasher struct {
-}
+	// start envoy
+	envoy := exec.Command("envoy",
+		"-c", "pkg/test/main/server_ads.yaml",
+		"--service-cluster", "test",
+		"--service-node", "test",
+		"--drain-time-s", "1")
+	envoy.Stdout = os.Stdout
+	envoy.Stderr = os.Stderr
+	envoy.Start()
 
-func (hash hasher) Hash(*api.Node) (cache.Key, error) {
-	return cache.Key(node), nil
-}
+	for {
+		if err := test.CheckResponse(listenPort); err != nil {
+			glog.Errorf("ERROR %v", err)
+		} else {
+			glog.Info("OK")
+		}
 
-type handler struct {
-}
-
-func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/text")
-	if _, err := w.Write([]byte("Hi, there!\n")); err != nil {
-		glog.Error(err)
-	}
-}
-
-func runHTTP() {
-	glog.Infof("upstream listening HTTP1.1 on %d", upstreamPort)
-	h := handler{}
-	if err := http.ListenAndServe(fmt.Sprintf(":%d", upstreamPort), h); err != nil {
-		glog.Error(err)
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -16,7 +16,6 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"net"
@@ -109,10 +108,8 @@ type handler struct {
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	glog.Infof("received request from %q...", r.RemoteAddr)
-	body := bytes.Buffer{}
 	w.Header().Set("Content-Type", "application/text")
-	if _, err := w.Write(body.Bytes()); err != nil {
+	if _, err := w.Write([]byte("Hi, there!\n")); err != nil {
 		glog.Error(err)
 	}
 }

--- a/pkg/test/main/server_xds.yaml
+++ b/pkg/test/main/server_xds.yaml
@@ -2,14 +2,17 @@ node:
   id: test-id
   cluster: test-cluster
 dynamic_resources:
-  lds_config: {ads: {}}
-  cds_config: {ads: {}}
-  ads_config:
-    api_type: GRPC
-    cluster_name: [ads_cluster]
+  lds_config:
+    api_config_source:
+      api_type: GRPC
+      cluster_name: [xds_cluster]
+  cds_config:
+    api_config_source:
+      api_type: GRPC
+      cluster_name: [xds_cluster]
 static_resources:
   clusters:
-  - name: ads_cluster
+  - name: xds_cluster
     connect_timeout: { seconds: 5 }
     type: STATIC
     hosts:

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -1,0 +1,146 @@
+// Copyright 2017 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+// Package test contains test utilities
+package test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/envoyproxy/go-control-plane/api"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	xds "github.com/envoyproxy/go-control-plane/pkg/grpc"
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc"
+)
+
+const (
+	node  = "service-node"
+	hello = "Hi, there!\n"
+)
+
+// Hasher is a single cache key hash.
+type Hasher struct {
+}
+
+// Hash function that always returns same value.
+func (h Hasher) Hash(*api.Node) (cache.Key, error) {
+	return cache.Key(node), nil
+}
+
+type handler struct {
+}
+
+func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/text")
+	if _, err := w.Write([]byte(hello)); err != nil {
+		glog.Error(err)
+	}
+}
+
+// RunHTTP opens a simple listener on the port.
+func RunHTTP(ctx context.Context, upstreamPort uint) {
+	glog.Infof("upstream listening HTTP1.1 on %d", upstreamPort)
+	h := handler{}
+	server := &http.Server{Addr: fmt.Sprintf(":%d", upstreamPort), Handler: h}
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			glog.Error(err)
+		}
+	}()
+	if err := server.Shutdown(ctx); err != nil {
+		glog.Error(err)
+	}
+}
+
+// RunXDS starts an xDS server at the given port.
+func RunXDS(ctx context.Context, config cache.Cache, port uint) {
+	server := xds.NewServer(config)
+	grpcServer := grpc.NewServer()
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		glog.Fatalf("failed to listen: %v", err)
+	}
+	server.Register(grpcServer)
+	glog.Infof("xDS server listening on %d", port)
+	go func() {
+		if err = grpcServer.Serve(lis); err != nil {
+			glog.Error(err)
+		}
+	}()
+	<-ctx.Done()
+	grpcServer.GracefulStop()
+}
+
+// RunCacheUpdate executes a config update sequence every second.
+func RunCacheUpdate(ctx context.Context,
+	config cache.Cache,
+	interval time.Duration,
+	upstreamPort, listenPort uint) {
+	i := 0
+	for {
+		version := fmt.Sprintf("version%d", i)
+		clusterName := fmt.Sprintf("cluster%d", i)
+		routeName := fmt.Sprintf("route%d", i)
+		// listener name must be same since ports are shared and previous listener is drained
+		listenerName := "listener"
+
+		endpoint := MakeEndpoint(clusterName, uint32(upstreamPort))
+		cluster := MakeCluster(clusterName)
+		route := MakeRoute(routeName, clusterName)
+		listener := MakeListener(listenerName, uint32(listenPort), routeName)
+
+		glog.Infof("updating cache with %d-labelled responses", i)
+		snapshot := cache.NewSnapshot(version,
+			[]proto.Message{endpoint},
+			[]proto.Message{cluster},
+			[]proto.Message{route},
+			[]proto.Message{listener})
+		config.SetSnapshot(cache.Key(node), snapshot)
+
+		select {
+		case <-time.After(interval):
+		case <-ctx.Done():
+			return
+		}
+		i++
+	}
+}
+
+// CheckResponse makes a request to localhost at the given port and checks that the response body matches.
+func CheckResponse(port uint) error {
+	glog.Infof("making a request to :%d", port)
+	client := http.Client{
+		Timeout: 1 * time.Second,
+	}
+	req, err := client.Get(fmt.Sprintf("http://localhost:%d", port))
+	if err != nil {
+		return err
+	}
+	defer req.Body.Close()
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return err
+	}
+	if string(body) != hello {
+		return fmt.Errorf("unexpected return %q", string(body))
+	}
+	return nil
+}

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -92,6 +92,7 @@ func RunXDS(ctx context.Context, config cache.Cache, port uint) {
 // RunCacheUpdate executes a config update sequence every second.
 func RunCacheUpdate(ctx context.Context,
 	config cache.Cache,
+	ads bool,
 	interval time.Duration,
 	upstreamPort, listenPort uint) {
 	i := 0
@@ -103,9 +104,9 @@ func RunCacheUpdate(ctx context.Context,
 		listenerName := "listener"
 
 		endpoint := MakeEndpoint(clusterName, uint32(upstreamPort))
-		cluster := MakeCluster(clusterName)
+		cluster := MakeCluster(ads, clusterName)
 		route := MakeRoute(routeName, clusterName)
-		listener := MakeListener(listenerName, uint32(listenPort), routeName)
+		listener := MakeListener(ads, listenerName, uint32(listenPort), routeName)
 
 		glog.Infof("updating cache with %d-labelled responses", i)
 		snapshot := cache.NewSnapshot(version,


### PR DESCRIPTION
- use `glog` for logging (at v=10)
- respond to review comments from last PR
- use stream ID for logging convenience
- configure Envoy to use four xDS services in place of one ADS service
- automate manual script with:
```bash
go run pkg/test/main/main.go  --logtostderr -v 10 # ADS
go run pkg/test/main/main.go  --logtostderr -v 10 -ads=false # L/R/C/EDS
```