### PR TITLE
Help for newcomers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,30 +35,33 @@ check_version_dirty:
 #-----------------
 #-- integration
 #-----------------
-.PHONY: $(BINDIR)/test integration integration.ads integration.ads.v3 integration.xds integration.xds.v3 integration.rest integration.rest.v3 integration.ads.tls
+.PHONY: $(BINDIR)/test $(BINDIR)/upstream integration integration.ads integration.ads.v3 integration.xds integration.xds.v3 integration.rest integration.rest.v3 integration.ads.tls
+
+$(BINDIR)/upstream:
+	@go build -race -o $@ internal/upstream/main.go
 
 $(BINDIR)/test:
 	@go build -race -o $@ pkg/test/main/main.go
 
 integration: integration.xds integration.xds.v3 integration.ads integration.ads.v3 integration.rest integration.rest.v3 integration.ads.tls
 
-integration.ads: $(BINDIR)/test
+integration.ads: $(BINDIR)/test $(BINDIR)/upstream
 	env XDS=ads build/integration.sh
 
-integration.ads.v3: $(BINDIR)/test
+integration.ads.v3: $(BINDIR)/test $(BINDIR)/upstream
 	env XDS=ads SUFFIX=v3 build/integration.sh
 
-integration.xds: $(BINDIR)/test
+integration.xds: $(BINDIR)/test $(BINDIR)/upstream
 	env XDS=xds build/integration.sh
 
-integration.xds.v3: $(BINDIR)/test
+integration.xds.v3: $(BINDIR)/test $(BINDIR)/upstream
 	env XDS=xds SUFFIX=v3 build/integration.sh
 
-integration.rest: $(BINDIR)/test
+integration.rest: $(BINDIR)/test $(BINDIR)/upstream
 	env XDS=rest build/integration.sh
 
-integration.rest.v3: $(BINDIR)/test
+integration.rest.v3: $(BINDIR)/test $(BINDIR)/upstream
 	env XDS=rest SUFFIX=v3 build/integration.sh
 
-integration.ads.tls: $(BINDIR)/test
+integration.ads.tls: $(BINDIR)/test $(BINDIR)/upstream
 	env XDS=ads build/integration.sh -tls

--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,14 @@ integration.rest.v3: $(BINDIR)/test $(BINDIR)/upstream
 
 integration.ads.tls: $(BINDIR)/test $(BINDIR)/upstream
 	env XDS=ads build/integration.sh -tls
