### PR TITLE
Add LoggerFuncs helper type.

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Envoyproxy Authors
+// Copyright 2020 Envoyproxy Authors
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
 //   you may not use this file except in compliance with the License.
@@ -28,4 +28,41 @@ type Logger interface {
 
 	// Errorf logs a formatted error message.
 	Errorf(format string, args ...interface{})
+}
+
+// LoggerFuncs implements the Logger interface, allowing the
+// caller to specify only the logging functions that are desired.
+type LoggerFuncs struct {
+	DebugFunc func(string, ...interface{})
+	InfoFunc  func(string, ...interface{})
+	WarnFunc  func(string, ...interface{})
+	ErrorFunc func(string, ...interface{})
+}
+
+// Debugf logs a formatted debugging message.
+func (f LoggerFuncs) Debugf(format string, args ...interface{}) {
+	if f.DebugFunc != nil {
+		f.DebugFunc(format, args...)
+	}
+}
+
+// Infof logs a formatted informational message.
+func (f LoggerFuncs) Infof(format string, args ...interface{}) {
+	if f.InfoFunc != nil {
+		f.InfoFunc(format, args...)
+	}
+}
+
+// Warnf logs a formatted warning message.
+func (f LoggerFuncs) Warnf(format string, args ...interface{}) {
+	if f.WarnFunc != nil {
+		f.WarnFunc(format, args...)
+	}
+}
+
+// Errorf logs a formatted error message.
+func (f LoggerFuncs) Errorf(format string, args ...interface{}) {
+	if f.ErrorFunc != nil {
+		f.ErrorFunc(format, args...)
+	}
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,71 @@
+// Copyright 2020 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package log
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleLoggerFuncs() {
+	logger := log.Logger{}
+
+	xdsLogger := LoggerFuncs{
+		DebugFunc: logger.Printf,
+		InfoFunc:  logger.Printf,
+		WarnFunc:  logger.Printf,
+		ErrorFunc: logger.Printf,
+	}
+
+	xdsLogger.Debugf("debug")
+	xdsLogger.Infof("info")
+	xdsLogger.Warnf("warn")
+	xdsLogger.Errorf("error")
+}
+
+func TestLoggerFuncs(t *testing.T) {
+	debug := 0
+	info := 0
+	warn := 0
+	error := 0
+
+	xdsLogger := LoggerFuncs{
+		DebugFunc: func(string, ...interface{}) { debug++ },
+		InfoFunc:  func(string, ...interface{}) { info++ },
+		WarnFunc:  func(string, ...interface{}) { warn++ },
+		ErrorFunc: func(string, ...interface{}) { error++ },
+	}
+
+	xdsLogger.Debugf("debug")
+	xdsLogger.Infof("info")
+	xdsLogger.Warnf("warn")
+	xdsLogger.Errorf("error")
+
+	assert.Equal(t, debug, 1)
+	assert.Equal(t, info, 1)
+	assert.Equal(t, warn, 1)
+	assert.Equal(t, error, 1)
+}
+
+func TestNilLoggerFuncs(t *testing.T) {
+	xdsLogger := LoggerFuncs{}
+
+	// Just verifying that nothing panics.
+	xdsLogger.Debugf("debug")
+	xdsLogger.Infof("info")
+	xdsLogger.Warnf("warn")
+	xdsLogger.Errorf("error")
+}


### PR DESCRIPTION
Add a LoggerFuncs helper type to reduce the amount of boilerplate
code needed to adapt a logging API to the log.Logger interface.

Signed-off-by: James Peach <jpeach@vmware.com>