### PR TITLE
fix golint and HTTPGateway logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,9 @@ tools.govet:
 tools.golint:
 	@command -v golint >/dev/null ; if [ $$? -ne 0 ]; then \
 		echo "--> installing golint"; \
-		go get github.com/golang/lint/golint; \
+		mkdir -p $$GOPATH/src/golang.org/x \
+		  && git clone https://github.com/golang/lint.git $$GOPATH/src/golang.org/x/lint \
+		  && go get -u golang.org/x/lint/golint; \
 	fi
 
 tools.glide:

--- a/pkg/server/gateway.go
+++ b/pkg/server/gateway.go
@@ -89,8 +89,7 @@ func (h *HTTPGateway) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 		http.Error(resp, "marshal error: "+err.Error(), http.StatusInternalServerError)
 	}
 
-	_, err = resp.Write(buf.Bytes())
-	if h.Log != nil {
+	if _, err = resp.Write(buf.Bytes()); err != nil && h.Log != nil {
 		h.Log.Errorf("gateway error: %v", err)
 	}
 }


### PR DESCRIPTION
Roughly logging without testing errors is annoying, so here is a minor fix on the `HTTPGateway`'s response log.