+
+#--------------------------------------
+#-- example xDS control plane server
+#--------------------------------------
+.PHONY: $(BINDIR)/example example
+
+$(BINDIR)/example:
+	@go build -race -o $@ internal/example/main/main.go
+
+example: $(BINDIR)/example
+	@build/example.sh

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ in the same environment as the circle ci. This makes sure to produce a consisten
     ./build/run_docker.sh make integration
     ```
 
+1. Take a look at the [example server](internal/example/README.md).
+
+
 ## Xds Api versioning
 
 The Envoy xDS APIs follow a well defined [versioning scheme](https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/versioning).
@@ -72,51 +75,4 @@ When v2 version is frozen in the future, we will change the experience such that
 
 ## Usage
 
-Register services on the gRPC server as follows.
-
-```go
-import (
-	"context"
-	"google.golang.org/grpc"
-	"net"
-
-	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
-	xds "github.com/envoyproxy/go-control-plane/pkg/server/v2"
-)
-
-func main() {
-	snapshotCache := cache.NewSnapshotCache(false, cache.IDHash{}, nil)
-	server := xds.NewServer(context.Background(), snapshotCache, nil)
-	grpcServer := grpc.NewServer()
-	lis, _ := net.Listen("tcp", ":8080")
-
-	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
-	api.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
-	api.RegisterClusterDiscoveryServiceServer(grpcServer, server)
-	api.RegisterRouteDiscoveryServiceServer(grpcServer, server)
-	api.RegisterListenerDiscoveryServiceServer(grpcServer, server)
-	go func() {
-		if err := grpcServer.Serve(lis); err != nil {
-			// error handling
-		}
-	}()
-}
-```
-
-As mentioned in [Scope](https://github.com/envoyproxy/go-control-plane/blob/master/README.md#scope), you need to cache Envoy configurations.
-Generate the key based on the node information as follows and cache the configurations.
-
-```go
-import (
-	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
- 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-)
-
-var clusters, endpoints, routes, listeners, runtimes []types.Resource
-
-snapshotCache := cache.NewSnapshotCache(false, cache.IDHash{}, nil)
-snapshot := cache.NewSnapshot("1.0", endpoints, clusters, routes, listeners, runtimes)
-_ = snapshotCache.SetSnapshot("node1", snapshot)
-```
+The [example server](internal/example/README.md) demonstrates how to integrate the go-control-plane with your code.

--- a/build/example.sh
+++ b/build/example.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+##
+## Runs Envoy and the example control plane server.  See
+## `internal/example` for the go source.
+##
+
+# Envoy start-up command
+ENVOY=${ENVOY:-/usr/local/bin/envoy}
+
+# Start envoy: important to keep drain time short
+(${ENVOY} -c sample/bootstrap-xdsv3.yaml --drain-time-s 1 -l debug)&
+ENVOY_PID=$!
+
+function cleanup() {
+  kill ${ENVOY_PID}
+}
+trap cleanup EXIT
+
+# Run the control plane
+bin/example -debug $@

--- a/build/integration.sh
+++ b/build/integration.sh
@@ -8,6 +8,8 @@ set -o pipefail
 ## This is a wrapper around the test app `pkg/test/main` that spawns/kills Envoy.
 ##
 
+MESSAGE=$'Hi, there!\n'
+
 # Management server type. Valid values are "ads", "xds", "rest"
 XDS=${XDS:-ads}
 
@@ -21,8 +23,9 @@ else
   RUNTIMES=1
 fi
 
-(bin/test --xds=${XDS} --runtimes=${RUNTIMES} -debug "$@")&
-SERVER_PID=$!
+# Start the http server that sits upstream of Envoy
+(bin/upstream -debug -message="$MESSAGE")&
+UPSTREAM_PID=$!
 
 # Envoy start-up command
 ENVOY=${ENVOY:-/usr/local/bin/envoy}
@@ -35,7 +38,9 @@ ENVOY_PID=$!
 
 function cleanup() {
   kill ${ENVOY_PID}
+  kill ${UPSTREAM_PID}
 }
 trap cleanup EXIT
 
-wait ${SERVER_PID}
+# run the test suite (which also contains the control plane)
+bin/test --xds=${XDS} --runtimes=${RUNTIMES} -debug -message="$MESSAGE" "$@"

--- a/build/integration.sh
+++ b/build/integration.sh
@@ -24,7 +24,7 @@ else
 fi
 
 # Start the http server that sits upstream of Envoy
-(bin/upstream -debug -message="$MESSAGE")&
+(bin/upstream -message="$MESSAGE")&
 UPSTREAM_PID=$!
 
 # Envoy start-up command

--- a/internal/example/README.md
+++ b/internal/example/README.md
@@ -1,0 +1,16 @@
+# Example xDS Server
+
+This is an example of a trivial xDS V3 control plane server.  It serves an Envoy configuration that's roughly equivalent to the one used by the Envoy ["Quick Start"](https://www.envoyproxy.io/docs/envoy/latest/start/start#quick-start-to-run-simple-example) docs: a simple http proxy.  You can run the example using the project top-level Makefile, e.g.:
+
+```
+go-control-plane$ make example
+```
+
+The Makefile builds the example server and then runs `build/example.sh` which runs both Envoy and the example server.  The example server serves a configuration defined in `internal/example/resource.go`.  If everything works correctly, you should be able to open a browser to [http://localhost:10000](http://localhost:10000) and see Acnodal.io's website.
+
+## Files
+
+* [main/main.go](main/main.go) is the example program entrypoint.  It instantiates the cache and xDS server and runs the xDS server process.
+* [resource.go](resource.go) generates a `Snapshot` structure which describes the configuration that the xDS server serves to Envoy.
+* [server.go](server.go) runs the xDS control plane server.
+* [logger.go](logger.go) implements the `pkg/log/Logger` interface which provides logging services to the cache.

--- a/internal/example/README.md
+++ b/internal/example/README.md
@@ -6,7 +6,7 @@ This is an example of a trivial xDS V3 control plane server.  It serves an Envoy
 go-control-plane$ make example
 ```
 
