### PR TITLE
add sds to snapshots such that secrets can be dynamically configured

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,6 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
+google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=

--- a/pkg/cache/v2/resource_test.go
+++ b/pkg/cache/v2/resource_test.go
@@ -31,6 +31,8 @@ const (
 	routeName    = "route0"
 	listenerName = "listener0"
 	runtimeName  = "runtime0"
+	tlsName      = "secret0"
+	rootName     = "root0"
 )
 
 var (
@@ -39,6 +41,7 @@ var (
 	testRoute    = resource.MakeRoute(routeName, clusterName)
 	testListener = resource.MakeHTTPListener(resource.Ads, listenerName, 80, routeName)
 	testRuntime  = resource.MakeRuntime(runtimeName)
+	testSecret   = resource.MakeSecrets(tlsName, rootName)
 )
 
 func TestValidate(t *testing.T) {

--- a/pkg/cache/v2/simple_test.go
+++ b/pkg/cache/v2/simple_test.go
@@ -51,7 +51,8 @@ var (
 		[]types.Resource{testCluster},
 		[]types.Resource{testRoute},
 		[]types.Resource{testListener},
-		[]types.Resource{testRuntime})
+		[]types.Resource{testRuntime},
+		[]types.Resource{testSecret[0]})
 
 	names = map[string][]string{
 		rsrc.EndpointType: {clusterName},

--- a/pkg/cache/v2/snapshot.go
+++ b/pkg/cache/v2/snapshot.go
@@ -60,13 +60,15 @@ func NewSnapshot(version string,
 	clusters []types.Resource,
 	routes []types.Resource,
 	listeners []types.Resource,
-	runtimes []types.Resource) Snapshot {
+	runtimes []types.Resource,
+	secrets []types.Resource) Snapshot {
 	out := Snapshot{}
 	out.Resources[types.Endpoint] = NewResources(version, endpoints)
 	out.Resources[types.Cluster] = NewResources(version, clusters)
 	out.Resources[types.Route] = NewResources(version, routes)
 	out.Resources[types.Listener] = NewResources(version, listeners)
 	out.Resources[types.Runtime] = NewResources(version, runtimes)
+	out.Resources[types.Secret] = NewResources(version, secrets)
 	return out
 }
 

--- a/pkg/cache/v2/snapshot_test.go
+++ b/pkg/cache/v2/snapshot_test.go
@@ -27,18 +27,18 @@ func TestSnapshotConsistent(t *testing.T) {
 	if err := snapshot.Consistent(); err != nil {
 		t.Errorf("got inconsistent snapshot for %#v", snapshot)
 	}
-	if snap := cache.NewSnapshot(version, []types.Resource{testEndpoint}, nil, nil, nil, nil); snap.Consistent() == nil {
+	if snap := cache.NewSnapshot(version, []types.Resource{testEndpoint}, nil, nil, nil, nil, nil); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 	if snap := cache.NewSnapshot(version, []types.Resource{resource.MakeEndpoint("missing", 8080)},
-		[]types.Resource{testCluster}, nil, nil, nil); snap.Consistent() == nil {
+		[]types.Resource{testCluster}, nil, nil, nil, nil); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
-	if snap := cache.NewSnapshot(version, nil, nil, nil, []types.Resource{testListener}, nil); snap.Consistent() == nil {
+	if snap := cache.NewSnapshot(version, nil, nil, nil, []types.Resource{testListener}, nil, nil); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 	if snap := cache.NewSnapshot(version, nil, nil,
-		[]types.Resource{resource.MakeRoute("test", clusterName)}, []types.Resource{testListener}, nil); snap.Consistent() == nil {
+		[]types.Resource{resource.MakeRoute("test", clusterName)}, []types.Resource{testListener}, nil, nil); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 }

--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -32,6 +32,8 @@ const (
 	routeName    = "route0"
 	listenerName = "listener0"
 	runtimeName  = "runtime0"
+	tlsName      = "secret0"
+	rootName     = "root0"
 )
 
 var (
@@ -40,6 +42,7 @@ var (
 	testRoute    = resource.MakeRoute(routeName, clusterName)
 	testListener = resource.MakeHTTPListener(resource.Ads, listenerName, 80, routeName)
 	testRuntime  = resource.MakeRuntime(runtimeName)
+	testSecret   = resource.MakeSecrets(tlsName, rootName)
 )
 
 func TestValidate(t *testing.T) {

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -52,7 +52,8 @@ var (
 		[]types.Resource{testCluster},
 		[]types.Resource{testRoute},
 		[]types.Resource{testListener},
-		[]types.Resource{testRuntime})
+		[]types.Resource{testRuntime},
+		[]types.Resource{testSecret[0]})
 
 	names = map[string][]string{
 		rsrc.EndpointType: {clusterName},

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -61,13 +61,15 @@ func NewSnapshot(version string,
 	clusters []types.Resource,
 	routes []types.Resource,
 	listeners []types.Resource,
-	runtimes []types.Resource) Snapshot {
+	runtimes []types.Resource,
+	secrets []types.Resource) Snapshot {
 	out := Snapshot{}
 	out.Resources[types.Endpoint] = NewResources(version, endpoints)
 	out.Resources[types.Cluster] = NewResources(version, clusters)
 	out.Resources[types.Route] = NewResources(version, routes)
 	out.Resources[types.Listener] = NewResources(version, listeners)
 	out.Resources[types.Runtime] = NewResources(version, runtimes)
+	out.Resources[types.Secret] = NewResources(version, secrets)
 	return out
 }
 

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -28,18 +28,18 @@ func TestSnapshotConsistent(t *testing.T) {
 	if err := snapshot.Consistent(); err != nil {
 		t.Errorf("got inconsistent snapshot for %#v", snapshot)
 	}
-	if snap := cache.NewSnapshot(version, []types.Resource{testEndpoint}, nil, nil, nil, nil); snap.Consistent() == nil {
+	if snap := cache.NewSnapshot(version, []types.Resource{testEndpoint}, nil, nil, nil, nil, nil); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 	if snap := cache.NewSnapshot(version, []types.Resource{resource.MakeEndpoint("missing", 8080)},
-		[]types.Resource{testCluster}, nil, nil, nil); snap.Consistent() == nil {
+		[]types.Resource{testCluster}, nil, nil, nil, nil); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
-	if snap := cache.NewSnapshot(version, nil, nil, nil, []types.Resource{testListener}, nil); snap.Consistent() == nil {
+	if snap := cache.NewSnapshot(version, nil, nil, nil, []types.Resource{testListener}, nil, nil); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 	if snap := cache.NewSnapshot(version, nil, nil,
-		[]types.Resource{resource.MakeRoute("test", clusterName)}, []types.Resource{testListener}, nil); snap.Consistent() == nil {
+		[]types.Resource{resource.MakeRoute("test", clusterName)}, []types.Resource{testListener}, nil, nil); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 }

--- a/pkg/test/resource/v2/resource.go
+++ b/pkg/test/resource/v2/resource.go
@@ -378,6 +378,13 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 		runtimes[i] = MakeRuntime(name)
 	}
 
+	var secrets []types.Resource
+	if ts.TLS {
+		for _, s := range MakeSecrets(tlsName, rootName) {
+			secrets = append(secrets, s)
+		}
+	}
+
 	out := cache.NewSnapshot(
 		ts.Version,
 		endpoints,
@@ -385,11 +392,8 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 		routes,
 		listeners,
 		runtimes,
+		secrets,
 	)
-
-	if ts.TLS {
-		out.Resources[types.Secret] = cache.NewResources(ts.Version, MakeSecrets(tlsName, rootName))
-	}
 
 	return out
 }

--- a/pkg/test/resource/v2/secret.go
+++ b/pkg/test/resource/v2/secret.go
@@ -17,7 +17,6 @@ package resource
 import (
 	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 const (
@@ -98,9 +97,9 @@ yA==
 )
 
 // MakeSecrets generates an SDS secret
-func MakeSecrets(tlsName, rootName string) []types.Resource {
-	return []types.Resource{
-		&auth.Secret{
+func MakeSecrets(tlsName, rootName string) []*auth.Secret {
+	return []*auth.Secret{
+		{
 			Name: tlsName,
 			Type: &auth.Secret_TlsCertificate{
 				TlsCertificate: &auth.TlsCertificate{
@@ -113,7 +112,7 @@ func MakeSecrets(tlsName, rootName string) []types.Resource {
 				},
 			},
 		},
-		&auth.Secret{
+		{
 			Name: rootName,
 			Type: &auth.Secret_ValidationContext{
 				ValidationContext: &auth.CertificateValidationContext{

--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -379,6 +379,13 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 		runtimes[i] = MakeRuntime(name)
 	}
 
+	var secrets []types.Resource
+	if ts.TLS {
+		for _, s := range MakeSecrets(tlsName, rootName) {
+			secrets = append(secrets, s)
+		}
+	}
+
 	out := cache.NewSnapshot(
 		ts.Version,
 		endpoints,
@@ -386,11 +393,8 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 		routes,
 		listeners,
 		runtimes,
+		secrets,
 	)
-
-	if ts.TLS {
-		out.Resources[types.Secret] = cache.NewResources(ts.Version, MakeSecrets(tlsName, rootName))
-	}
 
 	return out
 }

--- a/pkg/test/resource/v3/secret.go
+++ b/pkg/test/resource/v3/secret.go
@@ -18,7 +18,6 @@ package resource
 import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 const (
@@ -99,9 +98,9 @@ yA==
 )
 
 // MakeSecrets generates an SDS secret
-func MakeSecrets(tlsName, rootName string) []types.Resource {
-	return []types.Resource{
-		&auth.Secret{
+func MakeSecrets(tlsName, rootName string) []*auth.Secret {
+	return []*auth.Secret{
+		{
 			Name: tlsName,
 			Type: &auth.Secret_TlsCertificate{
 				TlsCertificate: &auth.TlsCertificate{
@@ -114,7 +113,7 @@ func MakeSecrets(tlsName, rootName string) []types.Resource {
 				},
 			},
 		},
-		&auth.Secret{
+		{
 			Name: rootName,
 			Type: &auth.Secret_ValidationContext{
 				ValidationContext: &auth.CertificateValidationContext{


### PR DESCRIPTION
Updates #57 by adding SDS to snapshots so that secrets can be dynamically configured. 

Signed-off-by: Steve Sloka <slokas@vmware.com>