### PR TITLE
Adding support to shutdown handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ import (
 
 func main() {
 	snapshotCache := cache.NewSnapshotCache(false, cache.IDHash{}, nil)
-	server := xds.NewServer(snapshotCache, nil)
+	server := xds.NewServer(snapshotCache, nil, make(chan bool))
 	grpcServer := grpc.NewServer()
 	lis, _ := net.Listen("tcp", ":8080")
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Register services on the gRPC server as follows.
 
 ```go
 import (
+	"context"
 	"google.golang.org/grpc"
 	"net"
 
@@ -75,7 +76,7 @@ import (
 
 func main() {
 	snapshotCache := cache.NewSnapshotCache(false, cache.IDHash{}, nil)
-	server := xds.NewServer(snapshotCache, nil, make(chan bool))
+	server := xds.NewServer(context.Background(), snapshotCache, nil)
 	grpcServer := grpc.NewServer()
 	lis, _ := net.Listen("tcp", ":8080")
 

--- a/pkg/server/gateway_test.go
+++ b/pkg/server/gateway_test.go
@@ -15,6 +15,7 @@
 package server_test
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -49,7 +50,7 @@ func TestGateway(t *testing.T) {
 			Resources: []cache.Resource{listener},
 		}},
 	}
-	gtw := server.HTTPGateway{Log: logger{t: t}, Server: server.NewServer(config, nil, make(chan bool))}
+	gtw := server.HTTPGateway{Log: logger{t: t}, Server: server.NewServer(context.Background(), config, nil)}
 
 	failCases := []struct {
 		path   string

--- a/pkg/server/gateway_test.go
+++ b/pkg/server/gateway_test.go
@@ -49,7 +49,7 @@ func TestGateway(t *testing.T) {
 			Resources: []cache.Resource{listener},
 		}},
 	}
-	gtw := server.HTTPGateway{Log: logger{t: t}, Server: server.NewServer(config, nil)}
+	gtw := server.HTTPGateway{Log: logger{t: t}, Server: server.NewServer(config, nil, make(chan bool))}
 
 	failCases := []struct {
 		path   string

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,8 +69,8 @@ type Callbacks interface {
 }
 
 // NewServer creates handlers from a config watcher and callbacks.
-func NewServer(config cache.Cache, callbacks Callbacks, done chan bool) Server {
-	return &server{cache: config, callbacks: callbacks, done: done}
+func NewServer(ctx context.Context, config cache.Cache, callbacks Callbacks) Server {
+	return &server{cache: config, callbacks: callbacks, ctx: ctx}
 }
 
 type server struct {
@@ -79,7 +79,7 @@ type server struct {
 
 	// streamCount for counting bi-di streams
 	streamCount int64
-	done        chan bool
+	ctx         context.Context
 }
 
 type stream interface {
@@ -207,7 +207,7 @@ func (s *server) process(stream stream, reqCh <-chan *v2.DiscoveryRequest, defau
 
 	for {
 		select {
-		case <-s.done:
+		case <-s.ctx.Done():
 			return nil
 		// config watcher can send the requested resources types in any order
 		case resp, more := <-values.endpoints:

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -88,7 +88,7 @@ func main() {
 	signal := make(chan struct{})
 	cb := &callbacks{signal: signal}
 	config := cache.NewSnapshotCache(mode == resource.Ads, cache.IDHash{}, logger{})
-	srv := server.NewServer(config, cb)
+	srv := server.NewServer(config, cb, make(chan bool))
 	als := &test.AccessLogService{}
 
 	// create a test snapshot

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -88,7 +88,7 @@ func main() {
 	signal := make(chan struct{})
 	cb := &callbacks{signal: signal}
 	config := cache.NewSnapshotCache(mode == resource.Ads, cache.IDHash{}, logger{})
-	srv := server.NewServer(config, cb, make(chan bool))
+	srv := server.NewServer(context.Background(), config, cb)
 	als := &test.AccessLogService{}
 
 	// create a test snapshot


### PR DESCRIPTION
We are missing a way in the go-control-plane to cleanly shutdown the handler. 

Scenario: We are implementing a scenario to gracefully shutdown the grpc server running the go-control-plane. The grpc server shutdown will stop accepting new connections, but will block until the existing connections are closed. 

With this PR, we are trying to add support for shutting down the stream by depending on an additional `done` channel.