### PR TITLE
implement extended type URLs in server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.11
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
-	github.com/cncf/udpa/go v0.0.0-20200313221541-5f7e5dd04533
+	github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cncf/udpa/go v0.0.0-20200313221541-5f7e5dd04533 h1:8wZizuKuZVu5COB7EsBYxBQz8nRcXXn5d4Gt91eJLvU=
-github.com/cncf/udpa/go v0.0.0-20200313221541-5f7e5dd04533/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354 h1:9kRtNpqLHbZVO/NNxhHp2ymxFxsHOe3x2efJGn//Tas=
+github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/pkg/cache/v2/cache.go
+++ b/pkg/cache/v2/cache.go
@@ -34,6 +34,7 @@ type Request = discovery.DiscoveryRequest
 // ConfigWatcher implementation must be thread-safe.
 type ConfigWatcher interface {
 	// CreateWatch returns a new open watch from a non-empty request.
+	// An individual consumer normally issues a single open watch by each type URL.
 	//
 	// Value channel produces requested resources, once they are available.  If
 	// the channel is closed prior to cancellation of the watch, an unrecoverable
@@ -58,7 +59,7 @@ type Response interface {
 	// Get the Constructed DiscoveryResponse
 	GetDiscoveryResponse() (*discovery.DiscoveryResponse, error)
 
-	// Get te original Request for the Response.
+	// Get the original Request for the Response.
 	GetRequest() *discovery.DiscoveryRequest
 
 	// Get the version in the Response.

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -35,6 +35,7 @@ type Request = discovery.DiscoveryRequest
 // ConfigWatcher implementation must be thread-safe.
 type ConfigWatcher interface {
 	// CreateWatch returns a new open watch from a non-empty request.
+	// An individual consumer normally issues a single open watch by each type URL.
 	//
 	// Value channel produces requested resources, once they are available.  If
 	// the channel is closed prior to cancellation of the watch, an unrecoverable
@@ -59,7 +60,7 @@ type Response interface {
 	// Get the Constructed DiscoveryResponse
 	GetDiscoveryResponse() (*discovery.DiscoveryResponse, error)
 
-	// Get te original Request for the Response.
+	// Get the original Request for the Response.
 	GetRequest() *discovery.DiscoveryRequest
 
 	// Get the version in the Response.

--- a/pkg/server/v2/server.go
+++ b/pkg/server/v2/server.go
@@ -432,7 +432,7 @@ func (s *server) process(stream stream, reqCh <-chan *discovery.DiscoveryRequest
 			default:
 				responseNonce, seen := values.nonces[req.TypeUrl]
 				if !seen || responseNonce == nonce {
-					if cancel, seen := values.cancellations[req.TypeUrl]; seen {
+					if cancel, seen := values.cancellations[req.TypeUrl]; seen && cancel != nil {
 						cancel()
 					}
 					var watch chan cache.Response

--- a/pkg/server/v2/server.go
+++ b/pkg/server/v2/server.go
@@ -175,10 +175,25 @@ type watches struct {
 	listenerNonce string
 	secretNonce   string
 	runtimeNonce  string
+
+	// Opaque resources share a muxed channel. Nonces and watch cancellations are indexed by type URL.
+	responses            chan cache.Response
+	cancellations        map[string]func()
+	nonces               map[string]string
+	stopResponseRoutines chan struct{}
+}
+
+// Initialize all watches
+func (values *watches) Init() {
+	// muxed channel needs a buffer to release go-routines populating it
+	values.responses = make(chan cache.Response, 5)
+	values.cancellations = make(map[string]func())
+	values.nonces = make(map[string]string)
+	values.stopResponseRoutines = make(chan struct{})
 }
 
 // Cancel all watches
-func (values watches) Cancel() {
+func (values *watches) Cancel() {
 	if values.endpointCancel != nil {
 		values.endpointCancel()
 	}
@@ -197,6 +212,10 @@ func (values watches) Cancel() {
 	if values.runtimeCancel != nil {
 		values.runtimeCancel()
 	}
+	for _, cancel := range values.cancellations {
+		cancel()
+	}
+	close(values.stopResponseRoutines)
 }
 
 func createResponse(resp cache.Response, typeURL string) (*discovery.DiscoveryResponse, error) {
@@ -221,8 +240,9 @@ func (s *server) process(stream stream, reqCh <-chan *discovery.DiscoveryRequest
 	// ignores stale nonces. nonce is only modified within send() function.
 	var streamNonce int64
 
-	// a collection of watches per request type
+	// a collection of stack allocated watches per request type
 	var values watches
+	values.Init()
 	defer func() {
 		values.Cancel()
 		if s.callbacks != nil {
@@ -320,6 +340,17 @@ func (s *server) process(stream stream, reqCh <-chan *discovery.DiscoveryRequest
 			}
 			values.runtimeNonce = nonce
 
+		case resp, more := <-values.responses:
+			if !more {
+				return status.Errorf(codes.Unavailable, "resource watch failed")
+			}
+			typeUrl := resp.GetRequest().TypeUrl
+			nonce, err := send(resp, typeUrl)
+			if err != nil {
+				return err
+			}
+			values.nonces[typeUrl] = nonce
+
 		case req, more := <-reqCh:
 			// input stream ended or errored out
 			if !more {
@@ -356,36 +387,72 @@ func (s *server) process(stream stream, reqCh <-chan *discovery.DiscoveryRequest
 
 			// cancel existing watches to (re-)request a newer version
 			switch {
-			case req.TypeUrl == resource.EndpointType && (values.endpointNonce == "" || values.endpointNonce == nonce):
-				if values.endpointCancel != nil {
-					values.endpointCancel()
+			case req.TypeUrl == resource.EndpointType:
+				if values.endpointNonce == "" || values.endpointNonce == nonce {
+					if values.endpointCancel != nil {
+						values.endpointCancel()
+					}
+					values.endpoints, values.endpointCancel = s.cache.CreateWatch(*req)
 				}
-				values.endpoints, values.endpointCancel = s.cache.CreateWatch(*req)
-			case req.TypeUrl == resource.ClusterType && (values.clusterNonce == "" || values.clusterNonce == nonce):
-				if values.clusterCancel != nil {
-					values.clusterCancel()
+			case req.TypeUrl == resource.ClusterType:
+				if values.clusterNonce == "" || values.clusterNonce == nonce {
+					if values.clusterCancel != nil {
+						values.clusterCancel()
+					}
+					values.clusters, values.clusterCancel = s.cache.CreateWatch(*req)
 				}
-				values.clusters, values.clusterCancel = s.cache.CreateWatch(*req)
-			case req.TypeUrl == resource.RouteType && (values.routeNonce == "" || values.routeNonce == nonce):
-				if values.routeCancel != nil {
-					values.routeCancel()
+			case req.TypeUrl == resource.RouteType:
+				if values.routeNonce == "" || values.routeNonce == nonce {
+					if values.routeCancel != nil {
+						values.routeCancel()
+					}
+					values.routes, values.routeCancel = s.cache.CreateWatch(*req)
 				}
-				values.routes, values.routeCancel = s.cache.CreateWatch(*req)
-			case req.TypeUrl == resource.ListenerType && (values.listenerNonce == "" || values.listenerNonce == nonce):
-				if values.listenerCancel != nil {
-					values.listenerCancel()
+			case req.TypeUrl == resource.ListenerType:
+				if values.listenerNonce == "" || values.listenerNonce == nonce {
+					if values.listenerCancel != nil {
+						values.listenerCancel()
+					}
+					values.listeners, values.listenerCancel = s.cache.CreateWatch(*req)
 				}
-				values.listeners, values.listenerCancel = s.cache.CreateWatch(*req)
-			case req.TypeUrl == resource.SecretType && (values.secretNonce == "" || values.secretNonce == nonce):
-				if values.secretCancel != nil {
-					values.secretCancel()
+			case req.TypeUrl == resource.SecretType:
+				if values.secretNonce == "" || values.secretNonce == nonce {
+					if values.secretCancel != nil {
+						values.secretCancel()
+					}
+					values.secrets, values.secretCancel = s.cache.CreateWatch(*req)
 				}
-				values.secrets, values.secretCancel = s.cache.CreateWatch(*req)
-			case req.TypeUrl == resource.RuntimeType && (values.runtimeNonce == "" || values.runtimeNonce == nonce):
-				if values.runtimeCancel != nil {
-					values.runtimeCancel()
+			case req.TypeUrl == resource.RuntimeType:
+				if values.runtimeNonce == "" || values.runtimeNonce == nonce {
+					if values.runtimeCancel != nil {
+						values.runtimeCancel()
+					}
+					values.runtimes, values.runtimeCancel = s.cache.CreateWatch(*req)
 				}
-				values.runtimes, values.runtimeCancel = s.cache.CreateWatch(*req)
+			default:
+				responseNonce, seen := values.nonces[req.TypeUrl]
+				if !seen || responseNonce == nonce {
+					if cancel, seen := values.cancellations[req.TypeUrl]; seen {
+						cancel()
+					}
+					var watch chan cache.Response
+					watch, values.cancellations[req.TypeUrl] = s.cache.CreateWatch(*req)
+					// Muxing watches across multiple type URLs onto a single channel requires spawning
+					// a go-routine. Golang does not allow selecting over a dynamic set of channels.
+					go func() {
+						select {
+						case resp, more := <-watch:
+							if more {
+								values.responses <- resp
+							} else {
+								close(values.responses)
+							}
+							break
+						case <-values.stopResponseRoutines:
+							break
+						}
+					}()
+				}
 			}
 		}
 	}

--- a/pkg/server/v3/server.go
+++ b/pkg/server/v3/server.go
@@ -433,7 +433,7 @@ func (s *server) process(stream stream, reqCh <-chan *discovery.DiscoveryRequest
 			default:
 				responseNonce, seen := values.nonces[req.TypeUrl]
 				if !seen || responseNonce == nonce {
-					if cancel, seen := values.cancellations[req.TypeUrl]; seen {
+					if cancel, seen := values.cancellations[req.TypeUrl]; seen && cancel != nil {
 						cancel()
 					}
 					var watch chan cache.Response

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -132,6 +132,8 @@ const (
 	clusterName  = "cluster0"
 	routeName    = "route0"
 	listenerName = "listener0"
+	secretName   = "secret0"
+	runtimeName  = "runtime0"
 )
 
 var (
@@ -139,15 +141,22 @@ var (
 		Id:      "test-id",
 		Cluster: "test-cluster",
 	}
-	endpoint  = resource.MakeEndpoint(clusterName, 8080)
-	cluster   = resource.MakeCluster(resource.Ads, clusterName)
-	route     = resource.MakeRoute(routeName, clusterName)
-	listener  = resource.MakeHTTPListener(resource.Ads, listenerName, 80, routeName)
-	testTypes = []string{
+	endpoint   = resource.MakeEndpoint(clusterName, 8080)
+	cluster    = resource.MakeCluster(resource.Ads, clusterName)
+	route      = resource.MakeRoute(routeName, clusterName)
+	listener   = resource.MakeHTTPListener(resource.Ads, listenerName, 80, routeName)
+	secret     = resource.MakeSecrets(secretName, "test")[0]
+	runtime    = resource.MakeRuntime(runtimeName)
+	opaque     = &core.Address{}
+	opaqueType = "unknown-type"
+	testTypes  = []string{
 		rsrc.EndpointType,
 		rsrc.ClusterType,
 		rsrc.RouteType,
 		rsrc.ListenerType,
+		rsrc.SecretType,
+		rsrc.RuntimeType,
+		opaqueType,
 	}
 )
 
@@ -172,6 +181,22 @@ func makeResponses() map[string][]cache.RawResponse {
 			Version:   "4",
 			Resources: []types.Resource{listener},
 			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
+		}},
+		rsrc.SecretType: {{
+			Version:   "5",
+			Resources: []types.Resource{secret},
+			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
+		}},
+		rsrc.RuntimeType: {{
+			Version:   "6",
+			Resources: []types.Resource{runtime},
+			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
+		}},
+		// Pass-through type (xDS does not exist for this type)
+		opaqueType: {{
+			Version:   "7",
+			Resources: []types.Resource{opaque},
+			Request:   discovery.DiscoveryRequest{TypeUrl: opaqueType},
 		}},
 	}
 }
@@ -199,6 +224,12 @@ func TestServerShutdown(t *testing.T) {
 					err = s.StreamRoutes(resp)
 				case rsrc.ListenerType:
 					err = s.StreamListeners(resp)
+				case rsrc.SecretType:
+					err = s.StreamSecrets(resp)
+				case rsrc.RuntimeType:
+					err = s.StreamRuntime(resp)
+				case opaqueType:
+					err = s.StreamAggregatedResources(resp)
 				}
 				if err != nil {
 					t.Errorf("Stream() => got %v, want no error", err)
@@ -240,6 +271,12 @@ func TestResponseHandlers(t *testing.T) {
 					err = s.StreamRoutes(resp)
 				case rsrc.ListenerType:
 					err = s.StreamListeners(resp)
+				case rsrc.SecretType:
+					err = s.StreamSecrets(resp)
+				case rsrc.RuntimeType:
+					err = s.StreamRuntime(resp)
+				case opaqueType:
+					err = s.StreamAggregatedResources(resp)
 				}
 				if err != nil {
 					t.Errorf("Stream() => got %v, want no error", err)
@@ -300,6 +337,12 @@ func TestFetch(t *testing.T) {
 	if out, err := s.FetchListeners(context.Background(), &discovery.DiscoveryRequest{Node: node}); out == nil || err != nil {
 		t.Errorf("unexpected empty or error for listeners: %v", err)
 	}
+	if out, err := s.FetchSecrets(context.Background(), &discovery.DiscoveryRequest{Node: node}); out == nil || err != nil {
+		t.Errorf("unexpected empty or error for listeners: %v", err)
+	}
+	if out, err := s.FetchRuntime(context.Background(), &discovery.DiscoveryRequest{Node: node}); out == nil || err != nil {
+		t.Errorf("unexpected empty or error for listeners: %v", err)
+	}
 
 	// try again and expect empty results
 	if out, err := s.FetchEndpoints(context.Background(), &discovery.DiscoveryRequest{Node: node}); out != nil {
@@ -328,6 +371,12 @@ func TestFetch(t *testing.T) {
 	if out, err := s.FetchListeners(context.Background(), nil); out != nil {
 		t.Errorf("expected empty on empty request: %v", err)
 	}
+	if out, err := s.FetchSecrets(context.Background(), nil); out != nil {
+		t.Errorf("expected empty on empty request: %v", err)
+	}
+	if out, err := s.FetchRuntime(context.Background(), nil); out != nil {
+		t.Errorf("expected empty on empty request: %v", err)
+	}
 
 	// send error from callback
 	callbackError = true
@@ -345,10 +394,10 @@ func TestFetch(t *testing.T) {
 	}
 
 	// verify fetch callbacks
-	if want := 8; requestCount != want {
+	if want := 10; requestCount != want {
 		t.Errorf("unexpected number of fetch requests: got %d, want %d", requestCount, want)
 	}
-	if want := 4; responseCount != want {
+	if want := 6; responseCount != want {
 		t.Errorf("unexpected number of fetch responses: got %d, want %d", responseCount, want)
 	}
 }
@@ -458,17 +507,15 @@ func TestAggregatedHandlers(t *testing.T) {
 		Node:    node,
 		TypeUrl: rsrc.ListenerType,
 	}
+	// Delta compress node
 	resp.recv <- &discovery.DiscoveryRequest{
-		Node:    node,
 		TypeUrl: rsrc.ClusterType,
 	}
 	resp.recv <- &discovery.DiscoveryRequest{
-		Node:          node,
 		TypeUrl:       rsrc.EndpointType,
 		ResourceNames: []string{clusterName},
 	}
 	resp.recv <- &discovery.DiscoveryRequest{
-		Node:          node,
 		TypeUrl:       rsrc.RouteType,
 		ResourceNames: []string{routeName},
 	}


### PR DESCRIPTION
Issue #323 
Allows the server to propagate xDS requests for future types (e.g. extension configs).
Increase test coverage to near full in the server implementation.
This is only the server, cache change will follow.

Signed-off-by: Kuat Yessenov <kuat@google.com>