### PR TITLE
add wellknown transport socket names

### DIFF
--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -116,3 +116,17 @@ const (
 	// HTTPGRPCAccessLog sink for the HTTP gRPC access log service
 	HTTPGRPCAccessLog = "envoy.http_grpc_access_log"
 )
+
+// Transport socket names
+const (
+	// TransportSocket Alts
+	TransportSocketAlts = "envoy.transport_sockets.alts"
+	// TransportSocket Tap
+	TransportSocketTap = "envoy.transport_sockets.tap"
+	// TransportSocket RawBuffer
+	TransportSocketRawBuffer = "envoy.transport_sockets.raw_buffer"
+	// TransportSocket Tls
+	TransportSocketTls = "envoy.transport_sockets.tls"
+	// TransportSocket Quic
+	TransportSocketQuic = "envoy.transport_sockets.quic"
+)


### PR DESCRIPTION
This PR adds wellknown `TransportSocket` names.

These names are based on [TransportSocketNameValues](https://github.com/envoyproxy/envoy/blob/6bd4bbe2e89450b1220bc8c14599167a7ef66f57/source/extensions/transport_sockets/well_known_names.h#L11-L22).