-The Makefile builds the example server and then runs `build/example.sh` which runs both Envoy and the example server.  The example server serves a configuration defined in `internal/example/resource.go`.  If everything works correctly, you should be able to open a browser to [http://localhost:10000](http://localhost:10000) and see Acnodal.io's website.
+The Makefile builds the example server and then runs `build/example.sh` which runs both Envoy and the example server.  The example server serves a configuration defined in `internal/example/resource.go`.  If everything works correctly, you should be able to open a browser to [http://localhost:10000](http://localhost:10000) and see Envoy's website.
 
 ## Files
 

--- a/internal/example/logger.go
+++ b/internal/example/logger.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package example
+
+import (
+	"log"
+)
+
+// An example of a logger that implements `pkg/log/Logger`.  Logs to
+// stdout.  If Debug == false then Debugf() and Infof() won't output
+// anything.
+type Logger struct {
+	Debug bool
+}
+
+// Log to stdout only if Debug is true.
+func (logger Logger) Debugf(format string, args ...interface{}) {
+	if logger.Debug {
+		log.Printf(format+"\n", args...)
+	}
+}
+
+// Log to stdout only if Debug is true.
+func (logger Logger) Infof(format string, args ...interface{}) {
+	if logger.Debug {
+		log.Printf(format+"\n", args...)
+	}
+}
+
+// Log to stdout always.
+func (logger Logger) Warnf(format string, args ...interface{}) {
+	log.Printf(format+"\n", args...)
+}
+
+// Log to stdout always.
+func (logger Logger) Errorf(format string, args ...interface{}) {
+	log.Printf(format+"\n", args...)
+}

--- a/internal/example/main/main.go
+++ b/internal/example/main/main.go
@@ -1,0 +1,75 @@
+// Copyright 2020 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package main
+
+import (
+	"context"
+	"flag"
+	"os"
+
+	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	testv3 "github.com/envoyproxy/go-control-plane/pkg/test/v3"
+
+	"github.com/envoyproxy/go-control-plane/internal/example"
+)
+
+var (
+	l example.Logger
+
+	port     uint
+	basePort uint
+	mode     string
+
+	nodeID string
+)
+
+func init() {
+	l = example.Logger{}
+
+	flag.BoolVar(&l.Debug, "debug", false, "Enable xDS server debug logging")
+
+	// The port that this xDS server listens on
+	flag.UintVar(&port, "port", 18000, "xDS management server port")
+
+	// Tell Envoy to use this Node ID
+	flag.StringVar(&nodeID, "nodeID", "test-id", "Node ID")
+}
+
+func main() {
+	flag.Parse()
+
+	// Create a cache
+	cache := cachev3.NewSnapshotCache(false, cachev3.IDHash{}, l)
+
+	// Create the snapshot that we'll serve to Envoy
+	snapshot := example.GenerateSnapshot()
+	if err := snapshot.Consistent(); err != nil {
+		l.Errorf("snapshot inconsistency: %+v\n%+v", snapshot, err)
+		os.Exit(1)
+	}
+	l.Debugf("will serve snapshot %+v", snapshot)
+
+	// Add the snapshot to the cache
+	if err := cache.SetSnapshot(nodeID, snapshot); err != nil {
+		l.Errorf("snapshot error %q for %+v", err, snapshot)
+		os.Exit(1)
+	}
+
+	// Run the xDS server
+	ctx := context.Background()
+	cb := &testv3.Callbacks{Debug: l.Debug}
+	srv := serverv3.NewServer(ctx, cache, cb)
+	example.RunServer(ctx, srv, port)
+}

--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -31,11 +31,11 @@ import (
 )
 
 const (
-	ClusterName  = "service_acnodal"
+	ClusterName  = "example_proxy_cluster"
 	RouteName    = "local_route"
 	ListenerName = "listener_0"
 	ListenerPort = 10000
-	UpstreamHost = "www.acnodal.io"
+	UpstreamHost = "www.envoyproxy.io"
 	UpstreamPort = 80
 )
 

--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -1,0 +1,176 @@
+// Copyright 2020 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package example
+
+import (
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+)
+
+const (
+	ClusterName  = "service_acnodal"
+	RouteName    = "local_route"
+	ListenerName = "listener_0"
+	ListenerPort = 10000
+	UpstreamHost = "www.acnodal.io"
+	UpstreamPort = 80
+)
+
+func makeCluster(clusterName string) *cluster.Cluster {
+	return &cluster.Cluster{
+		Name:                 clusterName,
+		ConnectTimeout:       ptypes.DurationProto(5 * time.Second),
+		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_LOGICAL_DNS},
+		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
+		LoadAssignment:       makeEndpoint(clusterName),
+	}
+}
+
+func makeEndpoint(clusterName string) *endpoint.ClusterLoadAssignment {
+	return &endpoint.ClusterLoadAssignment{
+		ClusterName: clusterName,
+		Endpoints: []*endpoint.LocalityLbEndpoints{{
+			LbEndpoints: []*endpoint.LbEndpoint{{
+				HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+					Endpoint: &endpoint.Endpoint{
+						Address: &core.Address{
+							Address: &core.Address_SocketAddress{
+								SocketAddress: &core.SocketAddress{
+									Protocol: core.SocketAddress_TCP,
+									Address:  UpstreamHost,
+									PortSpecifier: &core.SocketAddress_PortValue{
+										PortValue: UpstreamPort,
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+		}},
+	}
+}
+
+func makeRoute(routeName string, clusterName string) *route.RouteConfiguration {
+	return &route.RouteConfiguration{
+		Name: routeName,
+		VirtualHosts: []*route.VirtualHost{{
+			Name:    "local_service",
+			Domains: []string{"*"},
+			Routes: []*route.Route{{
+				Match: &route.RouteMatch{
+					PathSpecifier: &route.RouteMatch_Prefix{
+						Prefix: "/",
+					},
+				},
+				Action: &route.Route_Route{
+					Route: &route.RouteAction{
+						ClusterSpecifier: &route.RouteAction_Cluster{
+							Cluster: clusterName,
+						},
+						HostRewriteSpecifier: &route.RouteAction_HostRewriteLiteral{
+							HostRewriteLiteral: UpstreamHost,
+						},
+					},
+				},
+			}},
+		}},
+	}
+}
+
+func makeHTTPListener(listenerName string, route string) *listener.Listener {
+	// HTTP filter configuration
+	manager := &hcm.HttpConnectionManager{
+		CodecType:  hcm.HttpConnectionManager_AUTO,
+		StatPrefix: "http",
+		RouteSpecifier: &hcm.HttpConnectionManager_Rds{
+			Rds: &hcm.Rds{
+				ConfigSource:    makeConfigSource(),
+				RouteConfigName: route,
+			},
+		},
+		HttpFilters: []*hcm.HttpFilter{{
+			Name: wellknown.Router,
+		}},
+	}
+	pbst, err := ptypes.MarshalAny(manager)
+	if err != nil {
+		panic(err)
+	}
+
+	return &listener.Listener{
+		Name: listenerName,
+		Address: &core.Address{
+			Address: &core.Address_SocketAddress{
+				SocketAddress: &core.SocketAddress{
+					Protocol: core.SocketAddress_TCP,
+					Address:  "0.0.0.0",
+					PortSpecifier: &core.SocketAddress_PortValue{
+						PortValue: ListenerPort,
+					},
+				},
+			},
+		},
+		FilterChains: []*listener.FilterChain{{
+			Filters: []*listener.Filter{{
+				Name: wellknown.HTTPConnectionManager,
+				ConfigType: &listener.Filter_TypedConfig{
+					TypedConfig: pbst,
+				},
+			}},
+		}},
+	}
+}
+
+func makeConfigSource() *core.ConfigSource {
+	source := &core.ConfigSource{}
+	source.ResourceApiVersion = resource.DefaultAPIVersion
+	source.ConfigSourceSpecifier = &core.ConfigSource_ApiConfigSource{
+		ApiConfigSource: &core.ApiConfigSource{
+			TransportApiVersion:       resource.DefaultAPIVersion,
+			ApiType:                   core.ApiConfigSource_GRPC,
+			SetNodeOnFirstMessageOnly: true,
+			GrpcServices: []*core.GrpcService{{
+				TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+					EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: "xds_cluster"},
+				},
+			}},
+		},
+	}
+	return source
+}
+
+func GenerateSnapshot() cache.Snapshot {
+	return cache.NewSnapshot(
+		"1",
+		[]types.Resource{}, // endpoints
+		[]types.Resource{makeCluster(ClusterName)},
+		[]types.Resource{makeRoute(RouteName, ClusterName)},
+		[]types.Resource{makeHTTPListener(ListenerName, RouteName)},
+		[]types.Resource{}, // runtimes
+		[]types.Resource{}, // secrets
+	)
+}

--- a/internal/example/server.go
+++ b/internal/example/server.go
@@ -1,0 +1,70 @@
+// Copyright 2020 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package example
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+
+	"google.golang.org/grpc"
+
+	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
+	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	endpointservice "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
+	listenerservice "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
+	routeservice "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
+	runtimeservice "github.com/envoyproxy/go-control-plane/envoy/service/runtime/v3"
+	secretservice "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+)
+
+const (
+	grpcMaxConcurrentStreams = 1000000
+)
+
+func registerServer(grpcServer *grpc.Server, server serverv3.Server) {
+	// register services
+	discoverygrpc.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
+	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
+	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, server)
+	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, server)
+	listenerservice.RegisterListenerDiscoveryServiceServer(grpcServer, server)
+	secretservice.RegisterSecretDiscoveryServiceServer(grpcServer, server)
+	runtimeservice.RegisterRuntimeDiscoveryServiceServer(grpcServer, server)
+}
+
+// RunServer starts an xDS server at the given port.
+func RunServer(ctx context.Context, srv3 serverv3.Server, port uint) {
+	// gRPC golang library sets a very small upper bound for the number gRPC/h2
+	// streams over a single TCP connection. If a proxy multiplexes requests over
+	// a single connection to the management server, then it might lead to
+	// availability problems.
+	var grpcOptions []grpc.ServerOption
+	grpcOptions = append(grpcOptions, grpc.MaxConcurrentStreams(grpcMaxConcurrentStreams))
+	grpcServer := grpc.NewServer(grpcOptions...)
+
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	registerServer(grpcServer, srv3)
+
+	log.Printf("management server listening on %d\n", port)
+	if err = grpcServer.Serve(lis); err != nil {
+		log.Println(err)
+	}
+}

--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -1,0 +1,9 @@
+# HTTP Upstream Test Server
+
+This server is used by the integration tests as an upstream server.
+It simply responds to HTTP GET requests with a canned message that is
+then proxied to the test framework via Envoy.
+
+For more info see the ```build/integration.sh``` script which runs the
+upstream server, and ```pkg/test/main/main.go``` for the test
+framework that sends and checks the requests.

--- a/internal/upstream/main.go
+++ b/internal/upstream/main.go
@@ -22,12 +22,10 @@ import (
 
 func main() {
 	var (
-		debug        bool
 		upstreamPort uint
 		hello        string
 	)
 
-	flag.BoolVar(&debug, "debug", false, "Use debug logging")
 	flag.UintVar(&upstreamPort, "upstream", 18080, "Upstream HTTP/1.1 port")
 	flag.StringVar(&hello, "message", "Default message", "Message to send in response")
 	flag.Parse()

--- a/internal/upstream/main.go
+++ b/internal/upstream/main.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Envoyproxy Authors
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	var (
+		debug        bool
+		upstreamPort uint
+		hello        string
+	)
+
+	flag.BoolVar(&debug, "debug", false, "Use debug logging")
+	flag.UintVar(&upstreamPort, "upstream", 18080, "Upstream HTTP/1.1 port")
+	flag.StringVar(&hello, "message", "Default message", "Message to send in response")
+	flag.Parse()
+
+	log.Printf("upstream listening HTTP/1.1 on %d\n", upstreamPort)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(hello)); err != nil {
+			log.Println(err)
+		}
+	})
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", upstreamPort), nil); err != nil {
+		log.Println(err)
+	}
+}

--- a/pkg/test/main/README.md
+++ b/pkg/test/main/README.md
@@ -35,38 +35,5 @@ eventually converges to use the latest pushed configuration) for each run.
 
 ## Customizing the test driver
 
