### PR TITLE
Allow Callbacks.OnStreamRequest() to return an error to close stream

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -80,7 +80,7 @@ func (c *callbacks) OnStreamOpen(context.Context, int64, string) error {
 	return nil
 }
 func (c *callbacks) OnStreamClosed(int64)                                                {}
-func (c *callbacks) OnStreamRequest(int64, *v2.DiscoveryRequest)                         {}
+func (c *callbacks) OnStreamRequest(int64, *v2.DiscoveryRequest) error                   { return nil }
 func (c *callbacks) OnStreamResponse(int64, *v2.DiscoveryRequest, *v2.DiscoveryResponse) {}
 func (c *callbacks) OnFetchRequest(context.Context, *v2.DiscoveryRequest) error {
 	if c.callbackError {

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -236,7 +236,7 @@ func (cb *callbacks) OnStreamOpen(_ context.Context, id int64, typ string) error
 func (cb *callbacks) OnStreamClosed(id int64) {
 	log.Debugf("stream %d closed", id)
 }
-func (cb *callbacks) OnStreamRequest(int64, *v2.DiscoveryRequest) {
+func (cb *callbacks) OnStreamRequest(int64, *v2.DiscoveryRequest) error {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 	cb.requests++
@@ -244,6 +244,7 @@ func (cb *callbacks) OnStreamRequest(int64, *v2.DiscoveryRequest) {
 		close(cb.signal)
 		cb.signal = nil
 	}
+	return nil
 }
 func (cb *callbacks) OnStreamResponse(int64, *v2.DiscoveryRequest, *v2.DiscoveryResponse) {}
 func (cb *callbacks) OnFetchRequest(_ context.Context, req *v2.DiscoveryRequest) error {


### PR DESCRIPTION
As mentioned #153, this PR allows Callbacks.OnStreamRequest() to return an error to close streams.  In certain circumstances, rate limiting, for example, server should be able to make a decision to terminate a stream after it receives a stream request. 