### PR TITLE
Several nodes may look to single snapshot

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -50,10 +50,10 @@ type Cache interface {
 	Fetch(context.Context, Request) (*Response, error)
 
 	// GetStatusInfo retrieves status information for a node ID.
-	GetStatusInfo(string) StatusInfo
+	GetStatusInfo(NodeID) StatusInfo
 
 	// GetStatusKeys retrieves node IDs for all statuses.
-	GetStatusKeys() []string
+	GetStatusKeys() []NodeID
 }
 
 // Response is a pre-serialized xDS response.

--- a/pkg/cache/simple_test.go
+++ b/pkg/cache/simple_test.go
@@ -33,11 +33,18 @@ const (
 	key = "node"
 )
 
-func (group) ID(node *core.Node) string {
+func (group) SnapshotID(node *core.Node) cache.SnapshotID {
 	if node != nil {
-		return node.Id
+		return cache.SnapshotID(node.Id)
 	}
-	return key
+	return cache.SnapshotID(key)
+}
+
+func (group) NodeID(node *core.Node) cache.NodeID {
+	if node != nil {
+		return cache.NodeID(node.Id)
+	}
+	return cache.NodeID(key)
 }
 
 var (
@@ -215,7 +222,7 @@ func TestConcurrentSetWatch(t *testing.T) {
 				id := fmt.Sprintf("%d", i%2)
 				var cancel func()
 				if i < 25 {
-					c.SetSnapshot(id, cache.Snapshot{
+					c.SetSnapshot(cache.SnapshotID(id), cache.Snapshot{
 						Endpoints: cache.NewResources(fmt.Sprintf("v%d", i), []cache.Resource{resource.MakeEndpoint(clusterName, uint32(i))}),
 					})
 				} else {

--- a/pkg/cache/status.go
+++ b/pkg/cache/status.go
@@ -21,10 +21,14 @@ import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 )
 
+type NodeID string
+type SnapshotID string
+
 // NodeHash computes string identifiers for Envoy nodes.
 type NodeHash interface {
 	// ID function defines a unique string identifier for the remote Envoy node.
-	ID(node *core.Node) string
+	SnapshotID(node *core.Node) SnapshotID
+	NodeID(node *core.Node) NodeID
 }
 
 // StatusInfo tracks the server state for the remote Envoy node.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -58,8 +58,8 @@ func (config *mockConfigWatcher) Fetch(ctx context.Context, req v2.DiscoveryRequ
 	return nil, errors.New("missing")
 }
 
-func (config *mockConfigWatcher) GetStatusInfo(string) cache.StatusInfo { return nil }
-func (config *mockConfigWatcher) GetStatusKeys() []string               { return nil }
+func (config *mockConfigWatcher) GetStatusInfo(cache.NodeID) cache.StatusInfo { return nil }
+func (config *mockConfigWatcher) GetStatusKeys() []cache.NodeID               { return nil }
 
 func makeMockConfigWatcher() *mockConfigWatcher {
 	return &mockConfigWatcher{

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -119,7 +119,7 @@ func main() {
 			log.Printf("snapshot inconsistency: %+v\n", snapshot)
 		}
 
-		err := config.SetSnapshot(nodeID, snapshot)
+		err := config.SetSnapshot(cache.SnapshotID(nodeID), snapshot)
 		if err != nil {
 			log.Printf("snapshot error %q for %+v\n", err, snapshot)
 			os.Exit(1)

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -18,6 +18,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"log"
 	"net"
 	"net/http"
@@ -41,11 +42,18 @@ type Hasher struct {
 }
 
 // ID function
-func (h Hasher) ID(node *core.Node) string {
+func (h Hasher) SnapshotID(node *core.Node) cache.SnapshotID {
 	if node == nil {
-		return "unknown"
+		return cache.SnapshotID("unknown")
 	}
-	return node.Id
+	return cache.SnapshotID(node.Id)
+}
+
+func (h Hasher) NodeID(node *core.Node) cache.NodeID {
+	if node == nil {
+		return cache.NodeID("unknown")
+	}
+	return cache.NodeID(node.Id)
 }
 
 type echo struct{}


### PR DESCRIPTION
Hi

Want to propose this change. 

The main idea - in many cases, several nodes will have the same set of resources. And especially we don't need to know in advance exact names of nodes that we want to configure. But obviously, watchers must be tracked separately depending on the exact node name.