### PR TITLE
add run_docker.sh and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,43 +43,45 @@ feedback, we might decided to revisit this aspect at a later point in time.
 
 ## Quick start
 
+It's recommended to run the command with script `./build/run_docker.sh` as it executes the command
+in the same environment as the circle ci. This makes sure to produce a consistent set of generated files.
+
 1. Setup existing build:
 
-```sh
-make build
-make test
-```
+    ```sh
+    ./build/run_docker.sh make build test
+    ```
 
-2. Generate proto files (if you update the [data-plane-api](https://github.com/envoyproxy/data-plane-api)
+1. Generate proto files (if you update the [data-plane-api](https://github.com/envoyproxy/data-plane-api)
 dependency)
 
-```sh
-make generate
-```
+    ```sh
+    ./build/run_docker.sh make generate
+    ```
 
-You should use the included [build image](Dockerfile.ci) to produce a consistent set of generated files, e.g.
+    __NOTE__: you may need to apply a small patch to correct imports in the generate files:
 
-```sh
-docker run -v $(pwd):/go-control-plane gcr.io/istio-testing/go-control-plane-ci:05-09-2019 make generate
-```
+    ```sh
+    ./build/run_docker.sh make generate-patch
+    ```
 
-Format the code:
+    Format the code:
 
-```sh
-make format
-```
+    ```sh
+    ./build/run_docker.sh make format
+    ```
 
-__NOTE__: you may need to apply a small patch to correct imports in the generate files:
+    Run build and unit tests again:
 
-```sh
-make generate-patch
-```
+    ```sh
+    ./build/run_docker.sh make build test
+    ```
 
-3. Run [integration test](pkg/test/main/README.md) against the latest Envoy binary:
+1. Run [integration test](pkg/test/main/README.md) against the latest Envoy binary:
 
-```sh
-make integration
-```
+    ```sh
+    ./build/run_docker.sh make integration
+    ```
 
 ## Usage
 

--- a/build/run_docker.sh
+++ b/build/run_docker.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+IMAGE_HUB="gcr.io/istio-testing/go-control-plane-ci"
+IMAGE_TAG=$(grep "${IMAGE_HUB}" .circleci/config.yml | sed -e "s#.*${IMAGE_HUB}:\(.*\)#\1#" | uniq)
+
+if [ -z "${IMAGE_TAG}" ]; then
+  echo "failed to extract the image tag for ${IMAGE_HUB}"
+  exit 1
+fi
+
+docker run -v $(pwd):/go-control-plane "${IMAGE_HUB}":"${IMAGE_TAG}" $*


### PR DESCRIPTION
Also the old image in the README is out-dated. This PR adds a script `run_docker.sh` that extracts the latest image automatically from the `.circleci/config.yml` so that we only need to update it in one place.