### PR TITLE
Support marshaling resource

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -65,8 +65,19 @@ type Response struct {
 	// Proxy responds with this version as an acknowledgement.
 	Version string
 
+	// The value indicating whether the resource is marshaled, and only one of `Resources` and `MarshaledResources` is available.
+	ResourceMarshaled bool
+
 	// Resources to be included in the response.
 	Resources []Resource
+
+	// Marshaled Resources to be included in the response.
+	MarshaledResources []MarshaledResource
+}
+
+type MarshaledResource struct {
+	Bytes []byte
+	ResourceType string
 }
 
 // SkipFetchError is the error returned when the cache fetch is short

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -75,10 +75,7 @@ type Response struct {
 	MarshaledResources []MarshaledResource
 }
 
-type MarshaledResource struct {
-	Bytes []byte
-	ResourceType string
-}
+type MarshaledResource = []byte
 
 // SkipFetchError is the error returned when the cache fetch is short
 // circuited due to the client's version already being up-to-date.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -75,6 +75,7 @@ type Response struct {
 	MarshaledResources []MarshaledResource
 }
 
+// MarshaledResource is an alias for the serialized binary array.
 type MarshaledResource = []byte
 
 // SkipFetchError is the error returned when the cache fetch is short

--- a/pkg/cache/resource.go
+++ b/pkg/cache/resource.go
@@ -78,28 +78,8 @@ func GetResourceName(res Resource) string {
 	}
 }
 
-// GetResourceType returns the type of resource.
-func GetResourceType(res Resource) string {
-	switch res.(type) {
-	case *v2.ClusterLoadAssignment:
-		return EndpointType
-	case *v2.Cluster:
-		return ClusterType
-	case *v2.RouteConfiguration:
-		return RouteType
-	case *v2.Listener:
-		return ListenerType
-	case *auth.Secret:
-		return SecretType
-	case *discovery.Runtime:
-		return RuntimeType
-	default:
-		return ""
-	}
-}
-
 // MarshalResource converts the Resource to MarshaledResource
-func MarshalResource(resource Resource) (*MarshaledResource, error) {
+func MarshalResource(resource Resource) (MarshaledResource, error) {
 	b := proto.NewBuffer(nil)
 	b.SetDeterministic(true)
 	err := b.Marshal(resource)
@@ -107,12 +87,7 @@ func MarshalResource(resource Resource) (*MarshaledResource, error) {
 		return nil, err
 	}
 
-	res := MarshaledResource{
-		Bytes:        b.Bytes(),
-		ResourceType: GetResourceType(resource),
-	}
-
-	return &res, nil
+	return b.Bytes(), nil
 }
 
 // GetResourceReferences returns the names for dependent resources (EDS cluster

--- a/pkg/cache/resource.go
+++ b/pkg/cache/resource.go
@@ -78,6 +78,43 @@ func GetResourceName(res Resource) string {
 	}
 }
 
