### PR TITLE
Upgrade: Update golang from 1.10 to 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/envoyproxy/go-control-plane
     docker:
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.11
     steps:
       - checkout
       - run: make depend.install


### PR DESCRIPTION
The current stable version of go is 1.11.

Signed-off-by: Nicholas J <nicholas.a.johns5@gmail.com>