### PR TITLE
Testing: Move creation of linux-test bin to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
+FROM golang:latest
+WORKDIR /go/src/github.com/envoyproxy/go-control-plane/
+ARG test_out_bin=bin/test-linux
+ENV CGO_ENABLED 1
+ENV GOOS linux
+ENV GOARCH amd64
+COPY . .
+RUN go build -race -o ${test_out_bin} pkg/test/main/main.go
+
 # Integration test docker file
 FROM envoyproxy/envoy:latest
 ADD sample /sample
 ADD build/integration.sh build/integration.sh
-ADD bin/test-linux /bin/test
+COPY --from=0 /go/src/github.com/envoyproxy/go-control-plane/bin/test-linux /bin/test
 ENTRYPOINT ["build/integration.sh"]

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ $(BINDIR)/test-linux: vendor
 	@echo "--> building Linux test binary"
 	@env GOOS=linux GOARCH=amd64 go build -race -o $@ pkg/test/main/main.go
 
-docker: $(BINDIR)/test-linux
+docker: vendor
 	@echo "--> building test docker image"
 	@docker build -t test .
 


### PR DESCRIPTION
This change takes the existing creation of a linux-test binary
and moves it to a Docker build step.  The advantage of this change
is that it's easier to support development of the go-control-plane
by keeping the creation of the test binary be consistent across
environments.

Signed-off-by: Nicholas J <nicholas.a.johns5@gmail.com>