+// GetResourceType returns the type of resource.
+func GetResourceType(res Resource) string {
+	switch res.(type) {
+	case *v2.ClusterLoadAssignment:
+		return EndpointType
+	case *v2.Cluster:
+		return ClusterType
+	case *v2.RouteConfiguration:
+		return RouteType
+	case *v2.Listener:
+		return ListenerType
+	case *auth.Secret:
+		return SecretType
+	case *discovery.Runtime:
+		return RuntimeType
+	default:
+		return ""
+	}
+}
+
+// MarshalResource converts the Resource to MarshaledResource
+func MarshalResource(resource Resource) (*MarshaledResource, error) {
+	b := proto.NewBuffer(nil)
+	b.SetDeterministic(true)
+	err := b.Marshal(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	res := MarshaledResource{
+		Bytes:        b.Bytes(),
+		ResourceType: GetResourceType(resource),
+	}
+
+	return &res, nil
+}
+
 // GetResourceReferences returns the names for dependent resources (EDS cluster
 // names for CDS, RDS routes names for LDS).
 func GetResourceReferences(resources map[string]Resource) map[string]bool {

--- a/pkg/cache/resource_test.go
+++ b/pkg/cache/resource_test.go
@@ -73,27 +73,6 @@ func TestValidate(t *testing.T) {
 }
 
 func TestGetResourceName(t *testing.T) {
-	if resourceType := cache.GetResourceType(endpoint); resourceType != cache.EndpointType {
-		t.Errorf("GetResourceType(%v) => got %q, want %q", endpoint, resourceType, cache.EndpointType)
-	}
-	if resourceType := cache.GetResourceType(cluster); resourceType != cache.ClusterType {
-		t.Errorf("GetResourceType(%v) => got %q, want %q", cluster, resourceType, clusterName)
-	}
-	if resourceType := cache.GetResourceType(route); resourceType != cache.RouteType {
-		t.Errorf("GetResourceType(%v) => got %q, want %q", route, resourceType, routeName)
-	}
-	if resourceType := cache.GetResourceType(listener); resourceType != cache.ListenerType {
-		t.Errorf("GetResourceType(%v) => got %q, want %q", listener, resourceType, listenerName)
-	}
-	if resourceType := cache.GetResourceType(runtime); resourceType != cache.RuntimeType {
-		t.Errorf("GetResourceType(%v) => got %q, want %q", runtime, resourceType, runtimeName)
-	}
-	if resourceType := cache.GetResourceType(nil); resourceType != "" {
-		t.Errorf("GetResourceType(nil) => got %q, want none", resourceType)
-	}
-}
-
-func TestGetResourceType(t *testing.T) {
 	if name := cache.GetResourceName(endpoint); name != clusterName {
 		t.Errorf("GetResourceName(%v) => got %q, want %q", endpoint, name, clusterName)
 	}

--- a/pkg/cache/resource_test.go
+++ b/pkg/cache/resource_test.go
@@ -73,6 +73,27 @@ func TestValidate(t *testing.T) {
 }
 
 func TestGetResourceName(t *testing.T) {
+	if resourceType := cache.GetResourceType(endpoint); resourceType != cache.EndpointType {
+		t.Errorf("GetResourceType(%v) => got %q, want %q", endpoint, resourceType, cache.EndpointType)
+	}
+	if resourceType := cache.GetResourceType(cluster); resourceType != cache.ClusterType {
+		t.Errorf("GetResourceType(%v) => got %q, want %q", cluster, resourceType, clusterName)
+	}
+	if resourceType := cache.GetResourceType(route); resourceType != cache.RouteType {
+		t.Errorf("GetResourceType(%v) => got %q, want %q", route, resourceType, routeName)
+	}
+	if resourceType := cache.GetResourceType(listener); resourceType != cache.ListenerType {
+		t.Errorf("GetResourceType(%v) => got %q, want %q", listener, resourceType, listenerName)
+	}
+	if resourceType := cache.GetResourceType(runtime); resourceType != cache.RuntimeType {
+		t.Errorf("GetResourceType(%v) => got %q, want %q", runtime, resourceType, runtimeName)
+	}
+	if resourceType := cache.GetResourceType(nil); resourceType != "" {
+		t.Errorf("GetResourceType(nil) => got %q, want none", resourceType)
+	}
+}
+
+func TestGetResourceType(t *testing.T) {
 	if name := cache.GetResourceName(endpoint); name != clusterName {
 		t.Errorf("GetResourceName(%v) => got %q, want %q", endpoint, name, clusterName)
 	}

--- a/pkg/cache/simple_test.go
+++ b/pkg/cache/simple_test.go
@@ -142,13 +142,13 @@ func TestSnapshotCacheFetch(t *testing.T) {
 	// no response for missing snapshot
 	if resp, err := c.Fetch(context.Background(),
 		v2.DiscoveryRequest{TypeUrl: cache.ClusterType, Node: &core.Node{Id: "oof"}}); resp != nil || err == nil {
-		t.Errorf("missing snapshot: response is not nil %q", resp)
+		t.Errorf("missing snapshot: response is not nil %v", resp)
 	}
 
 	// no response for latest version
 	if resp, err := c.Fetch(context.Background(),
 		v2.DiscoveryRequest{TypeUrl: cache.ClusterType, VersionInfo: version}); resp != nil || err == nil {
-		t.Errorf("latest version: response is not nil %q", resp)
+		t.Errorf("latest version: response is not nil %v", resp)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"sync/atomic"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -138,19 +137,32 @@ func createResponse(resp *cache.Response, typeURL string) (*v2.DiscoveryResponse
 	if resp == nil {
 		return nil, errors.New("missing response")
 	}
-	resources := make([]*any.Any, len(resp.Resources))
-	for i := 0; i < len(resp.Resources); i++ {
+
+	var resources []*any.Any
+	if resp.ResourceMarshaled {
+		resources = make([]*any.Any, len(resp.MarshaledResources))
+	} else{
+		resources = make([]*any.Any, len(resp.Resources))
+	}
+
+	for i := 0; i < len(resources); i++ {
 		// Envoy relies on serialized protobuf bytes for detecting changes to the resources.
 		// This requires deterministic serialization.
-		b := proto.NewBuffer(nil)
-		b.SetDeterministic(true)
-		err := b.Marshal(resp.Resources[i])
-		if err != nil {
-			return nil, err
-		}
-		resources[i] = &any.Any{
-			TypeUrl: typeURL,
-			Value:   b.Bytes(),
+		if resp.ResourceMarshaled {
+			resources[i] = &any.Any{
+				TypeUrl: typeURL,
+				Value:   resp.MarshaledResources[i].Bytes,
+			}
+		} else {
+			marshaledResource, err := cache.MarshalResource(resp.Resources[i])
+			if err != nil {
+				return nil, err
+			}
+
+			resources[i] = &any.Any{
+				TypeUrl: typeURL,
+				Value:   marshaledResource.Bytes,
+			}
 		}
 	}
 	out := &v2.DiscoveryResponse{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -151,7 +151,7 @@ func createResponse(resp *cache.Response, typeURL string) (*v2.DiscoveryResponse
 		if resp.ResourceMarshaled {
 			resources[i] = &any.Any{
 				TypeUrl: typeURL,
-				Value:   resp.MarshaledResources[i].Bytes,
+				Value:   resp.MarshaledResources[i],
 			}
 		} else {
 			marshaledResource, err := cache.MarshalResource(resp.Resources[i])
@@ -161,7 +161,7 @@ func createResponse(resp *cache.Response, typeURL string) (*v2.DiscoveryResponse
 
 			resources[i] = &any.Any{
 				TypeUrl: typeURL,
-				Value:   marshaledResource.Bytes,
+				Value:   marshaledResource,
 			}
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -141,7 +141,7 @@ func createResponse(resp *cache.Response, typeURL string) (*v2.DiscoveryResponse
 	var resources []*any.Any
 	if resp.ResourceMarshaled {
 		resources = make([]*any.Any, len(resp.MarshaledResources))
-	} else{
+	} else {
 		resources = make([]*any.Any, len(resp.Resources))
 	}
 


### PR DESCRIPTION
The PR is about the issue https://github.com/envoyproxy/go-control-plane/issues/238.
In this PR, it updates the interface of Response https://github.com/envoyproxy/go-control-plane/blob/e78985eb6c01876c02fb837c077253d03b5e6425/pkg/cache/cache.go#L60-L70, and allow users to specify whether the resource is marshaled, when implementing the interface of Cache: https://github.com/envoyproxy/go-control-plane/blob/e78985eb6c01876c02fb837c077253d03b5e6425/pkg/cache/cache.go#L32-L57