### PR TITLE
Adds access to context in the server callbacks

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,6 +48,7 @@ type Server interface {
 // The callbacks are invoked synchronously.
 type Callbacks interface {
 	// OnStreamOpen is called once an xDS stream is open with a stream ID and the type URL (or "" for ADS).
+	// Returning an error will end processing and close the stream. OnStreamClosed will still be called.
 	OnStreamOpen(context.Context, int64, string) error
 	// OnStreamClosed is called immediately prior to closing an xDS stream with a stream ID.
 	OnStreamClosed(int64)
@@ -55,7 +56,8 @@ type Callbacks interface {
 	OnStreamRequest(int64, *v2.DiscoveryRequest)
 	// OnStreamResponse is called immediately prior to sending a response on a stream.
 	OnStreamResponse(int64, *v2.DiscoveryRequest, *v2.DiscoveryResponse)
-	// OnFetchRequest is called for each Fetch request
+	// OnFetchRequest is called for each Fetch request. Returning an error will end processing of the
+	// request and respond with an error.
 	OnFetchRequest(context.Context, *v2.DiscoveryRequest) error
 	// OnFetchResponse is called immediately prior to sending a response.
 	OnFetchResponse(*v2.DiscoveryRequest, *v2.DiscoveryResponse)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -47,7 +48,7 @@ type Server interface {
 // The callbacks are invoked synchronously.
 type Callbacks interface {
 	// OnStreamOpen is called once an xDS stream is open with a stream ID and the type URL (or "" for ADS).
-	OnStreamOpen(int64, string)
+	OnStreamOpen(context.Context, int64, string) error
 	// OnStreamClosed is called immediately prior to closing an xDS stream with a stream ID.
 	OnStreamClosed(int64)
 	// OnStreamRequest is called once a request is received on a stream.
@@ -55,12 +56,12 @@ type Callbacks interface {
 	// OnStreamResponse is called immediately prior to sending a response on a stream.
 	OnStreamResponse(int64, *v2.DiscoveryRequest, *v2.DiscoveryResponse)
 	// OnFetchRequest is called for each Fetch request
-	OnFetchRequest(*v2.DiscoveryRequest)
+	OnFetchRequest(context.Context, *v2.DiscoveryRequest) error
 	// OnFetchResponse is called immediately prior to sending a response.
 	OnFetchResponse(*v2.DiscoveryRequest, *v2.DiscoveryResponse)
 }
 
-// NewServer creates handlers from a config watcher and an optional logger.
+// NewServer creates handlers from a config watcher and callbacks.
 func NewServer(config cache.Cache, callbacks Callbacks) Server {
 	return &server{cache: config, callbacks: callbacks}
 }
@@ -74,6 +75,8 @@ type server struct {
 }
 
 type stream interface {
+	grpc.ServerStream
+
 	Send(*v2.DiscoveryResponse) error
 	Recv() (*v2.DiscoveryRequest, error)
 }
@@ -170,7 +173,9 @@ func (s *server) process(stream stream, reqCh <-chan *v2.DiscoveryRequest, defau
 	}
 
 	if s.callbacks != nil {
-		s.callbacks.OnStreamOpen(streamID, defaultTypeURL)
+		if err := s.callbacks.OnStreamOpen(stream.Context(), streamID, defaultTypeURL); err != nil {
+			return err
+		}
 	}
 
 	for {
@@ -319,7 +324,9 @@ func (s *server) StreamListeners(stream v2.ListenerDiscoveryService_StreamListen
 // Fetch is the universal fetch method.
 func (s *server) Fetch(ctx context.Context, req *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
 	if s.callbacks != nil {
-		s.callbacks.OnFetchRequest(req)
+		if err := s.callbacks.OnFetchRequest(ctx, req); err != nil {
+			return nil, err
+		}
 	}
 	resp, err := s.cache.Fetch(ctx, *req)
 	if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -68,17 +68,24 @@ func makeMockConfigWatcher() *mockConfigWatcher {
 }
 
 type callbacks struct {
-	fetchReq  int
-	fetchResp int
+	fetchReq      int
+	fetchResp     int
+	callbackError bool
 }
 
 func (c *callbacks) OnStreamOpen(context.Context, int64, string) error {
+	if c.callbackError {
+		return errors.New("stream open error")
+	}
 	return nil
 }
 func (c *callbacks) OnStreamClosed(int64)                                                {}
 func (c *callbacks) OnStreamRequest(int64, *v2.DiscoveryRequest)                         {}
 func (c *callbacks) OnStreamResponse(int64, *v2.DiscoveryRequest, *v2.DiscoveryResponse) {}
 func (c *callbacks) OnFetchRequest(context.Context, *v2.DiscoveryRequest) error {
+	if c.callbackError {
+		return errors.New("fetch request error")
+	}
 	c.fetchReq++
 	return nil
 }
@@ -272,6 +279,21 @@ func TestFetch(t *testing.T) {
 		t.Errorf("expected empty on empty request: %v", err)
 	}
 
+	// send error from callback
+	cb.callbackError = true
+	if out, err := s.FetchEndpoints(context.Background(), &v2.DiscoveryRequest{Node: node}); out != nil || err == nil {
+		t.Errorf("expected empty or error due to callback error")
+	}
+	if out, err := s.FetchClusters(context.Background(), &v2.DiscoveryRequest{Node: node}); out != nil || err == nil {
+		t.Errorf("expected empty or error due to callback error")
+	}
+	if out, err := s.FetchRoutes(context.Background(), &v2.DiscoveryRequest{Node: node}); out != nil || err == nil {
+		t.Errorf("expected empty or error due to callback error")
+	}
+	if out, err := s.FetchListeners(context.Background(), &v2.DiscoveryRequest{Node: node}); out != nil || err == nil {
+		t.Errorf("expected empty or error due to callback error")
+	}
+
 	// verify fetch callbacks
 	if want := 8; cb.fetchReq != want {
 		t.Errorf("unexpected number of fetch requests: got %d, want %d", cb.fetchReq, want)
@@ -320,7 +342,7 @@ func TestSendError(t *testing.T) {
 				TypeUrl: typ,
 			}
 
-			// check that response fails since watch gets closed
+			// check that response fails since send returns error
 			if err := s.StreamAggregatedResources(resp); err == nil {
 				t.Error("Stream() => got no error, want send error")
 			}
@@ -440,5 +462,29 @@ func TestAggregateRequestType(t *testing.T) {
 	resp.recv <- &v2.DiscoveryRequest{Node: node}
 	if err := s.StreamAggregatedResources(resp); err == nil {
 		t.Error("StreamAggregatedResources() => got nil, want an error")
+	}
+}
+
+func TestCallbackError(t *testing.T) {
+	for _, typ := range cache.ResponseTypes {
+		t.Run(typ, func(t *testing.T) {
+			config := makeMockConfigWatcher()
+			config.responses = makeResponses()
+			s := server.NewServer(config, &callbacks{callbackError: true})
+
+			// make a request
+			resp := makeMockStream(t)
+			resp.recv <- &v2.DiscoveryRequest{
+				Node:    node,
+				TypeUrl: typ,
+			}
+
+			// check that response fails since stream open returns error
+			if err := s.StreamAggregatedResources(resp); err == nil {
+				t.Error("Stream() => got no error, want error")
+			}
+
+			close(resp.recv)
+		})
 	}
 }

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -218,8 +218,9 @@ func (cb *callbacks) Report() {
 	defer cb.mu.Unlock()
 	log.WithFields(log.Fields{"fetches": cb.fetches, "requests": cb.requests}).Info("server callbacks")
 }
-func (cb *callbacks) OnStreamOpen(id int64, typ string) {
+func (cb *callbacks) OnStreamOpen(_ context.Context, id int64, typ string) error {
 	log.Debugf("stream %d open for %s", id, typ)
+	return nil
 }
 func (cb *callbacks) OnStreamClosed(id int64) {
 	log.Debugf("stream %d closed", id)
@@ -234,7 +235,7 @@ func (cb *callbacks) OnStreamRequest(int64, *v2.DiscoveryRequest) {
 	}
 }
 func (cb *callbacks) OnStreamResponse(int64, *v2.DiscoveryRequest, *v2.DiscoveryResponse) {}
-func (cb *callbacks) OnFetchRequest(req *v2.DiscoveryRequest) {
+func (cb *callbacks) OnFetchRequest(_ context.Context, req *v2.DiscoveryRequest) error {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 	cb.fetches++
@@ -242,5 +243,6 @@ func (cb *callbacks) OnFetchRequest(req *v2.DiscoveryRequest) {
 		close(cb.signal)
 		cb.signal = nil
 	}
+	return nil
 }
 func (cb *callbacks) OnFetchResponse(*v2.DiscoveryRequest, *v2.DiscoveryResponse) {}


### PR DESCRIPTION
This change adds the stream/request context to the server callbacks.  This allows functionality such as an authentication middleware that extracts an identity and adds it to the context to have authorization checks in the server callbacks.  The context can be checked during the OnStreamOpen or OnFetchRequest callbacks.  If for some reason the request should not be allowed to proceed, then the callback can return an error to end processing.

Since this is a breaking change for consumers of this package as a library, the version number should be bumped.