### PR TITLE
Deprecate non-mandatory cache interface contracts

### DIFF
--- a/pkg/cache/v2/cache.go
+++ b/pkg/cache/v2/cache.go
@@ -49,12 +49,6 @@ type Cache interface {
 
 	// Fetch implements the polling method of the config cache using a non-empty request.
 	Fetch(context.Context, Request) (*Response, error)
-
-	// GetStatusInfo retrieves status information for a node ID.
-	GetStatusInfo(string) StatusInfo
-
-	// GetStatusKeys retrieves node IDs for all statuses.
-	GetStatusKeys() []string
 }
 
 // Response is a pre-serialized xDS response.

--- a/pkg/cache/v2/simple.go
+++ b/pkg/cache/v2/simple.go
@@ -52,6 +52,12 @@ type SnapshotCache interface {
 
 	// ClearSnapshot removes all status and snapshot information associated with a node.
 	ClearSnapshot(node string)
+
+	// GetStatusInfo retrieves status information for a node ID.
+	GetStatusInfo(string) StatusInfo
+
+	// GetStatusKeys retrieves node IDs for all statuses.
+	GetStatusKeys() []string
 }
 
 type snapshotCache struct {

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -50,12 +50,6 @@ type Cache interface {
 
 	// Fetch implements the polling method of the config cache using a non-empty request.
 	Fetch(context.Context, Request) (*Response, error)
-
-	// GetStatusInfo retrieves status information for a node ID.
-	GetStatusInfo(string) StatusInfo
-
-	// GetStatusKeys retrieves node IDs for all statuses.
-	GetStatusKeys() []string
 }
 
 // Response is a pre-serialized xDS response.

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -53,6 +53,12 @@ type SnapshotCache interface {
 
 	// ClearSnapshot removes all status and snapshot information associated with a node.
 	ClearSnapshot(node string)
+
+	// GetStatusInfo retrieves status information for a node ID.
+	GetStatusInfo(string) StatusInfo
+
+	// GetStatusKeys retrieves node IDs for all statuses.
+	GetStatusKeys() []string
 }
 
 type snapshotCache struct {

--- a/pkg/server/v2/server_test.go
+++ b/pkg/server/v2/server_test.go
@@ -60,9 +60,6 @@ func (config *mockConfigWatcher) Fetch(ctx context.Context, req discovery.Discov
 	return nil, errors.New("missing")
 }
 
-func (config *mockConfigWatcher) GetStatusInfo(string) cache.StatusInfo { return nil }
-func (config *mockConfigWatcher) GetStatusKeys() []string               { return nil }
-
 func makeMockConfigWatcher() *mockConfigWatcher {
 	return &mockConfigWatcher{
 		counts: make(map[string]int),

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -61,9 +61,6 @@ func (config *mockConfigWatcher) Fetch(ctx context.Context, req discovery.Discov
 	return nil, errors.New("missing")
 }
 
-func (config *mockConfigWatcher) GetStatusInfo(string) cache.StatusInfo { return nil }
-func (config *mockConfigWatcher) GetStatusKeys() []string               { return nil }
-
 func makeMockConfigWatcher() *mockConfigWatcher {
 	return &mockConfigWatcher{
 		counts: make(map[string]int),


### PR DESCRIPTION
Deprecate from the cache interface:
* GetStatusInfo(string) StatusInfo
* GetStatusKeys() []string

These functions are not referenced anywhere in the [server
implementation](https://github.com/envoyproxy/go-control-plane/blob/e933a9f2ccd2c350a7d7c67317fceb79b3cd8ff6/pkg/server/server.go#L77).
and thus are not critical in the contract.

Oftentimes, consumers of the gcp library have had to implement the
contract but do little except `return nil` in the implementation. Rather
than make the functions mandatory, I've moved them over to the
SnapshotCache interface, where they are used.

This will not break existing implementations since users that have
implemented these functions remain operable; they're just no longer
required. Will reduce bloat in implementations that aren't using it.

Signed-off-by: Jess Yuen <jyuen@lyft.com>