### PR TITLE
Properly reply to envoy clients when the REST fetch is skipped.

### DIFF
--- a/pkg/cache/simple.go
+++ b/pkg/cache/simple.go
@@ -16,13 +16,13 @@ package cache
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/pkg/log"
+	"github.com/envoyproxy/go-control-plane/pkg/util"
 )
 
 // SnapshotCache is a snapshot-based cache that maintains a single versioned
@@ -286,7 +286,7 @@ func (cache *snapshotCache) Fetch(ctx context.Context, request Request) (*Respon
 		// It might be beneficial to hold the request since Envoy will re-attempt the refresh.
 		version := snapshot.GetVersion(request.TypeUrl)
 		if request.VersionInfo == version {
-			return nil, errors.New("skip fetch: version up to date")
+			return nil, &util.SkipFetchError{}
 		}
 
 		resources := snapshot.GetResources(request.TypeUrl)

--- a/pkg/server/gateway.go
+++ b/pkg/server/gateway.go
@@ -25,6 +25,7 @@ import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/envoyproxy/go-control-plane/pkg/log"
+	"github.com/envoyproxy/go-control-plane/pkg/util"
 )
 
 // HTTPGateway is a custom implementation of [gRPC gateway](https://github.com/grpc-ecosystem/grpc-gateway)
@@ -80,9 +81,13 @@ func (h *HTTPGateway) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	// fetch results
 	res, err := h.Server.Fetch(req.Context(), out)
 	if err != nil {
-		// Note that this is treated as internal error. We may want to use another code for
-		// the latest version fetch request.
-		http.Error(resp, "fetch error: "+err.Error(), http.StatusInternalServerError)
+		// SkipFetchErrors will return a 304 which will signify to the envoy client that
+		// it is already at the latest version; all other errors will 500 with a message.
+		if _, ok := err.(*util.SkipFetchError); ok {
+			resp.WriteHeader(http.StatusNotModified)
+		} else {
+			http.Error(resp, "fetch error: "+err.Error(), http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/pkg/util/wellknown.go
+++ b/pkg/util/wellknown.go
@@ -113,3 +113,12 @@ const (
 	// HTTPGRPCAccessLog sink for the HTTP gRPC access log service
 	HTTPGRPCAccessLog = "envoy.http_grpc_access_log"
 )
+
+// SkipFetchError is the error returned when the cache fetch is short
+// circuited due to the client's version already being up-to-date.
+type SkipFetchError struct{}
+
+// Error satisfies the error interface
+func (e SkipFetchError) Error() string {
+	return "skip fetch: version up to date"
+}


### PR DESCRIPTION
When an envoy client initiates a REST fetch, `go-control-plane` compares the client's current version against the proper current version. If these versions match then the fetch is short-circuited and "errors". This erroring culminates in a HTTP status code 500 being sent to the client (just like with any generic error). Due to the change [here](https://github.com/envoyproxy/envoy/pull/6948) and the documentation [here](https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/v2_overview#rest-endpoints) in `envoyproxy`, skipped fetches should be signaled to the client as HTTP status code 304.

This PR gives the skipped fetch path a specific error type (in `simple.go`) and then checks for that specific error type in `gateway.go`. A 304 is specially returned when the error is of the `SkipFetchError` type. This will allow the `envoy` client to properly understand that the fetch was skipped and it will no longer log the following warning:

```
[28][warning][config] [bazel-out/k8-opt/bin/source/common/config/_virtual_includes/http_subscription_lib/common/config/http_subscription_impl.h:115] REST config update failed: fetch failure
```