### PR TITLE
[Cleanup] Minor lint changes for google3 copybara

### DIFF
--- a/pkg/server/v2/server.go
+++ b/pkg/server/v2/server.go
@@ -21,10 +21,11 @@ import (
 	"strconv"
 	"sync/atomic"
 
-	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	anypb "github.com/golang/protobuf/ptypes/any"
 
 	clusterservice "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -32,7 +33,7 @@ import (
 	listenerservice "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	routeservice "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	discoveryservice "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	runtimeservice "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	secretservice "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
@@ -45,7 +46,7 @@ type Server interface {
 	clusterservice.ClusterDiscoveryServiceServer
 	routeservice.RouteDiscoveryServiceServer
 	listenerservice.ListenerDiscoveryServiceServer
-	discoverygrpc.AggregatedDiscoveryServiceServer
+	discoveryservice.AggregatedDiscoveryServiceServer
 	secretservice.SecretDiscoveryServiceServer
 	runtimeservice.RuntimeDiscoveryServiceServer
 
@@ -145,18 +146,18 @@ func createResponse(resp *cache.Response, typeURL string) (*discovery.DiscoveryR
 		return nil, errors.New("missing response")
 	}
 
-	var resources []*any.Any
+	var resources []*anypb.Any
 	if resp.ResourceMarshaled {
-		resources = make([]*any.Any, len(resp.MarshaledResources))
+		resources = make([]*anypb.Any, len(resp.MarshaledResources))
 	} else {
-		resources = make([]*any.Any, len(resp.Resources))
+		resources = make([]*anypb.Any, len(resp.Resources))
 	}
 
 	for i := 0; i < len(resources); i++ {
 		// Envoy relies on serialized protobuf bytes for detecting changes to the resources.
 		// This requires deterministic serialization.
 		if resp.ResourceMarshaled {
-			resources[i] = &any.Any{
+			resources[i] = &anypb.Any{
 				TypeUrl: typeURL,
 				Value:   resp.MarshaledResources[i],
 			}
@@ -166,7 +167,7 @@ func createResponse(resp *cache.Response, typeURL string) (*discovery.DiscoveryR
 				return nil, err
 			}
 
-			resources[i] = &any.Any{
+			resources[i] = &anypb.Any{
 				TypeUrl: typeURL,
 				Value:   marshaledResource,
 			}
@@ -387,7 +388,7 @@ func (s *server) handler(stream stream, typeURL string) error {
 	return err
 }
 
-func (s *server) StreamAggregatedResources(stream discoverygrpc.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+func (s *server) StreamAggregatedResources(stream discoveryservice.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 	return s.handler(stream, resource.AnyType)
 }
 
@@ -481,7 +482,7 @@ func (s *server) FetchRuntime(ctx context.Context, req *discovery.DiscoveryReque
 	return s.Fetch(ctx, req)
 }
 
-func (s *server) DeltaAggregatedResources(_ discoverygrpc.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+func (s *server) DeltaAggregatedResources(_ discoveryservice.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
 	return errors.New("not implemented")
 }
 

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -8,11 +8,12 @@ import (
 	"net"
 	"net/http"
 
+	"google.golang.org/grpc"
+
 	serverv2 "github.com/envoyproxy/go-control-plane/pkg/server/v2"
 	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	testv2 "github.com/envoyproxy/go-control-plane/pkg/test/v2"
 	testv3 "github.com/envoyproxy/go-control-plane/pkg/test/v3"
-	"google.golang.org/grpc"
 
 	gcplogger "github.com/envoyproxy/go-control-plane/pkg/log"
 )

--- a/pkg/test/v2/register.go
+++ b/pkg/test/v2/register.go
@@ -23,7 +23,7 @@ import (
 	listenerservice "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	routeservice "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	accessloggrpc "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
-	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	discoveryservice "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	runtimeservice "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	secretservice "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/server/v2"
@@ -37,7 +37,7 @@ func RegisterAccessLogServer(grpcServer *grpc.Server, als *AccessLogService) {
 // RegisterServer registers with v2 services.
 func RegisterServer(grpcServer *grpc.Server, server server.Server) {
 	// register services
-	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
+	discoveryservice.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
 	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
 	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, server)
 	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, server)

--- a/pkg/test/v3/register.go
+++ b/pkg/test/v3/register.go
@@ -21,7 +21,7 @@ import (
 
 	accessloggrpc "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3"
 	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
-	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	discoveryservice "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	endpointservice "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
 	listenerservice "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
 	routeservice "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
@@ -38,7 +38,7 @@ func RegisterAccessLogServer(grpcServer *grpc.Server, als *AccessLogService) {
 // RegisterServer registers with v2 services.
 func RegisterServer(grpcServer *grpc.Server, server server.Server) {
 	// register services
-	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
+	discoveryservice.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
 	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
 	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, server)
 	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, server)


### PR DESCRIPTION
- `any` renamed to `anypb` since it's a non-envoy proto
- `discoverygrpc` renamed to `discoveryservice` for consistency

Signed-off-by: Teju Nareddy <nareddyt@google.com>