### PR TITLE
Wait for http server to exit prior to closing (#114)

### DIFF
--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -66,10 +66,6 @@ func RunHTTP(ctx context.Context, upstreamPort uint) {
 			log.Error(err)
 		}
 	}()
-	<-ctx.Done()
-	if err := server.Shutdown(ctx); err != nil {
-		log.Error(err)
-	}
 }
 
 // RunAccessLogServer starts an accesslog service.
@@ -137,8 +133,4 @@ func RunManagementGateway(ctx context.Context, srv xds.Server, port uint) {
 			log.Error(err)
 		}
 	}()
-	<-ctx.Done()
-	if err := server.Shutdown(ctx); err != nil {
-		log.Error(err)
-	}
 }

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -66,6 +66,7 @@ func RunHTTP(ctx context.Context, upstreamPort uint) {
 			log.Error(err)
 		}
 	}()
+	<-ctx.Done()
 	if err := server.Shutdown(ctx); err != nil {
 		log.Error(err)
 	}
@@ -136,6 +137,7 @@ func RunManagementGateway(ctx context.Context, srv xds.Server, port uint) {
 			log.Error(err)
 		}
 	}()
+	<-ctx.Done()
 	if err := server.Shutdown(ctx); err != nil {
 		log.Error(err)
 	}


### PR DESCRIPTION
We are running the test http servers in a goroutine. Consequently,
executing returns to the thread starting the server. This caller
assumes that the server is done, so it closes the server for graceful
shutdown. However, the server may not be done since it's running on a
separate thread and we're not waiting for that to finish. This leads to
the integration failing randomly.

Fix the problem by waiting for ctx->Done, like we're doing with the
grpc servers.