### PR TITLE
Add: Datadog tracer name to wellknown types

### DIFF
--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -99,6 +99,8 @@ const (
 	Zipkin = "envoy.tracers.zipkin"
 	// DynamicOT tracer name
 	DynamicOT = "envoy.tracers.dynamic_ot"
+	// Datadog tracer name
+	Datadog = "envoy.tracers.datadog"
 )
 
 // Stats sink names


### PR DESCRIPTION
Simple PR: Adding Datadog APM/Tracer as a well known type.