### PR TITLE
Rename grpc imports

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,19 +28,20 @@ import (
 	"google.golang.org/grpc/status"
 
 	v2 "github.com/envoyproxy/go-control-plane/v2/envoy/api/v2"
+	v2grpc "github.com/envoyproxy/go-control-plane/v2/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/v2/envoy/api/v2/core"
-	discovery "github.com/envoyproxy/go-control-plane/v2/envoy/service/discovery/v2"
+	discoverygrpc "github.com/envoyproxy/go-control-plane/v2/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/v2/pkg/cache"
 )
 
 // Server is a collection of handlers for streaming discovery requests.
 type Server interface {
-	v2.EndpointDiscoveryServiceServer
-	v2.ClusterDiscoveryServiceServer
-	v2.RouteDiscoveryServiceServer
-	v2.ListenerDiscoveryServiceServer
-	discovery.AggregatedDiscoveryServiceServer
-	discovery.SecretDiscoveryServiceServer
+	v2grpc.EndpointDiscoveryServiceServer
+	v2grpc.ClusterDiscoveryServiceServer
+	v2grpc.RouteDiscoveryServiceServer
+	v2grpc.ListenerDiscoveryServiceServer
+	discoverygrpc.AggregatedDiscoveryServiceServer
+	discoverygrpc.SecretDiscoveryServiceServer
 
 	// Fetch is the universal fetch method.
 	Fetch(context.Context, *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error)
@@ -343,27 +344,27 @@ func (s *server) handler(stream stream, typeURL string) error {
 	return err
 }
 
-func (s *server) StreamAggregatedResources(stream discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+func (s *server) StreamAggregatedResources(stream discoverygrpc.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 	return s.handler(stream, cache.AnyType)
 }
 
-func (s *server) StreamEndpoints(stream v2.EndpointDiscoveryService_StreamEndpointsServer) error {
+func (s *server) StreamEndpoints(stream v2grpc.EndpointDiscoveryService_StreamEndpointsServer) error {
 	return s.handler(stream, cache.EndpointType)
 }
 
-func (s *server) StreamClusters(stream v2.ClusterDiscoveryService_StreamClustersServer) error {
+func (s *server) StreamClusters(stream v2grpc.ClusterDiscoveryService_StreamClustersServer) error {
 	return s.handler(stream, cache.ClusterType)
 }
 
-func (s *server) StreamRoutes(stream v2.RouteDiscoveryService_StreamRoutesServer) error {
+func (s *server) StreamRoutes(stream v2grpc.RouteDiscoveryService_StreamRoutesServer) error {
 	return s.handler(stream, cache.RouteType)
 }
 
-func (s *server) StreamListeners(stream v2.ListenerDiscoveryService_StreamListenersServer) error {
+func (s *server) StreamListeners(stream v2grpc.ListenerDiscoveryService_StreamListenersServer) error {
 	return s.handler(stream, cache.ListenerType)
 }
 
-func (s *server) StreamSecrets(stream discovery.SecretDiscoveryService_StreamSecretsServer) error {
+func (s *server) StreamSecrets(stream discoverygrpc.SecretDiscoveryService_StreamSecretsServer) error {
 	return s.handler(stream, cache.SecretType)
 }
 
@@ -425,26 +426,26 @@ func (s *server) FetchSecrets(ctx context.Context, req *v2.DiscoveryRequest) (*v
 	return s.Fetch(ctx, req)
 }
 
-func (s *server) DeltaAggregatedResources(_ discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+func (s *server) DeltaAggregatedResources(_ discoverygrpc.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
 	return errors.New("not implemented")
 }
 
-func (s *server) DeltaEndpoints(_ v2.EndpointDiscoveryService_DeltaEndpointsServer) error {
+func (s *server) DeltaEndpoints(_ v2grpc.EndpointDiscoveryService_DeltaEndpointsServer) error {
 	return errors.New("not implemented")
 }
 
-func (s *server) DeltaClusters(_ v2.ClusterDiscoveryService_DeltaClustersServer) error {
+func (s *server) DeltaClusters(_ v2grpc.ClusterDiscoveryService_DeltaClustersServer) error {
 	return errors.New("not implemented")
 }
 
-func (s *server) DeltaRoutes(_ v2.RouteDiscoveryService_DeltaRoutesServer) error {
+func (s *server) DeltaRoutes(_ v2grpc.RouteDiscoveryService_DeltaRoutesServer) error {
 	return errors.New("not implemented")
 }
 
-func (s *server) DeltaListeners(_ v2.ListenerDiscoveryService_DeltaListenersServer) error {
+func (s *server) DeltaListeners(_ v2grpc.ListenerDiscoveryService_DeltaListenersServer) error {
 	return errors.New("not implemented")
 }
 
-func (s *server) DeltaSecrets(_ discovery.SecretDiscoveryService_DeltaSecretsServer) error {
+func (s *server) DeltaSecrets(_ discoverygrpc.SecretDiscoveryService_DeltaSecretsServer) error {
 	return errors.New("not implemented")
 }

--- a/pkg/test/accesslog.go
+++ b/pkg/test/accesslog.go
@@ -7,6 +7,7 @@ import (
 
 	alf "github.com/envoyproxy/go-control-plane/v2/envoy/data/accesslog/v2"
 	als "github.com/envoyproxy/go-control-plane/v2/envoy/service/accesslog/v2"
+	alsgrpc "github.com/envoyproxy/go-control-plane/v2/envoy/service/accesslog/v2"
 )
 
 // AccessLogService buffers access logs from the remote Envoy nodes.
@@ -32,7 +33,7 @@ func (svc *AccessLogService) Dump(f func(string)) {
 }
 
 // StreamAccessLogs implements the access log service.
-func (svc *AccessLogService) StreamAccessLogs(stream als.AccessLogService_StreamAccessLogsServer) error {
+func (svc *AccessLogService) StreamAccessLogs(stream alsgrpc.AccessLogService_StreamAccessLogsServer) error {
 	var logName string
 	for {
 		msg, err := stream.Recv()

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -24,9 +24,9 @@ import (
 
 	"google.golang.org/grpc"
 
-	v2 "github.com/envoyproxy/go-control-plane/v2/envoy/api/v2"
-	accesslog "github.com/envoyproxy/go-control-plane/v2/envoy/service/accesslog/v2"
-	discovery "github.com/envoyproxy/go-control-plane/v2/envoy/service/discovery/v2"
+	v2grpc "github.com/envoyproxy/go-control-plane/v2/envoy/api/v2"
+	accessloggrpc "github.com/envoyproxy/go-control-plane/v2/envoy/service/accesslog/v2"
+	discoverygrpc "github.com/envoyproxy/go-control-plane/v2/envoy/service/discovery/v2"
 	xds "github.com/envoyproxy/go-control-plane/v2/pkg/server"
 )
 
@@ -55,7 +55,7 @@ func RunHTTP(ctx context.Context, upstreamPort uint) {
 	}()
 }
 
-// RunAccessLogServer starts an accesslog service.
+// RunAccessLogServer starts an accessloggrpc service.
 func RunAccessLogServer(ctx context.Context, als *AccessLogService, port uint) {
 	grpcServer := grpc.NewServer()
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
@@ -63,7 +63,7 @@ func RunAccessLogServer(ctx context.Context, als *AccessLogService, port uint) {
 		log.Fatal(err)
 	}
 
-	accesslog.RegisterAccessLogServiceServer(grpcServer, als)
+	accessloggrpc.RegisterAccessLogServiceServer(grpcServer, als)
 	log.Printf("access log server listening on %d\n", port)
 
 	go func() {
@@ -94,12 +94,12 @@ func RunManagementServer(ctx context.Context, server xds.Server, port uint) {
 	}
 
 	// register services
-	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
-	v2.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
-	v2.RegisterClusterDiscoveryServiceServer(grpcServer, server)
-	v2.RegisterRouteDiscoveryServiceServer(grpcServer, server)
-	v2.RegisterListenerDiscoveryServiceServer(grpcServer, server)
-	discovery.RegisterSecretDiscoveryServiceServer(grpcServer, server)
+	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
+	v2grpc.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
+	v2grpc.RegisterClusterDiscoveryServiceServer(grpcServer, server)
+	v2grpc.RegisterRouteDiscoveryServiceServer(grpcServer, server)
+	v2grpc.RegisterListenerDiscoveryServiceServer(grpcServer, server)
+	discoverygrpc.RegisterSecretDiscoveryServiceServer(grpcServer, server)
 
 	log.Printf("management server listening on %d\n", port)
 	go func() {


### PR DESCRIPTION
Needed to be compatible with internal build rules.
So separate out grpc service imports from regular proto imports.

Signed-off-by: Teju Nareddy <nareddyt@google.com>