### PR TITLE
make isPerXdsConfig usable

### DIFF
--- a/envoy/service/status/v3/csds.pb.go
+++ b/envoy/service/status/v3/csds.pb.go
@@ -149,7 +149,7 @@ type PerXdsConfig struct {
 	//	*PerXdsConfig_RouteConfig
 	//	*PerXdsConfig_ScopedRouteConfig
 	//	*PerXdsConfig_EndpointConfig
-	PerXdsConfig isPerXdsConfig_PerXdsConfig `protobuf_oneof:"per_xds_config"`
+	PerXdsConfig IsPerXdsConfig_PerXdsConfig `protobuf_oneof:"per_xds_config"`
 }
 
 func (x *PerXdsConfig) Reset() {
@@ -191,7 +191,7 @@ func (x *PerXdsConfig) GetStatus() ConfigStatus {
 	return ConfigStatus_UNKNOWN
 }
 
-func (m *PerXdsConfig) GetPerXdsConfig() isPerXdsConfig_PerXdsConfig {
+func (m *PerXdsConfig) GetPerXdsConfig() IsPerXdsConfig_PerXdsConfig {
 	if m != nil {
 		return m.PerXdsConfig
 	}
@@ -233,7 +233,7 @@ func (x *PerXdsConfig) GetEndpointConfig() *v31.EndpointsConfigDump {
 	return nil
 }
 
-type isPerXdsConfig_PerXdsConfig interface {
+type IsPerXdsConfig_PerXdsConfig interface {
 	isPerXdsConfig_PerXdsConfig()
 }
 


### PR DESCRIPTION
This is a private interface with only one member, which is also private.  The effect is that it is impossible to set members of this type from outside the package.  It appears that the intent is that the five PerXdsConfig_* types would be usable on these members, but this is not the case.  

I am aware that this is a generated file, but I'm struggling to find data on how the file is generated, and to understand how we could modify generation to not create unusable interfaces.

For reference, the following code does not work before this PR, unless it is placed in the status package directly:

```
x := status.PerXdsConfig {
    PerXdsConfig: status.PerXdsConfig_ClusterConfig{},
}
```

The above currently fails to compile.