### PR TITLE
fix envoy.ext_authz depreciated name

### DIFF
--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -46,7 +46,7 @@ const (
 	// Squash HTTP filter
 	Squash = "envoy.squash"
 	// HTTPExternalAuthorization HTTP filter
-	HTTPExternalAuthorization = "envoy.ext_authz"
+	HTTPExternalAuthorization = "envoy.filters.http.ext_authz"
 	// HTTPRoleBasedAccessControl HTTP filter
 	HTTPRoleBasedAccessControl = "envoy.filters.http.rbac"
 	// HTTPGRPCStats HTTP filter
@@ -74,7 +74,7 @@ const (
 	// MySQLProxy network filter
 	MySQLProxy = "envoy.filters.network.mysql_proxy"
 	// ExternalAuthorization network filter
-	ExternalAuthorization = "envoy.ext_authz"
+	ExternalAuthorization = "envoy.filters.network.ext_authz"
 	// RoleBasedAccessControl network filter
 	RoleBasedAccessControl = "envoy.filters.network.rbac"
 )


### PR DESCRIPTION
Hello! This name will soon be depreciated: https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated, and is currently throwing warnings. If possible, I'd like to update those two fields here.