-The test driver has the following options:
-
-```
-Usage of bin/test:
-  -als uint
-    	Accesslog server port (default 18090)
-  -base uint
-    	Listener port (default 9000)
-  -clusters int
-    	Number of clusters (default 2)
-  -debug
-    	Use debug logging
-  -delay duration
-    	Interval between request batch retries (default 500ms)
-  -gateway uint
-    	Management server port for HTTP gateway (default 18001)
-  -http int
-    	Number of HTTP listeners (and RDS configs) (default 1)
-  -nodeID string
-    	Node ID (default "test-id")
-  -port uint
-    	Management server port (default 18000)
-  -r int
-    	Number of requests between snapshot updates (default 5)
-  -tcp int
-    	Number of TCP pass-through listeners (default 1)
-  -runtimes int
-        Number of RTDS layers (default 1)
-  -u int
-    	Number of snapshot updates (default 3)
-  -upstream uint
-    	Upstream HTTP/1.1 port (default 18080)
-  -xds string
-    	Management server type (ads, xds, rest) (default "ads")
-```
+You can run ```bin/test -help``` to get a list of the cli flags that
+the test program accepts.  There are also comments in ```main.go```.

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -63,21 +63,76 @@ var (
 
 func init() {
 	flag.BoolVar(&debug, "debug", false, "Use debug logging")
-	flag.UintVar(&port, "port", 18000, "Management server port")
-	flag.UintVar(&gatewayPort, "gateway", 18001, "Management server port for HTTP gateway")
+
+	//
+	// These parameters control the ports that the integration test
+	// components use to talk to one another
+	//
+
+	// The port that the Envoy xDS client uses to talk to the control
+	// plane xDS server (part of this program)
+	flag.UintVar(&port, "port", 18000, "xDS management server port")
+
+	// The port that the Envoy REST client uses to talk to the control
+	// plane gateway (which translates from REST to xDS)
+	flag.UintVar(&gatewayPort, "gateway", 18001, "Management HTTP gateway (from HTTP to xDS) server port")
+
+	// The port that Envoy uses to talk to the upstream http "echo"
+	// server
 	flag.UintVar(&upstreamPort, "upstream", 18080, "Upstream HTTP/1.1 port")
-	flag.UintVar(&basePort, "base", 9000, "Listener port")
-	flag.UintVar(&alsPort, "als", 18090, "Accesslog server port")
-	flag.DurationVar(&delay, "delay", 500*time.Millisecond, "Interval between request batch retries")
-	flag.IntVar(&requests, "r", 5, "Number of requests between snapshot updates")
-	flag.IntVar(&updates, "u", 3, "Number of snapshot updates")
-	flag.StringVar(&mode, "xds", resourcev2.Ads, "Management server type (ads, xds, rest)")
-	flag.IntVar(&clusters, "clusters", 4, "Number of clusters")
-	flag.IntVar(&httpListeners, "http", 2, "Number of HTTP listeners (and RDS configs)")
-	flag.IntVar(&tcpListeners, "tcp", 2, "Number of TCP pass-through listeners")
-	flag.IntVar(&runtimes, "runtimes", 1, "Number of RTDS layers")
+
+	// The port that the tests below use to talk to Envoy's proxy of the
+	// upstream server
+	flag.UintVar(&basePort, "base", 9000, "Envoy Proxy listener port")
+
+	// The control plane accesslog server port (currently unused)
+	flag.UintVar(&alsPort, "als", 18090, "Control plane accesslog server port")
+
+	//
+	// These parameters control Envoy configuration
+	//
+
+	// Tell Envoy to request configurations from the control plane using
+	// this protocol
+	flag.StringVar(&mode, "xds", resourcev2.Ads, "Management protocol to test (ADS, xDS, REST)")
+
+	// Tell Envoy to use this Node ID
 	flag.StringVar(&nodeID, "nodeID", "test-id", "Node ID")
+
+	// Tell Envoy to use TLS to talk to the control plane
 	flag.BoolVar(&tls, "tls", false, "Enable TLS on all listeners and use SDS for secret delivery")
+
+	// Tell Envoy to configure this many clusters for each snapshot
+	flag.IntVar(&clusters, "clusters", 4, "Number of clusters")
+
+	// Tell Envoy to configure this many Runtime Discovery Service
+	// layers for each snapshot
+	flag.IntVar(&runtimes, "runtimes", 1, "Number of RTDS layers")
+
+	//
+	// These parameters control the test harness
+	//
+
+	// The message that the tests expect to receive from the upstream
+	// server
+	flag.StringVar(&upstreamMessage, "message", "Default message", "Upstream HTTP server response message")
+
+	// Time to wait between test request batches
+	flag.DurationVar(&delay, "delay", 500*time.Millisecond, "Interval between request batch retries")
+
+	// Each test loads a configuration snapshot into the control plane
+	// which is then picked up by Envoy.  This parameter specifies how
+	// many snapshots to test
+	flag.IntVar(&updates, "u", 3, "Number of snapshot updates")
+
+	// Each snapshot test sends this many requests to the upstream
+	// server for each snapshot for each listener port
+	flag.IntVar(&requests, "r", 5, "Number of requests between snapshot updates")
+
+	// Test this many HTTP listeners per snapshot
+	flag.IntVar(&httpListeners, "http", 2, "Number of HTTP listeners (and RDS configs)")
+	// Test this many TCP listeners per snapshot
+	flag.IntVar(&tcpListeners, "tcp", 2, "Number of TCP pass-through listeners")
 }
 
 // main returns code 1 if any of the batches failed to pass all requests

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -41,11 +41,12 @@ import (
 var (
 	debug bool
 
-	port         uint
-	gatewayPort  uint
-	upstreamPort uint
-	basePort     uint
-	alsPort      uint
+	port            uint
+	gatewayPort     uint
+	upstreamPort    uint
+	upstreamMessage string
+	basePort        uint
+	alsPort         uint
 
 	delay    time.Duration
 	requests int
@@ -139,9 +140,6 @@ func init() {
 func main() {
 	flag.Parse()
 	ctx := context.Background()
-
-	// start upstream
-	go test.RunHTTP(ctx, upstreamPort)
 
 	// create a cache
 	signal := make(chan struct{})
@@ -289,7 +287,7 @@ func callEcho() (int, int) {
 				ch <- err
 				return
 			}
-			if string(body) != test.Hello {
+			if string(body) != upstreamMessage {
 				ch <- fmt.Errorf("unexpected return %q", string(body))
 				return
 			}

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -18,13 +18,8 @@ import (
 )
 
 const (
-	// Hello is the echo message
-	Hello = "Hi, there!\n"
-
 	grpcMaxConcurrentStreams = 1000000
 )
-
-type echo struct{}
 
 // HTTPGateway is a custom implementation of [gRPC gateway](https://github.com/grpc-ecosystem/grpc-gateway)
 // specialized to Envoy xDS API.
@@ -124,22 +119,4 @@ func (h *HTTPGateway) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	if _, err = resp.Write(bytes); err != nil && h.Log != nil {
 		h.Log.Errorf("gateway error: %v", err)
 	}
-}
-
-func (h echo) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/text")
-	if _, err := w.Write([]byte(Hello)); err != nil {
-		log.Println(err)
-	}
-}
-
-// RunHTTP opens a simple listener on the port.
-func RunHTTP(ctx context.Context, upstreamPort uint) {
-	log.Printf("upstream listening HTTP/1.1 on %d\n", upstreamPort)
-	server := &http.Server{Addr: fmt.Sprintf(":%d", upstreamPort), Handler: echo{}}
-	go func() {
-		if err := server.ListenAndServe(); err != nil {
-			log.Println(err)
-		}
-	}()
 }


### PR DESCRIPTION
I noticed some comments in issues and PR's about newcomers having trouble figuring out how to use go-control-plane to make their own control planes.  The integration test is a great example, but its primary mission is to be a test, not an example, so it's got a lot of code that gets in the way of understanding how to integrate go-control-plane.

Here are three commits that helped me figure out what's going on:

* better documentation of the many integration test options (especially the ports used since there are a lot of them)
* break the "upstream" HTTP server into its own process, which made it easier for me to build a mental model of what's happening during the tests
* a trivial, minimal example server that newcomers can run easily and copy into their projects.
