### PR TITLE
Add a GetSnapshot method to SnapshotCache interface

### DIFF
--- a/pkg/cache/simple.go
+++ b/pkg/cache/simple.go
@@ -47,6 +47,9 @@ type SnapshotCache interface {
 	// the version differs from the snapshot version.
 	SetSnapshot(node string, snapshot Snapshot) error
 
+	// GetSnapshots gets the snapshot for a node.
+	GetSnapshot(node string) (Snapshot, error)
+
 	// ClearSnapshot removes all status and snapshot information associated with a node.
 	ClearSnapshot(node string)
 }
@@ -120,6 +123,18 @@ func (cache *snapshotCache) SetSnapshot(node string, snapshot Snapshot) error {
 	}
 
 	return nil
+}
+
+// GetSnapshots gets the snapshot for a node, and returns an error if not found.
+func (cache *snapshotCache) GetSnapshot(node string) (Snapshot, error) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	snap, ok := cache.snapshots[node]
+	if !ok {
+		return Snapshot{}, fmt.Errorf("no snapshot found for node %s", node)
+	}
+	return snap, nil
 }
 
 // ClearSnapshot clears snapshot and info for a node.

--- a/pkg/cache/simple.go
+++ b/pkg/cache/simple.go
@@ -127,8 +127,8 @@ func (cache *snapshotCache) SetSnapshot(node string, snapshot Snapshot) error {
 
 // GetSnapshots gets the snapshot for a node, and returns an error if not found.
 func (cache *snapshotCache) GetSnapshot(node string) (Snapshot, error) {
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
 
 	snap, ok := cache.snapshots[node]
 	if !ok {

--- a/pkg/cache/simple_test.go
+++ b/pkg/cache/simple_test.go
@@ -112,6 +112,14 @@ func TestSnapshotCacheFetch(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	snap, err := c.GetSnapshot(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(snap, snapshot) {
+		t.Errorf("expect snapshot: %v, got: %v", snapshot, snap)
+	}
+
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
 			resp, err := c.Fetch(context.Background(), v2.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})

--- a/pkg/cache/simple_test.go
+++ b/pkg/cache/simple_test.go
@@ -75,8 +75,20 @@ func (log logger) Errorf(format string, args ...interface{}) { log.t.Logf(format
 func TestSnapshotCache(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
 
+	if _, err := c.GetSnapshot(key); err == nil {
+		t.Errorf("unexpected snapshot found for key %q", key)
+	}
+
 	if err := c.SetSnapshot(key, snapshot); err != nil {
 		t.Fatal(err)
+	}
+
+	snap, err := c.GetSnapshot(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(snap, snapshot) {
+		t.Errorf("expect snapshot: %v, got: %v", snapshot, snap)
 	}
 
 	// try to get endpoints with incorrect list of names
@@ -110,14 +122,6 @@ func TestSnapshotCacheFetch(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
 	if err := c.SetSnapshot(key, snapshot); err != nil {
 		t.Fatal(err)
-	}
-
-	snap, err := c.GetSnapshot(key)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(snap, snapshot) {
-		t.Errorf("expect snapshot: %v, got: %v", snapshot, snap)
 	}
 
 	for _, typ := range testTypes {


### PR DESCRIPTION
Currently `SnapshotCache` doesn't have a way to get the snapshot for a `node`, not even checking whether a snapshot exist for a `node`.  

This adds a `GetSnapshot` method to the `SnapshotCache` interface. Example use case: when implementing the OnStreamRequest callback, it needs to know whether the snapshot for a `node` has already been generated or not, and generate snapshot only if it doesn't 