### PR TITLE
Update tests to fix breaking changes to bootstrap

### DIFF
--- a/build/integration.sh
+++ b/build/integration.sh
@@ -16,13 +16,15 @@ SERVER_PID=$!
 
 # Envoy start-up command
 ENVOY=${ENVOY:-/usr/local/bin/envoy}
+ENVOY_LOG="envoy.log"
 
 # Start envoy: important to keep drain time short
-(${ENVOY} -c sample/bootstrap-${XDS}.yaml --drain-time-s 1 --v2-config-only -l debug 2> envoy.log)&
+(${ENVOY} -c sample/bootstrap-${XDS}.yaml --drain-time-s 1 -l debug 2> ${ENVOY_LOG})&
 ENVOY_PID=$!
 
 function cleanup() {
   kill ${ENVOY_PID}
+  echo Envoy log: ${ENVOY_LOG}
 }
 trap cleanup EXIT
 

--- a/pkg/test/resource/resource.go
+++ b/pkg/test/resource/resource.go
@@ -91,8 +91,12 @@ func MakeCluster(mode string, clusterName string) *v2.Cluster {
 		edsSource = &core.ConfigSource{
 			ConfigSourceSpecifier: &core.ConfigSource_ApiConfigSource{
 				ApiConfigSource: &core.ApiConfigSource{
-					ApiType:      core.ApiConfigSource_GRPC,
-					ClusterNames: []string{XdsCluster},
+					ApiType: core.ApiConfigSource_GRPC,
+					GrpcServices: []*core.GrpcService{{
+						TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+							EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: XdsCluster},
+						},
+					}},
 				},
 			},
 		}
@@ -155,8 +159,12 @@ func MakeHTTPListener(mode string, listenerName string, port uint32, route strin
 	case Xds:
 		rdsSource.ConfigSourceSpecifier = &core.ConfigSource_ApiConfigSource{
 			ApiConfigSource: &core.ApiConfigSource{
-				ApiType:      core.ApiConfigSource_GRPC,
-				ClusterNames: []string{XdsCluster},
+				ApiType: core.ApiConfigSource_GRPC,
+				GrpcServices: []*core.GrpcService{{
+					TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: XdsCluster},
+					},
+				}},
 			},
 		}
 	case Rest:

--- a/sample/bootstrap-ads.yaml
+++ b/sample/bootstrap-ads.yaml
@@ -8,8 +8,9 @@ admin:
 dynamic_resources:
   ads_config:
     api_type: GRPC
-    cluster_names:
-    - xds_cluster
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
   cds_config:
     ads: {}
   lds_config:

--- a/sample/bootstrap-xds.yaml
+++ b/sample/bootstrap-xds.yaml
@@ -9,13 +9,15 @@ dynamic_resources:
   cds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names:
-      - xds_cluster
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
   lds_config:
     api_config_source:
       api_type: GRPC
-      cluster_names:
-      - xds_cluster
+      grpc_services:
+      - envoy_grpc:
+          cluster_name: xds_cluster
 node:
   cluster: test-cluster
   id: test-id


### PR DESCRIPTION
`cluster_names` is no longer valid for gRPC API config sources.

Signed-off-by: Kuat Yessenov <kuat@google.com>