### PR TITLE
Remove deprecated cluster.hosts in sample

### DIFF
--- a/sample/bootstrap-ads.yaml
+++ b/sample/bootstrap-ads.yaml
@@ -21,9 +21,14 @@ node:
 static_resources:
   clusters:
   - connect_timeout: 1s
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 18000
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 18000
     http2_protocol_options: {}
     name: xds_cluster

--- a/sample/bootstrap-rest.yaml
+++ b/sample/bootstrap-rest.yaml
@@ -24,8 +24,13 @@ node:
 static_resources:
   clusters:
   - connect_timeout: 1s
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 18001
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 18000
     name: xds_cluster

--- a/sample/bootstrap-xds.yaml
+++ b/sample/bootstrap-xds.yaml
@@ -24,9 +24,14 @@ node:
 static_resources:
   clusters:
   - connect_timeout: 1s
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 18000
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 18000
     http2_protocol_options: {}
     name: xds_cluster


### PR DESCRIPTION
Substitute `cluster.hosts` with `cluster.load_assignment` in the sample configs, as per [deprecation](https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated#version-1-8-0-oct-4-2018).