### PR TITLE
pkg/wellknown: update wellknown const types

### DIFF
--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -18,33 +18,33 @@ package wellknown
 // HTTP filter names
 const (
 	// Buffer HTTP filter
-	Buffer = "envoy.buffer"
+	Buffer = "envoy.filters.http.buffer"
 	// CORS HTTP filter
 	CORS = "envoy.filters.http.cors"
 	// Dynamo HTTP filter
-	Dynamo = "envoy.http_dynamo_filter"
+	Dynamo = "envoy.filters.http.dynamo"
 	// Fault HTTP filter
-	Fault = "envoy.fault"
+	Fault = "envoy.filters.http.fault"
 	// GRPCHTTP1Bridge HTTP filter
-	GRPCHTTP1Bridge = "envoy.grpc_http1_bridge"
+	GRPCHTTP1Bridge = "envoy.filters.http.grpc_http1_bridge"
 	// GRPCJSONTranscoder HTTP filter
-	GRPCJSONTranscoder = "envoy.grpc_json_transcoder"
+	GRPCJSONTranscoder = "envoy.filters.http.grpc_json_transcoder"
 	// GRPCWeb HTTP filter
-	GRPCWeb = "envoy.grpc_web"
+	GRPCWeb = "envoy.filters.http.grpc_web"
 	// Gzip HTTP filter
-	Gzip = "envoy.gzip"
+	Gzip = "envoy.filters.http.gzip"
 	// IPTagging HTTP filter
-	IPTagging = "envoy.ip_tagging"
+	IPTagging = "envoy.filters.http.ip_tagging"
 	// HTTPRateLimit filter
-	HTTPRateLimit = "envoy.rate_limit"
+	HTTPRateLimit = "envoy.filters.http.ratelimit"
 	// Router HTTP filter
-	Router = "envoy.router"
+	Router = "envoy.filters.http.router"
 	// Health checking HTTP filter
-	HealthCheck = "envoy.health_check"
+	HealthCheck = "envoy.filters.http.health_check"
 	// Lua HTTP filter
-	Lua = "envoy.lua"
+	Lua = "envoy.filters.http.lua"
 	// Squash HTTP filter
-	Squash = "envoy.squash"
+	Squash = "envoy.filters.http.squash"
 	// HTTPExternalAuthorization HTTP filter
 	HTTPExternalAuthorization = "envoy.filters.http.ext_authz"
 	// HTTPRoleBasedAccessControl HTTP filter
@@ -56,21 +56,21 @@ const (
 // Network filter names
 const (
 	// ClientSSLAuth network filter
-	ClientSSLAuth = "envoy.client_ssl_auth"
+	ClientSSLAuth = "envoy.filters.network.client_ssl_auth"
 	// Echo network filter
-	Echo = "envoy.echo"
+	Echo = "envoy.filters.network.echo"
 	// HTTPConnectionManager network filter
-	HTTPConnectionManager = "envoy.http_connection_manager"
+	HTTPConnectionManager = "envoy.filters.network.http_connection_manager"
 	// TCPProxy network filter
-	TCPProxy = "envoy.tcp_proxy"
+	TCPProxy = "envoy.filters.network.tcp_proxy"
 	// RateLimit network filter
-	RateLimit = "envoy.ratelimit"
+	RateLimit = "envoy.filters.network.ratelimit"
 	// MongoProxy network filter
-	MongoProxy = "envoy.mongo_proxy"
+	MongoProxy = "envoy.filters.network.mongo_proxy"
 	// ThriftProxy network filter
 	ThriftProxy = "envoy.filters.network.thrift_proxy"
 	// RedisProxy network filter
-	RedisProxy = "envoy.redis_proxy"
+	RedisProxy = "envoy.filters.network.redis_proxy"
 	// MySQLProxy network filter
 	MySQLProxy = "envoy.filters.network.mysql_proxy"
 	// ExternalAuthorization network filter
@@ -82,41 +82,41 @@ const (
 // Listener filter names
 const (
 	// OriginalDestination listener filter
-	OriginalDestination = "envoy.listener.original_dst"
+	OriginalDestination = "envoy.filters.listener.original_dst"
 	// ProxyProtocol listener filter
-	ProxyProtocol = "envoy.listener.proxy_protocol"
+	ProxyProtocol = "envoy.filters.listener.proxy_protocol"
 	// TlsInspector listener filter
-	TlsInspector = "envoy.listener.tls_inspector"
+	TlsInspector = "envoy.filters.listener.tls_inspector"
 	// HttpInspector listener filter
-	HttpInspector = "envoy.listener.http_inspector"
+	HttpInspector = "envoy.filters.listener.http_inspector"
 )
 
 // Tracing provider names
 const (
 	// Lightstep tracer name
-	Lightstep = "envoy.lightstep"
+	Lightstep = "envoy.tracers.lightstep"
 	// Zipkin tracer name
-	Zipkin = "envoy.zipkin"
+	Zipkin = "envoy.tracers.zipkin"
 	// DynamicOT tracer name
-	DynamicOT = "envoy.dynamic.ot"
+	DynamicOT = "envoy.tracers.dynamic_ot"
 )
 
 // Stats sink names
 const (
 	// Statsd sink
-	Statsd = "envoy.statsd"
+	Statsd = "envoy.stat_sinks.statsd"
 	// DogStatsD compatible stastsd sink
-	DogStatsd = "envoy.dog_statsd"
+	DogStatsd = "envoy.stat_sinks.dog_statsd"
 	// MetricsService sink
-	MetricsService = "envoy.metrics_service"
+	MetricsService = "envoy.stat_sinks.metrics_service"
 )
 
 // Access log sink names
 const (
 	// FileAccessLog sink name
-	FileAccessLog = "envoy.file_access_log"
+	FileAccessLog = "envoy.access_loggers.file"
 	// HTTPGRPCAccessLog sink for the HTTP gRPC access log service
-	HTTPGRPCAccessLog = "envoy.http_grpc_access_log"
+	HTTPGRPCAccessLog = "envoy.access_loggers.http_grpc"
 )
 
 // Transport socket names


### PR DESCRIPTION
Updates #293 

This updates the wellknown types inside `pgk/wellknown` for Envoy v1.14.0. It also skips the `envoy.cors` update since that's covered in #291 

Signed-off-by: Steve Sloka <slokas@vmware.com>