### PR TITLE
Fix loop over resources in cache:simple:respond

### DIFF
--- a/pkg/cache/simple.go
+++ b/pkg/cache/simple.go
@@ -133,13 +133,18 @@ func respond(watch Watch, snapshot Snapshot, group Key) {
 		}
 
 		// check that every snapshot resource name is present in the request
+		found := false
 		for _, resource := range resources {
 			resourceName := GetResourceName(resource)
-			if _, exists := names[resourceName]; !exists {
-				glog.V(10).Infof("not responding for %s from %q at %q since %q not requested %v",
-					typ.String(), group, version, resourceName, watch.Names)
-				continue
+			if _, exists := names[resourceName]; exists {
+				found = true
+				break
 			}
+		}
+		if !found {
+			glog.V(10).Infof("not responding for %s from %q at %q since %v do not exist in resources",
+				typ.String(), group, version, watch.Names)
+			return
 		}
 	}
 

--- a/pkg/cache/simple.go
+++ b/pkg/cache/simple.go
@@ -138,7 +138,7 @@ func respond(watch Watch, snapshot Snapshot, group Key) {
 			if _, exists := names[resourceName]; !exists {
 				glog.V(10).Infof("not responding for %s from %q at %q since %q not requested %v",
 					typ.String(), group, version, resourceName, watch.Names)
-				return
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
This would break when having, for example, multiple clusters and requesting ClusterLoadAssignment for the second in resources.

I used this repo to build an XDS that uses consul as backend (opinionated towards our in-house setup). I have 114 services, and envoy only has endpoints for one. This fixes that.