### PR TITLE
Close request.Body in Gateway

### DIFF
--- a/pkg/server/gateway.go
+++ b/pkg/server/gateway.go
@@ -61,6 +61,7 @@ func (h *HTTPGateway) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	}
 
 	body, err := ioutil.ReadAll(req.Body)
+	defer req.Body.Close()
 	if err != nil {
 		http.Error(resp, "cannot read body", http.StatusBadRequest)
 		return


### PR DESCRIPTION
Closes request.Body to avoid memory leak.