### PR TITLE
bump Envoy version in integration docker image

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -21,4 +21,4 @@ RUN rm go.mod
 RUN rm go.sum
 
 # add envoy
-COPY --from=envoyproxy/envoy:v1.13.1 /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --from=envoyproxy/envoy:v1.14.1 /usr/local/bin/envoy /usr/local/bin/envoy


### PR DESCRIPTION
I did some work updating the wellknown types in #294. The integration tests failed since the Envoy image is v1.13. This updates the Envoy version in the integration docker image to v1.14.1. 

Signed-off-by: Steve Sloka <slokas@vmware.com>