### PR TITLE
Feature: Add support for stale-bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,46 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# General configuration
+# Label to use when marking as stale
+staleLabel: stale
+
+# Pull request specific configuration
+pulls:
+  # Number of days of inactivity before an Issue or Pull Request becomes stale
+  daysUntilStale: 30
+  # Number of days of inactivity before a stale Issue or Pull Request is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+  daysUntilClose: 7
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    activity in the last 30 days. It will be closed in 7 days if no further activity occurs. Please
+    feel free to give a status update now, ping for review, or re-open when it's ready.
+    Thank you for your contributions!
+  # Comment to post when closing a stale Issue or Pull Request.
+  closeComment: >
+     This pull request has been automatically closed because it has not had
+     activity in the last 37 days. Please feel free to give a status update now, ping for review, or re-open when it's ready.
+     Thank you for your contributions!
+  # Limit the number of actions per hour, from 1-30. Default is 30
+  limitPerRun: 1
+  exemptLabels:
+    - no stalebot
+
+# Issue specific configuration
+issues:
+  limitPerRun: 1
+  daysUntilStale: 30
+  daysUntilClose: 7
+  markComment: >
+    This issue has been automatically marked as stale because it has not had activity in the
+    last 30 days. It will be closed in the next 7 days unless it is tagged "help wanted" or other activity
+    occurs. Thank you for your contributions.
+  closeComment: >
+    This issue has been automatically closed because it has not had activity in the
+    last 37 days. If this issue is still valid, please ping a maintainer and ask them to label it as "help wanted".
+    Thank you for your contributions.
+  exemptLabels:
+    - help wanted
+    - no stalebot
+    - enhancement


### PR DESCRIPTION
This PR adds support for stale-bot to keep issues and PRs clean over
time.

The period for marking issues and pull requests stale was increase to
30days due to the low-touch nature of this repository.  Additionally issues marked "enhancement" are not marked as stale.

If this integration is not necessary I am definitely open to closing this PR 😄 .

Followup: an admin will need to enable stale-bot for this repo.

Signed-off-by: Nicholas J <nicholas.a.johns5@gmail.com>