### PR TITLE
Fix standard definitions import

### DIFF
--- a/build/generate_protos.sh
+++ b/build/generate_protos.sh
@@ -15,6 +15,7 @@ imports=(
   ${xds}
   "${root}/vendor/github.com/lyft/protoc-gen-validate"
   "${root}/vendor/github.com/gogo/protobuf"
+  "${root}/vendor/github.com/gogo/protobuf/protobuf"
   "${root}/vendor/istio.io/gogo-genproto/prometheus"
   "${root}/vendor/istio.io/gogo-genproto/googleapis"
   "${root}/vendor/istio.io/gogo-genproto/opencensus/proto/trace"


### PR DESCRIPTION
`protoc` automatically includes `include` directory next to it, which is not always the case.
Force including definitions for the standard protos, like `google.protobuf.Struct`.

cc @ostromart

Signed-off-by: Kuat Yessenov <kuat@google.com>