### PR TITLE
Rename ResponseIface to Response

### DIFF
--- a/pkg/cache/v2/cache.go
+++ b/pkg/cache/v2/cache.go
@@ -17,6 +17,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -41,7 +42,7 @@ type ConfigWatcher interface {
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.
-	CreateWatch(Request) (value chan ResponseIface, cancel func())
+	CreateWatch(Request) (value chan Response, cancel func())
 }
 
 // Cache is a generic config cache with a watcher.
@@ -49,10 +50,11 @@ type Cache interface {
 	ConfigWatcher
 
 	// Fetch implements the polling method of the config cache using a non-empty request.
-	Fetch(context.Context, Request) (ResponseIface, error)
+	Fetch(context.Context, Request) (Response, error)
 }
 
-type ResponseIface interface {
+// Response is a wrapper around Envoy's DiscoveryResponse.
+type Response interface {
 	// Get the Constructed DiscoveryResponse
 	GetDiscoveryResponse() (*discovery.DiscoveryResponse, error)
 
@@ -60,12 +62,13 @@ type ResponseIface interface {
 	GetRequest() *discovery.DiscoveryRequest
 
 	// Get the version in the Response.
-	GetVersion() string
+	GetVersion() (string, error)
 }
 
-// Response is a pre-serialized xDS response.
-type Response struct {
-	ResponseIface
+// RawResponse is a pre-serialized xDS response containing the raw resources to
+// be included in the final Discovery Response.
+type RawResponse struct {
+	Response
 	// Request is the original request.
 	Request discovery.DiscoveryRequest
 
@@ -76,27 +79,29 @@ type Response struct {
 	// Resources to be included in the response.
 	Resources []types.Resource
 
-	// The value indicating whether the resource is marshaled, and only one of `Resources` and `MarshaledResources` is available.
+	// isResourceMarshaled indicates whether the resources have been marshaled.
+	// This is internally maintained by go-control-plane to prevent future
+	// duplication in marshaling efforts.
 	isResourceMarshaled bool
 
-	// Marshaled Resources to be included in the response.
+	// marshaledResponse holds the serialized discovery response.
 	marshaledResponse *discovery.DiscoveryResponse
 }
 
 // PassthroughResponse is a pre constructed xDS response that need not go through marshalling transformations.
 type PassthroughResponse struct {
-	ResponseIface
+	Response
 	// Request is the original request.
 	Request discovery.DiscoveryRequest
 
 	// The discovery response that needs to be sent as is, without any marshalling transformations.
-	Response *discovery.DiscoveryResponse
+	DiscoveryResponse *discovery.DiscoveryResponse
 }
 
 // GetDiscoveryResponse performs the marshalling the first time its called and uses the cached response subsequently.
 // This is necessary because the marshalled response does not change across the calls.
 // This caching behavior is important in high throughput scenarios because grpc marshalling has a cost and it drives the cpu utilization under load.
-func (r Response) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
+func (r RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	if r.isResourceMarshaled {
 		return r.marshaledResponse, nil
 	}
@@ -123,22 +128,30 @@ func (r Response) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	}, nil
 }
 
-func (r Response) GetRequest() *discovery.DiscoveryRequest {
+// GetRequest returns the original Discovery Request.
+func (r RawResponse) GetRequest() *discovery.DiscoveryRequest {
 	return &r.Request
 }
 
-func (r Response) GetVersion() string {
-	return r.Version
+// GetVersion returns the response version.
+func (r RawResponse) GetVersion() (string, error) {
+	return r.Version, nil
 }
 
+// GetDiscoveryResponse returns the final passthrough Discovery Response.
 func (r PassthroughResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
-	return r.Response, nil
+	return r.DiscoveryResponse, nil
 }
 
+// GetRequest returns the original Discovery Request
 func (r PassthroughResponse) GetRequest() *discovery.DiscoveryRequest {
 	return &r.Request
 }
 
-func (r PassthroughResponse) GetVersion() string {
-	return r.Response.VersionInfo
+// GetVersion returns the response version.
+func (r PassthroughResponse) GetVersion() (string, error) {
+	if r.DiscoveryResponse != nil {
+		return r.DiscoveryResponse.VersionInfo, nil
+	}
+	return "", fmt.Errorf("DiscoveryResponse is nil")
 }

--- a/pkg/cache/v2/cache_test.go
+++ b/pkg/cache/v2/cache_test.go
@@ -19,7 +19,7 @@ const (
 
 func TestResponseGetDiscoveryResponse(t *testing.T) {
 	routes := []types.Resource{&route.RouteConfiguration{Name: resourceName}}
-	resp := cache.Response{
+	resp := cache.RawResponse{
 		Request:   discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
 		Resources: routes,
@@ -46,13 +46,13 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 		VersionInfo: "v",
 	}
 	resp := cache.PassthroughResponse{
-		Request:  discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
-		Response: dr,
+		Request:           discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
+		DiscoveryResponse: dr,
 	}
 
 	discoveryResponse, err := resp.GetDiscoveryResponse()
 	assert.Nil(t, err)
-	assert.Equal(t, discoveryResponse.VersionInfo, resp.Response.VersionInfo)
+	assert.Equal(t, discoveryResponse.VersionInfo, resp.DiscoveryResponse.VersionInfo)
 	assert.Equal(t, len(discoveryResponse.Resources), 1)
 
 	r := &route.RouteConfiguration{}

--- a/pkg/cache/v2/simple.go
+++ b/pkg/cache/v2/simple.go
@@ -172,7 +172,7 @@ func superset(names map[string]bool, resources map[string]types.Resource) error 
 }
 
 // CreateWatch returns a watch for an xDS request.
-func (cache *snapshotCache) CreateWatch(request Request) (chan ResponseIface, func()) {
+func (cache *snapshotCache) CreateWatch(request Request) (chan Response, func()) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.Lock()
@@ -190,7 +190,7 @@ func (cache *snapshotCache) CreateWatch(request Request) (chan ResponseIface, fu
 	info.mu.Unlock()
 
 	// allocate capacity 1 to allow one-time non-blocking use
-	value := make(chan ResponseIface, 1)
+	value := make(chan Response, 1)
 
 	snapshot, exists := cache.snapshots[nodeID]
 	version := snapshot.GetVersion(request.TypeUrl)
@@ -234,7 +234,7 @@ func (cache *snapshotCache) cancelWatch(nodeID string, watchID int64) func() {
 
 // Respond to a watch with the snapshot value. The value channel should have capacity not to block.
 // TODO(kuat) do not respond always, see issue https://github.com/envoyproxy/go-control-plane/issues/46
-func (cache *snapshotCache) respond(request Request, value chan ResponseIface, resources map[string]types.Resource, version string) {
+func (cache *snapshotCache) respond(request Request, value chan Response, resources map[string]types.Resource, version string) {
 	// for ADS, the request names must match the snapshot names
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.ResourceNames) != 0 && cache.ads {
@@ -253,7 +253,7 @@ func (cache *snapshotCache) respond(request Request, value chan ResponseIface, r
 	value <- createResponse(request, resources, version)
 }
 
-func createResponse(request Request, resources map[string]types.Resource, version string) ResponseIface {
+func createResponse(request Request, resources map[string]types.Resource, version string) Response {
 	filtered := make([]types.Resource, 0, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
@@ -272,7 +272,7 @@ func createResponse(request Request, resources map[string]types.Resource, versio
 		}
 	}
 
-	return Response{
+	return RawResponse{
 		Request:   request,
 		Version:   version,
 		Resources: filtered,
@@ -281,7 +281,7 @@ func createResponse(request Request, resources map[string]types.Resource, versio
 
 // Fetch implements the cache fetch function.
 // Fetch is called on multiple streams, so responding to individual names with the same version works.
-func (cache *snapshotCache) Fetch(ctx context.Context, request Request) (ResponseIface, error) {
+func (cache *snapshotCache) Fetch(ctx context.Context, request Request) (Response, error) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.RLock()

--- a/pkg/cache/v2/simple_test.go
+++ b/pkg/cache/v2/simple_test.go
@@ -112,11 +112,11 @@ func TestSnapshotCache(t *testing.T) {
 			value, _ := c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 			select {
 			case out := <-value:
-				if out.GetVersion() != version {
-					t.Errorf("got version %q, want %q", out.GetVersion(), version)
+				if gotVersion, _ := out.GetVersion(); gotVersion != version {
+					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.Response).Resources), snapshot.GetResources(typ)) {
-					t.Errorf("get resources %v, want %v", out.(cache.Response).Resources, snapshot.GetResources(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot.GetResources(typ)) {
+					t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot.GetResources(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -137,8 +137,8 @@ func TestSnapshotCacheFetch(t *testing.T) {
 			if err != nil || resp == nil {
 				t.Fatal("unexpected error or null response")
 			}
-			if resp.GetVersion() != version {
-				t.Errorf("got version %q, want %q", resp.GetVersion(), version)
+			if gotVersion, _ := resp.GetVersion(); gotVersion != version {
+				t.Errorf("got version %q, want %q", gotVersion, version)
 			}
 		})
 	}
@@ -158,7 +158,7 @@ func TestSnapshotCacheFetch(t *testing.T) {
 
 func TestSnapshotCacheWatch(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
-	watches := make(map[string]chan cache.ResponseIface)
+	watches := make(map[string]chan cache.Response)
 	for _, typ := range testTypes {
 		watches[typ], _ = c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 	}
@@ -169,11 +169,11 @@ func TestSnapshotCacheWatch(t *testing.T) {
 		t.Run(typ, func(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
-				if out.GetVersion() != version {
-					t.Errorf("got version %q, want %q", out.GetVersion(), version)
+				if gotVersion, _ := out.GetVersion(); gotVersion != version {
+					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.Response).Resources), snapshot.GetResources(typ)) {
-					t.Errorf("get resources %v, want %v", out.(cache.Response).Resources, snapshot.GetResources(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot.GetResources(typ)) {
+					t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot.GetResources(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -202,11 +202,11 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	// validate response for endpoints
 	select {
 	case out := <-watches[rsrc.EndpointType]:
-		if out.GetVersion() != version2 {
-			t.Errorf("got version %q, want %q", out.GetVersion(), version2)
+		if gotVersion, _ := out.GetVersion(); gotVersion != version2 {
+			t.Errorf("got version %q, want %q", gotVersion, version2)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.Response).Resources), snapshot2.Resources[types.Endpoint].Items) {
-			t.Errorf("get resources %v, want %v", out.(cache.Response).Resources, snapshot2.Resources[types.Endpoint].Items)
+		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
+			t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")

--- a/pkg/cache/v2/status.go
+++ b/pkg/cache/v2/status.go
@@ -73,8 +73,8 @@ type ResponseWatch struct {
 	// Request is the original request for the watch.
 	Request Request
 
-	// Response is the channel to push response to.
-	Response chan ResponseIface
+	// Response is the channel to push responses to.
+	Response chan Response
 }
 
 // newStatusInfo initializes a status info data structure.

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -42,7 +43,7 @@ type ConfigWatcher interface {
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.
-	CreateWatch(Request) (value chan ResponseIface, cancel func())
+	CreateWatch(Request) (value chan Response, cancel func())
 }
 
 // Cache is a generic config cache with a watcher.
@@ -50,10 +51,11 @@ type Cache interface {
 	ConfigWatcher
 
 	// Fetch implements the polling method of the config cache using a non-empty request.
-	Fetch(context.Context, Request) (ResponseIface, error)
+	Fetch(context.Context, Request) (Response, error)
 }
 
-type ResponseIface interface {
+// Response is a wrapper around Envoy's DiscoveryResponse.
+type Response interface {
 	// Get the Constructed DiscoveryResponse
 	GetDiscoveryResponse() (*discovery.DiscoveryResponse, error)
 
@@ -61,12 +63,13 @@ type ResponseIface interface {
 	GetRequest() *discovery.DiscoveryRequest
 
 	// Get the version in the Response.
-	GetVersion() string
+	GetVersion() (string, error)
 }
 
-// Response is a pre-serialized xDS response.
-type Response struct {
-	ResponseIface
+// RawResponse is a pre-serialized xDS response containing the raw resources to
+// be included in the final Discovery Response.
+type RawResponse struct {
+	Response
 	// Request is the original request.
 	Request discovery.DiscoveryRequest
 
@@ -77,27 +80,29 @@ type Response struct {
 	// Resources to be included in the response.
 	Resources []types.Resource
 
-	// The value indicating whether the resource is marshaled, and only one of `Resources` and `MarshaledResources` is available.
+	// isResourceMarshaled indicates whether the resources have been marshaled.
+	// This is internally maintained by go-control-plane to prevent future
+	// duplication in marshaling efforts.
 	isResourceMarshaled bool
 
-	// Marshaled Resources to be included in the response.
+	// marshaledResponse holds the serialized discovery response.
 	marshaledResponse *discovery.DiscoveryResponse
 }
 
 // PassthroughResponse is a pre constructed xDS response that need not go through marshalling transformations.
 type PassthroughResponse struct {
-	ResponseIface
+	Response
 	// Request is the original request.
 	Request discovery.DiscoveryRequest
 
 	// The discovery response that needs to be sent as is, without any marshalling transformations.
-	Response *discovery.DiscoveryResponse
+	DiscoveryResponse *discovery.DiscoveryResponse
 }
 
 // GetDiscoveryResponse performs the marshalling the first time its called and uses the cached response subsequently.
 // This is necessary because the marshalled response does not change across the calls.
 // This caching behavior is important in high throughput scenarios because grpc marshalling has a cost and it drives the cpu utilization under load.
-func (r Response) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
+func (r RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	if r.isResourceMarshaled {
 		return r.marshaledResponse, nil
 	}
@@ -124,22 +129,30 @@ func (r Response) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	}, nil
 }
 
-func (r Response) GetRequest() *discovery.DiscoveryRequest {
+// GetRequest returns the original Discovery Request.
+func (r RawResponse) GetRequest() *discovery.DiscoveryRequest {
 	return &r.Request
 }
 
-func (r Response) GetVersion() string {
-	return r.Version
+// GetVersion returns the response version.
+func (r RawResponse) GetVersion() (string, error) {
+	return r.Version, nil
 }
 
+// GetDiscoveryResponse returns the final passthrough Discovery Response.
 func (r PassthroughResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
-	return r.Response, nil
+	return r.DiscoveryResponse, nil
 }
 
+// GetRequest returns the original Discovery Request
 func (r PassthroughResponse) GetRequest() *discovery.DiscoveryRequest {
 	return &r.Request
 }
 
-func (r PassthroughResponse) GetVersion() string {
-	return r.Response.VersionInfo
+// GetVersion returns the response version.
+func (r PassthroughResponse) GetVersion() (string, error) {
+	if r.DiscoveryResponse != nil {
+		return r.DiscoveryResponse.VersionInfo, nil
+	}
+	return "", fmt.Errorf("DiscoveryResponse is nil")
 }

--- a/pkg/cache/v3/cache_test.go
+++ b/pkg/cache/v3/cache_test.go
@@ -20,7 +20,7 @@ const (
 
 func TestResponseGetDiscoveryResponse(t *testing.T) {
 	routes := []types.Resource{&route.RouteConfiguration{Name: resourceName}}
-	resp := cache.Response{
+	resp := cache.RawResponse{
 		Request:   discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
 		Resources: routes,
@@ -47,13 +47,13 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 		VersionInfo: "v",
 	}
 	resp := cache.PassthroughResponse{
-		Request:  discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
-		Response: dr,
+		Request:           discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
+		DiscoveryResponse: dr,
 	}
 
 	discoveryResponse, err := resp.GetDiscoveryResponse()
 	assert.Nil(t, err)
-	assert.Equal(t, discoveryResponse.VersionInfo, resp.Response.VersionInfo)
+	assert.Equal(t, discoveryResponse.VersionInfo, resp.DiscoveryResponse.VersionInfo)
 	assert.Equal(t, len(discoveryResponse.Resources), 1)
 
 	r := &route.RouteConfiguration{}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -173,7 +173,7 @@ func superset(names map[string]bool, resources map[string]types.Resource) error 
 }
 
 // CreateWatch returns a watch for an xDS request.
-func (cache *snapshotCache) CreateWatch(request Request) (chan ResponseIface, func()) {
+func (cache *snapshotCache) CreateWatch(request Request) (chan Response, func()) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.Lock()
@@ -191,7 +191,7 @@ func (cache *snapshotCache) CreateWatch(request Request) (chan ResponseIface, fu
 	info.mu.Unlock()
 
 	// allocate capacity 1 to allow one-time non-blocking use
-	value := make(chan ResponseIface, 1)
+	value := make(chan Response, 1)
 
 	snapshot, exists := cache.snapshots[nodeID]
 	version := snapshot.GetVersion(request.TypeUrl)
@@ -235,7 +235,7 @@ func (cache *snapshotCache) cancelWatch(nodeID string, watchID int64) func() {
 
 // Respond to a watch with the snapshot value. The value channel should have capacity not to block.
 // TODO(kuat) do not respond always, see issue https://github.com/envoyproxy/go-control-plane/issues/46
-func (cache *snapshotCache) respond(request Request, value chan ResponseIface, resources map[string]types.Resource, version string) {
+func (cache *snapshotCache) respond(request Request, value chan Response, resources map[string]types.Resource, version string) {
 	// for ADS, the request names must match the snapshot names
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.ResourceNames) != 0 && cache.ads {
@@ -254,7 +254,7 @@ func (cache *snapshotCache) respond(request Request, value chan ResponseIface, r
 	value <- createResponse(request, resources, version)
 }
 
-func createResponse(request Request, resources map[string]types.Resource, version string) ResponseIface {
+func createResponse(request Request, resources map[string]types.Resource, version string) Response {
 	filtered := make([]types.Resource, 0, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
@@ -273,7 +273,7 @@ func createResponse(request Request, resources map[string]types.Resource, versio
 		}
 	}
 
-	return Response{
+	return RawResponse{
 		Request:   request,
 		Version:   version,
 		Resources: filtered,
@@ -282,7 +282,7 @@ func createResponse(request Request, resources map[string]types.Resource, versio
 
 // Fetch implements the cache fetch function.
 // Fetch is called on multiple streams, so responding to individual names with the same version works.
-func (cache *snapshotCache) Fetch(ctx context.Context, request Request) (ResponseIface, error) {
+func (cache *snapshotCache) Fetch(ctx context.Context, request Request) (Response, error) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.RLock()

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -113,11 +113,11 @@ func TestSnapshotCache(t *testing.T) {
 			value, _ := c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 			select {
 			case out := <-value:
-				if out.GetVersion() != version {
-					t.Errorf("got version %q, want %q", out.GetVersion(), version)
+				if gotVersion, _ := out.GetVersion(); gotVersion != version {
+					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.Response).Resources), snapshot.GetResources(typ)) {
-					t.Errorf("get resources %v, want %v", out.(cache.Response).Resources, snapshot.GetResources(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot.GetResources(typ)) {
+					t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot.GetResources(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -138,8 +138,8 @@ func TestSnapshotCacheFetch(t *testing.T) {
 			if err != nil || resp == nil {
 				t.Fatal("unexpected error or null response")
 			}
-			if resp.GetVersion() != version {
-				t.Errorf("got version %q, want %q", resp.GetVersion(), version)
+			if gotVersion, _ := resp.GetVersion(); gotVersion != version {
+				t.Errorf("got version %q, want %q", gotVersion, version)
 			}
 		})
 	}
@@ -159,7 +159,7 @@ func TestSnapshotCacheFetch(t *testing.T) {
 
 func TestSnapshotCacheWatch(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
-	watches := make(map[string]chan cache.ResponseIface)
+	watches := make(map[string]chan cache.Response)
 	for _, typ := range testTypes {
 		watches[typ], _ = c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 	}
@@ -170,11 +170,11 @@ func TestSnapshotCacheWatch(t *testing.T) {
 		t.Run(typ, func(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
-				if out.GetVersion() != version {
-					t.Errorf("got version %q, want %q", out.GetVersion(), version)
+				if gotVersion, _ := out.GetVersion(); gotVersion != version {
+					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.Response).Resources), snapshot.GetResources(typ)) {
-					t.Errorf("get resources %v, want %v", out.(cache.Response).Resources, snapshot.GetResources(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot.GetResources(typ)) {
+					t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot.GetResources(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -203,11 +203,11 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	// validate response for endpoints
 	select {
 	case out := <-watches[rsrc.EndpointType]:
-		if out.GetVersion() != version2 {
-			t.Errorf("got version %q, want %q", out.GetVersion(), version2)
+		if gotVersion, _ := out.GetVersion(); gotVersion != version2 {
+			t.Errorf("got version %q, want %q", gotVersion, version2)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.Response).Resources), snapshot2.Resources[types.Endpoint].Items) {
-			t.Errorf("get resources %v, want %v", out.(cache.Response).Resources, snapshot2.Resources[types.Endpoint].Items)
+		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
+			t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -74,8 +74,8 @@ type ResponseWatch struct {
 	// Request is the original request for the watch.
 	Request Request
 
-	// Response is the channel to push response to.
-	Response chan ResponseIface
+	// Response is the channel to push responses to.
+	Response chan Response
 }
 
 // newStatusInfo initializes a status info data structure.

--- a/pkg/server/v2/gateway_test.go
+++ b/pkg/server/v2/gateway_test.go
@@ -41,7 +41,7 @@ func (log logger) Errorf(format string, args ...interface{}) { log.t.Logf(format
 
 func TestGateway(t *testing.T) {
 	config := makeMockConfigWatcher()
-	config.responses = map[string][]cache.Response{
+	config.responses = map[string][]cache.RawResponse{
 		resource.ClusterType: {{
 			Version:   "2",
 			Resources: []types.Resource{cluster},

--- a/pkg/server/v2/server.go
+++ b/pkg/server/v2/server.go
@@ -95,12 +95,12 @@ type stream interface {
 
 // watches for all xDS resource types
 type watches struct {
-	endpoints chan cache.ResponseIface
-	clusters  chan cache.ResponseIface
-	routes    chan cache.ResponseIface
-	listeners chan cache.ResponseIface
-	secrets   chan cache.ResponseIface
-	runtimes  chan cache.ResponseIface
+	endpoints chan cache.Response
+	clusters  chan cache.Response
+	routes    chan cache.Response
+	listeners chan cache.Response
+	secrets   chan cache.Response
+	runtimes  chan cache.Response
 
 	endpointCancel func()
 	clusterCancel  func()
@@ -139,7 +139,7 @@ func (values watches) Cancel() {
 	}
 }
 
-func createResponse(resp cache.ResponseIface, typeURL string) (*discovery.DiscoveryResponse, error) {
+func createResponse(resp cache.Response, typeURL string) (*discovery.DiscoveryResponse, error) {
 	if resp == nil {
 		return nil, errors.New("missing response")
 	}
@@ -171,7 +171,7 @@ func (s *server) process(stream stream, reqCh <-chan *discovery.DiscoveryRequest
 	}()
 
 	// sends a response by serializing to protobuf Any
-	send := func(resp cache.ResponseIface, typeURL string) (string, error) {
+	send := func(resp cache.Response, typeURL string) (string, error) {
 		out, err := createResponse(resp, typeURL)
 		if err != nil {
 			return "", err

--- a/pkg/server/v2/server_test.go
+++ b/pkg/server/v2/server_test.go
@@ -35,13 +35,13 @@ import (
 
 type mockConfigWatcher struct {
 	counts     map[string]int
-	responses  map[string][]cache.Response
+	responses  map[string][]cache.RawResponse
 	closeWatch bool
 }
 
-func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (chan cache.ResponseIface, func()) {
+func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (chan cache.Response, func()) {
 	config.counts[req.TypeUrl] = config.counts[req.TypeUrl] + 1
-	out := make(chan cache.ResponseIface, 1)
+	out := make(chan cache.Response, 1)
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out <- config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
@@ -51,7 +51,7 @@ func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (ch
 	return out, func() {}
 }
 
-func (config *mockConfigWatcher) Fetch(ctx context.Context, req discovery.DiscoveryRequest) (cache.ResponseIface, error) {
+func (config *mockConfigWatcher) Fetch(ctx context.Context, req discovery.DiscoveryRequest) (cache.Response, error) {
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out := config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
@@ -177,8 +177,8 @@ var (
 	}
 )
 
-func makeResponses() map[string][]cache.Response {
-	return map[string][]cache.Response{
+func makeResponses() map[string][]cache.RawResponse {
+	return map[string][]cache.RawResponse{
 		rsrc.EndpointType: {{
 			Version:   "1",
 			Resources: []types.Resource{endpoint},

--- a/pkg/server/v3/gateway_test.go
+++ b/pkg/server/v3/gateway_test.go
@@ -42,7 +42,7 @@ func (log logger) Errorf(format string, args ...interface{}) { log.t.Logf(format
 
 func TestGateway(t *testing.T) {
 	config := makeMockConfigWatcher()
-	config.responses = map[string][]cache.Response{
+	config.responses = map[string][]cache.RawResponse{
 		resource.ClusterType: {{
 			Version:   "2",
 			Resources: []types.Resource{cluster},

--- a/pkg/server/v3/server.go
+++ b/pkg/server/v3/server.go
@@ -96,12 +96,12 @@ type stream interface {
 
 // watches for all xDS resource types
 type watches struct {
-	endpoints chan cache.ResponseIface
-	clusters  chan cache.ResponseIface
-	routes    chan cache.ResponseIface
-	listeners chan cache.ResponseIface
-	secrets   chan cache.ResponseIface
-	runtimes  chan cache.ResponseIface
+	endpoints chan cache.Response
+	clusters  chan cache.Response
+	routes    chan cache.Response
+	listeners chan cache.Response
+	secrets   chan cache.Response
+	runtimes  chan cache.Response
 
 	endpointCancel func()
 	clusterCancel  func()
@@ -140,7 +140,7 @@ func (values watches) Cancel() {
 	}
 }
 
-func createResponse(resp cache.ResponseIface, typeURL string) (*discovery.DiscoveryResponse, error) {
+func createResponse(resp cache.Response, typeURL string) (*discovery.DiscoveryResponse, error) {
 	if resp == nil {
 		return nil, errors.New("missing response")
 	}
@@ -172,7 +172,7 @@ func (s *server) process(stream stream, reqCh <-chan *discovery.DiscoveryRequest
 	}()
 
 	// sends a response by serializing to protobuf Any
-	send := func(resp cache.ResponseIface, typeURL string) (string, error) {
+	send := func(resp cache.Response, typeURL string) (string, error) {
 		out, err := createResponse(resp, typeURL)
 		if err != nil {
 			return "", err

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -36,13 +36,13 @@ import (
 
 type mockConfigWatcher struct {
 	counts     map[string]int
-	responses  map[string][]cache.Response
+	responses  map[string][]cache.RawResponse
 	closeWatch bool
 }
 
-func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (chan cache.ResponseIface, func()) {
+func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (chan cache.Response, func()) {
 	config.counts[req.TypeUrl] = config.counts[req.TypeUrl] + 1
-	out := make(chan cache.ResponseIface, 1)
+	out := make(chan cache.Response, 1)
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out <- config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
@@ -52,7 +52,7 @@ func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (ch
 	return out, func() {}
 }
 
-func (config *mockConfigWatcher) Fetch(ctx context.Context, req discovery.DiscoveryRequest) (cache.ResponseIface, error) {
+func (config *mockConfigWatcher) Fetch(ctx context.Context, req discovery.DiscoveryRequest) (cache.Response, error) {
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out := config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
@@ -178,8 +178,8 @@ var (
 	}
 )
 
-func makeResponses() map[string][]cache.Response {
-	return map[string][]cache.Response{
+func makeResponses() map[string][]cache.RawResponse {
+	return map[string][]cache.RawResponse{
 		rsrc.EndpointType: {{
 			Version:   "1",
 			Resources: []types.Resource{endpoint},


### PR DESCRIPTION
* Also return possible error on `GetVersion()`
* Update documentation for a few Response functions.
* Names the current `Response` struct, containing the raw resources to `RawResponse`.

Response was the original name used by cache `CreateWatch()` and
`Fetch()` response objects.

The current setup alludes to the [implementation
Response](https://github.com/envoyproxy/go-control-plane/blob/b12a9ed045da8cd01b3813e0193d1a381ea9e585/pkg/cache/v2/cache.go#L67-L84)
being the defacto implementation, which isn't the case anymore with the
introduction of a PassthroughResponse struct. Interface is also an
implementation detail that should be hidden from the consumer.

Related: #300 

Signed-off-by: Jess Yuen <jyuen@lyft.com>