### PR TITLE
unpin envoy from CI testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go-control-plane
     docker:
-      - image: gcr.io/istio-testing/go-control-plane-ci:05-09-2019
+      - image: gcr.io/istio-testing/go-control-plane-ci:05-31-2019
     steps:
       - checkout
       - run: make build

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -22,5 +22,4 @@ RUN rm go.mod
 RUN rm go.sum
 
 # add envoy
-# Due to https://github.com/envoyproxy/envoy/issues/6237, we have to pin envoy temporarily
-COPY --from=envoyproxy/envoy:0634e7bcbfea7317eaf805a657d048ffa27f519a /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --from=envoyproxy/envoy:latest /usr/local/bin/envoy /usr/local/bin/envoy


### PR DESCRIPTION
The issue with DELTA_GRPC being force upon was fixed, so we can unpin envoy now.

Signed-off-by: Kuat Yessenov <kuat@google.com>