### PR TITLE
Add simple usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,49 @@ make test
 ```sh
 make integration.docker
 ```
+
+## Usage
+
+Register services on the gRPC server as follows.
+
+```go
+import (
+	"net"
+
+	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	xds "github.com/envoyproxy/go-control-plane/pkg/server"
+)
+
+func main() {
+  snapshotCache := cache.NewSnapshotCache(false, hash{}, nil)
+	server := xds.NewServer(snapshotCache, nil)
+	grpcServer := grpc.NewServer()
+	lis, _ := net.Listen("tcp", ":8080")
+
+	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
+	api.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
+	api.RegisterClusterDiscoveryServiceServer(grpcServer, server)
+	api.RegisterRouteDiscoveryServiceServer(grpcServer, server)
+	api.RegisterListenerDiscoveryServiceServer(grpcServer, server)
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			// error handling
+		}
+	}()
+}
+```
+
+As mentioned in [Scope](https://github.com/envoyproxy/go-control-plane/blob/master/README.md#scope), you need to cache Envoy configurations.  
+Generate the key based on the node information as follows and cache the configurations.
+
+```go
+import "github.com/envoyproxy/go-control-plane/pkg/cache"
+
+var clusters, endpoints, routes, listeners []cache.Resource
+
+snapshotCache := cache.NewSnapshotCache(false, hash{}, nil)
+snapshot := cache.NewSnapshot("1.0", endpoints, clusters, routes, listeners)
+_ = snapshotCache.SetSnapshot("node1", snapshot)
+```


### PR DESCRIPTION
Hi, I love go-control-plane.

I think that adding a simple usage to the README will lower the difficulty level of use.
In particular, the use of `pkg/cache.SnapshotCache.SetSnapshot()` is mandatory and this should be documented.