### PR TITLE
fix http cors filter deprecated name

### DIFF
--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -20,7 +20,7 @@ const (
 	// Buffer HTTP filter
 	Buffer = "envoy.buffer"
 	// CORS HTTP filter
-	CORS = "envoy.cors"
+	CORS = "envoy.filters.http.cors"
 	// Dynamo HTTP filter
 	Dynamo = "envoy.http_dynamo_filter"
 	// Fault HTTP filter


### PR DESCRIPTION
`envoy.cors` has been deprecated in favor of `envoy.filters.http.cors` since `1.14.0`

Source:
https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.14.0.html?highlight=deprecated