### PR TITLE
cache: fix per-response caching and switch to pointers for requests and responses

### DIFF
--- a/build/integration.sh
+++ b/build/integration.sh
@@ -37,8 +37,8 @@ echo Envoy log: ${ENVOY_LOG}
 ENVOY_PID=$!
 
 function cleanup() {
-  kill ${ENVOY_PID}
-  kill ${UPSTREAM_PID}
+  kill ${ENVOY_PID} ${UPSTREAM_PID}
+  wait ${ENVOY_PID} ${UPSTREAM_PID} 2> /dev/null || true
 }
 trap cleanup EXIT
 

--- a/pkg/cache/v2/cache.go
+++ b/pkg/cache/v2/cache.go
@@ -43,7 +43,7 @@ type ConfigWatcher interface {
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.
-	CreateWatch(Request) (value chan Response, cancel func())
+	CreateWatch(*Request) (value chan Response, cancel func())
 }
 
 // Cache is a generic config cache with a watcher.
@@ -51,7 +51,7 @@ type Cache interface {
 	ConfigWatcher
 
 	// Fetch implements the polling method of the config cache using a non-empty request.
-	Fetch(context.Context, Request) (Response, error)
+	Fetch(context.Context, *Request) (Response, error)
 }
 
 // Response is a wrapper around Envoy's DiscoveryResponse.
@@ -70,7 +70,7 @@ type Response interface {
 // be included in the final Discovery Response.
 type RawResponse struct {
 	// Request is the original request.
-	Request discovery.DiscoveryRequest
+	Request *discovery.DiscoveryRequest
 
 	// Version of the resources as tracked by the cache for the given type.
 	// Proxy responds with this version as an acknowledgement.
@@ -78,11 +78,6 @@ type RawResponse struct {
 
 	// Resources to be included in the response.
 	Resources []types.Resource
-
-	// isResourceMarshaled indicates whether the resources have been marshaled.
-	// This is internally maintained by go-control-plane to prevent future
-	// duplication in marshaling efforts.
-	isResourceMarshaled bool
 
 	// marshaledResponse holds the serialized discovery response.
 	marshaledResponse *discovery.DiscoveryResponse
@@ -93,7 +88,7 @@ var _ Response = &RawResponse{}
 // PassthroughResponse is a pre constructed xDS response that need not go through marshalling transformations.
 type PassthroughResponse struct {
 	// Request is the original request.
-	Request discovery.DiscoveryRequest
+	Request *discovery.DiscoveryRequest
 
 	// The discovery response that needs to be sent as is, without any marshalling transformations.
 	DiscoveryResponse *discovery.DiscoveryResponse
@@ -104,55 +99,55 @@ var _ Response = &PassthroughResponse{}
 // GetDiscoveryResponse performs the marshalling the first time its called and uses the cached response subsequently.
 // This is necessary because the marshalled response does not change across the calls.
 // This caching behavior is important in high throughput scenarios because grpc marshalling has a cost and it drives the cpu utilization under load.
-func (r RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
-	if r.isResourceMarshaled {
-		return r.marshaledResponse, nil
+func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
+
+	if r.marshaledResponse == nil {
+
+		marshaledResources := make([]*any.Any, len(r.Resources))
+
+		for i, resource := range r.Resources {
+			marshaledResource, err := MarshalResource(resource)
+			if err != nil {
+				return nil, err
+			}
+			marshaledResources[i] = &any.Any{
+				TypeUrl: r.Request.TypeUrl,
+				Value:   marshaledResource,
+			}
+		}
+
+		r.marshaledResponse = &discovery.DiscoveryResponse{
+			VersionInfo: r.Version,
+			Resources:   marshaledResources,
+			TypeUrl:     r.Request.TypeUrl,
+		}
 	}
 
-	marshaledResources := make([]*any.Any, len(r.Resources))
-
-	for i, resource := range r.Resources {
-		marshaledResource, err := MarshalResource(resource)
-		if err != nil {
-			return nil, err
-		}
-		marshaledResources[i] = &any.Any{
-			TypeUrl: r.Request.TypeUrl,
-			Value:   marshaledResource,
-		}
-	}
-
-	r.isResourceMarshaled = true
-
-	return &discovery.DiscoveryResponse{
-		VersionInfo: r.Version,
-		Resources:   marshaledResources,
-		TypeUrl:     r.Request.TypeUrl,
-	}, nil
+	return r.marshaledResponse, nil
 }
 
 // GetRequest returns the original Discovery Request.
-func (r RawResponse) GetRequest() *discovery.DiscoveryRequest {
-	return &r.Request
+func (r *RawResponse) GetRequest() *discovery.DiscoveryRequest {
+	return r.Request
 }
 
 // GetVersion returns the response version.
-func (r RawResponse) GetVersion() (string, error) {
+func (r *RawResponse) GetVersion() (string, error) {
 	return r.Version, nil
 }
 
 // GetDiscoveryResponse returns the final passthrough Discovery Response.
-func (r PassthroughResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
+func (r *PassthroughResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	return r.DiscoveryResponse, nil
 }
 
 // GetRequest returns the original Discovery Request
-func (r PassthroughResponse) GetRequest() *discovery.DiscoveryRequest {
-	return &r.Request
+func (r *PassthroughResponse) GetRequest() *discovery.DiscoveryRequest {
+	return r.Request
 }
 
 // GetVersion returns the response version.
-func (r PassthroughResponse) GetVersion() (string, error) {
+func (r *PassthroughResponse) GetVersion() (string, error) {
 	if r.DiscoveryResponse != nil {
 		return r.DiscoveryResponse.VersionInfo, nil
 	}

--- a/pkg/cache/v2/cache_test.go
+++ b/pkg/cache/v2/cache_test.go
@@ -20,7 +20,7 @@ const (
 func TestResponseGetDiscoveryResponse(t *testing.T) {
 	routes := []types.Resource{&route.RouteConfiguration{Name: resourceName}}
 	resp := cache.RawResponse{
-		Request:   discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
+		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
 		Resources: routes,
 	}
@@ -29,6 +29,10 @@ func TestResponseGetDiscoveryResponse(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, discoveryResponse.VersionInfo, resp.Version)
 	assert.Equal(t, len(discoveryResponse.Resources), 1)
+
+	cachedResponse, err := resp.GetDiscoveryResponse()
+	assert.Nil(t, err)
+	assert.Same(t, discoveryResponse, cachedResponse)
 
 	r := &route.RouteConfiguration{}
 	err = ptypes.UnmarshalAny(discoveryResponse.Resources[0], r)
@@ -46,7 +50,7 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 		VersionInfo: "v",
 	}
 	resp := cache.PassthroughResponse{
-		Request:           discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
+		Request:           &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		DiscoveryResponse: dr,
 	}
 

--- a/pkg/cache/v2/linear.go
+++ b/pkg/cache/v2/linear.go
@@ -84,8 +84,8 @@ func (cache *LinearCache) respond(value chan Response, staleResources []string) 
 			}
 		}
 	}
-	value <- RawResponse{
-		Request:   Request{TypeUrl: cache.typeURL},
+	value <- &RawResponse{
+		Request:   &Request{TypeUrl: cache.typeURL},
 		Resources: resources,
 		Version:   strconv.FormatUint(cache.version, 10),
 	}
@@ -141,7 +141,7 @@ func (cache *LinearCache) DeleteResource(name string) error {
 	return nil
 }
 
-func (cache *LinearCache) CreateWatch(request Request) (chan Response, func()) {
+func (cache *LinearCache) CreateWatch(request *Request) (chan Response, func()) {
 	value := make(chan Response, 1)
 	if request.TypeUrl != cache.typeURL {
 		close(value)
@@ -207,7 +207,7 @@ func (cache *LinearCache) CreateWatch(request Request) (chan Response, func()) {
 	}
 }
 
-func (cache *LinearCache) Fetch(ctx context.Context, request Request) (Response, error) {
+func (cache *LinearCache) Fetch(ctx context.Context, request *Request) (Response, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/cache/v2/linear_test.go
+++ b/pkg/cache/v2/linear_test.go
@@ -71,9 +71,9 @@ func mustBlock(t *testing.T, w <-chan Response) {
 
 func TestLinearInitialResources(t *testing.T) {
 	c := NewLinearCache(testType, map[string]types.Resource{"a": testResource("a"), "b": testResource("b")})
-	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType})
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType})
 	verifyResponse(t, w, "0", 1)
-	w, _ = c.CreateWatch(Request{TypeUrl: testType})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType})
 	verifyResponse(t, w, "0", 2)
 }
 
@@ -84,7 +84,7 @@ func TestLinearCornerCases(t *testing.T) {
 		t.Error("expected error on nil resource")
 	}
 	// create an incorrect type URL request
-	w, _ := c.CreateWatch(Request{TypeUrl: "test"})
+	w, _ := c.CreateWatch(&Request{TypeUrl: "test"})
 	select {
 	case _, more := <-w:
 		if more {
@@ -99,9 +99,9 @@ func TestLinearBasic(t *testing.T) {
 	c := NewLinearCache(testType, nil)
 
 	// Create watches before a resource is ready
-	w1, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	w1, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w1)
-	w, _ := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w, _ := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 2)
 	checkWatchCount(t, c, "b", 1)
@@ -112,44 +112,44 @@ func TestLinearBasic(t *testing.T) {
 	verifyResponse(t, w, "1", 1)
 
 	// Request again, should get same response
-	w, _ = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	checkWatchCount(t, c, "a", 0)
 	verifyResponse(t, w, "1", 1)
-	w, _ = c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	checkWatchCount(t, c, "a", 0)
 	verifyResponse(t, w, "1", 1)
 
 	// Add another element and update the first, response should be different
 	c.UpdateResource("b", testResource("b"))
 	c.UpdateResource("a", testResource("aa"))
-	w, _ = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "3", 1)
-	w, _ = c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "3", 2)
 }
 
 func TestLinearDeletion(t *testing.T) {
 	c := NewLinearCache(testType, map[string]types.Resource{"a": testResource("a"), "b": testResource("b")})
-	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	c.DeleteResource("a")
 	verifyResponse(t, w, "1", 0)
 	checkWatchCount(t, c, "a", 0)
-	w, _ = c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "1", 1)
 	checkWatchCount(t, c, "b", 0)
 	c.DeleteResource("b")
-	w, _ = c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "1"})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
 	verifyResponse(t, w, "2", 0)
 	checkWatchCount(t, c, "b", 0)
 }
 
 func TestLinearWatchTwo(t *testing.T) {
 	c := NewLinearCache(testType, map[string]types.Resource{"a": testResource("a"), "b": testResource("b")})
-	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"})
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
-	w1, _ := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w1, _ := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w1)
 	c.UpdateResource("a", testResource("aa"))
 	// should only get the modified resource
@@ -162,24 +162,24 @@ func TestLinearCancel(t *testing.T) {
 	c.UpdateResource("a", testResource("a"))
 
 	// cancel watch-all
-	w, cancel := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "1"})
+	w, cancel := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	cancel()
 	checkWatchCount(t, c, "a", 0)
 
 	// cancel watch for "a"
-	w, cancel = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
+	w, cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	cancel()
 	checkWatchCount(t, c, "a", 0)
 
 	// open four watches for "a" and "b" and two for all, cancel one of each, make sure the second one is unaffected
-	w, cancel = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
-	w2, cancel2 := c.CreateWatch(Request{ResourceNames: []string{"b"}, TypeUrl: testType, VersionInfo: "1"})
-	w3, cancel3 := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "1"})
-	w4, cancel4 := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "1"})
+	w, cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
+	w2, cancel2 := c.CreateWatch(&Request{ResourceNames: []string{"b"}, TypeUrl: testType, VersionInfo: "1"})
+	w3, cancel3 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
+	w4, cancel4 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
 	mustBlock(t, w)
 	mustBlock(t, w2)
 	mustBlock(t, w3)
@@ -212,7 +212,7 @@ func TestLinearConcurrentSetWatch(t *testing.T) {
 				} else {
 					id2 := fmt.Sprintf("%d", i-1)
 					t.Logf("request resources %q and %q", id, id2)
-					value, _ := c.CreateWatch(Request{
+					value, _ := c.CreateWatch(&Request{
 						// Only expect one to become stale
 						ResourceNames: []string{id, id2},
 						VersionInfo:   "0",

--- a/pkg/cache/v2/mux.go
+++ b/pkg/cache/v2/mux.go
@@ -34,8 +34,8 @@ type MuxCache struct {
 
 var _ Cache = &MuxCache{}
 
-func (mux *MuxCache) CreateWatch(request Request) (chan Response, func()) {
-	key := mux.Classify(request)
+func (mux *MuxCache) CreateWatch(request *Request) (chan Response, func()) {
+	key := mux.Classify(*request)
 	cache, exists := mux.Caches[key]
 	if !exists {
 		value := make(chan Response, 0)
@@ -45,6 +45,6 @@ func (mux *MuxCache) CreateWatch(request Request) (chan Response, func()) {
 	return cache.CreateWatch(request)
 }
 
-func (mux *MuxCache) Fetch(ctx context.Context, request Request) (Response, error) {
+func (mux *MuxCache) Fetch(ctx context.Context, request *Request) (Response, error) {
 	return nil, errors.New("not implemented")
 }

--- a/pkg/cache/v2/simple.go
+++ b/pkg/cache/v2/simple.go
@@ -172,7 +172,7 @@ func superset(names map[string]bool, resources map[string]types.Resource) error 
 }
 
 // CreateWatch returns a watch for an xDS request.
-func (cache *snapshotCache) CreateWatch(request Request) (chan Response, func()) {
+func (cache *snapshotCache) CreateWatch(request *Request) (chan Response, func()) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.Lock()
@@ -234,7 +234,7 @@ func (cache *snapshotCache) cancelWatch(nodeID string, watchID int64) func() {
 
 // Respond to a watch with the snapshot value. The value channel should have capacity not to block.
 // TODO(kuat) do not respond always, see issue https://github.com/envoyproxy/go-control-plane/issues/46
-func (cache *snapshotCache) respond(request Request, value chan Response, resources map[string]types.Resource, version string) {
+func (cache *snapshotCache) respond(request *Request, value chan Response, resources map[string]types.Resource, version string) {
 	// for ADS, the request names must match the snapshot names
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.ResourceNames) != 0 && cache.ads {
@@ -253,7 +253,7 @@ func (cache *snapshotCache) respond(request Request, value chan Response, resour
 	value <- createResponse(request, resources, version)
 }
 
-func createResponse(request Request, resources map[string]types.Resource, version string) Response {
+func createResponse(request *Request, resources map[string]types.Resource, version string) Response {
 	filtered := make([]types.Resource, 0, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
@@ -272,7 +272,7 @@ func createResponse(request Request, resources map[string]types.Resource, versio
 		}
 	}
 
-	return RawResponse{
+	return &RawResponse{
 		Request:   request,
 		Version:   version,
 		Resources: filtered,
@@ -281,7 +281,7 @@ func createResponse(request Request, resources map[string]types.Resource, versio
 
 // Fetch implements the cache fetch function.
 // Fetch is called on multiple streams, so responding to individual names with the same version works.
-func (cache *snapshotCache) Fetch(ctx context.Context, request Request) (Response, error) {
+func (cache *snapshotCache) Fetch(ctx context.Context, request *Request) (Response, error) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.RLock()

--- a/pkg/cache/v2/simple_test.go
+++ b/pkg/cache/v2/simple_test.go
@@ -101,7 +101,7 @@ func TestSnapshotCache(t *testing.T) {
 
 	// try to get endpoints with incorrect list of names
 	// should not receive response
-	value, _ := c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{"none"}})
+	value, _ := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{"none"}})
 	select {
 	case out := <-value:
 		t.Errorf("watch for endpoints and mismatched names => got %v, want none", out)
@@ -110,14 +110,14 @@ func TestSnapshotCache(t *testing.T) {
 
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
-			value, _ := c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
+			value, _ := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 			select {
 			case out := <-value:
 				if gotVersion, _ := out.GetVersion(); gotVersion != version {
 					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot.GetResources(typ)) {
-					t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot.GetResources(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResources(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResources(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -134,7 +134,7 @@ func TestSnapshotCacheFetch(t *testing.T) {
 
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
-			resp, err := c.Fetch(context.Background(), discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
+			resp, err := c.Fetch(context.Background(), &discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 			if err != nil || resp == nil {
 				t.Fatal("unexpected error or null response")
 			}
@@ -146,13 +146,13 @@ func TestSnapshotCacheFetch(t *testing.T) {
 
 	// no response for missing snapshot
 	if resp, err := c.Fetch(context.Background(),
-		discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, Node: &core.Node{Id: "oof"}}); resp != nil || err == nil {
+		&discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, Node: &core.Node{Id: "oof"}}); resp != nil || err == nil {
 		t.Errorf("missing snapshot: response is not nil %v", resp)
 	}
 
 	// no response for latest version
 	if resp, err := c.Fetch(context.Background(),
-		discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, VersionInfo: version}); resp != nil || err == nil {
+		&discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, VersionInfo: version}); resp != nil || err == nil {
 		t.Errorf("latest version: response is not nil %v", resp)
 	}
 }
@@ -161,7 +161,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
 	watches := make(map[string]chan cache.Response)
 	for _, typ := range testTypes {
-		watches[typ], _ = c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
+		watches[typ], _ = c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 	}
 	if err := c.SetSnapshot(key, snapshot); err != nil {
 		t.Fatal(err)
@@ -173,8 +173,8 @@ func TestSnapshotCacheWatch(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != version {
 					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot.GetResources(typ)) {
-					t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot.GetResources(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResources(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResources(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -184,7 +184,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 
 	// open new watches with the latest version
 	for _, typ := range testTypes {
-		watches[typ], _ = c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: version})
+		watches[typ], _ = c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: version})
 	}
 	if count := c.GetStatusInfo(key).GetNumWatches(); count != len(testTypes) {
 		t.Errorf("watches should be created for the latest version: %d", count)
@@ -206,8 +206,8 @@ func TestSnapshotCacheWatch(t *testing.T) {
 		if gotVersion, _ := out.GetVersion(); gotVersion != version2 {
 			t.Errorf("got version %q, want %q", gotVersion, version2)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
-			t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
+		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
+			t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")
@@ -230,7 +230,7 @@ func TestConcurrentSetWatch(t *testing.T) {
 					if cancel != nil {
 						cancel()
 					}
-					_, cancel = c.CreateWatch(discovery.DiscoveryRequest{
+					_, cancel = c.CreateWatch(&discovery.DiscoveryRequest{
 						Node:    &core.Node{Id: id},
 						TypeUrl: rsrc.EndpointType,
 					})
@@ -243,7 +243,7 @@ func TestConcurrentSetWatch(t *testing.T) {
 func TestSnapshotCacheWatchCancel(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
 	for _, typ := range testTypes {
-		_, cancel := c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
+		_, cancel := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 		cancel()
 	}
 	// should be status info for the node

--- a/pkg/cache/v2/status.go
+++ b/pkg/cache/v2/status.go
@@ -71,7 +71,7 @@ type statusInfo struct {
 // ResponseWatch is a watch record keeping both the request and an open channel for the response.
 type ResponseWatch struct {
 	// Request is the original request for the watch.
-	Request Request
+	Request *Request
 
 	// Response is the channel to push responses to.
 	Response chan Response

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -44,7 +44,7 @@ type ConfigWatcher interface {
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.
-	CreateWatch(Request) (value chan Response, cancel func())
+	CreateWatch(*Request) (value chan Response, cancel func())
 }
 
 // Cache is a generic config cache with a watcher.
@@ -52,7 +52,7 @@ type Cache interface {
 	ConfigWatcher
 
 	// Fetch implements the polling method of the config cache using a non-empty request.
-	Fetch(context.Context, Request) (Response, error)
+	Fetch(context.Context, *Request) (Response, error)
 }
 
 // Response is a wrapper around Envoy's DiscoveryResponse.
@@ -71,7 +71,7 @@ type Response interface {
 // be included in the final Discovery Response.
 type RawResponse struct {
 	// Request is the original request.
-	Request discovery.DiscoveryRequest
+	Request *discovery.DiscoveryRequest
 
 	// Version of the resources as tracked by the cache for the given type.
 	// Proxy responds with this version as an acknowledgement.
@@ -79,11 +79,6 @@ type RawResponse struct {
 
 	// Resources to be included in the response.
 	Resources []types.Resource
-
-	// isResourceMarshaled indicates whether the resources have been marshaled.
-	// This is internally maintained by go-control-plane to prevent future
-	// duplication in marshaling efforts.
-	isResourceMarshaled bool
 
 	// marshaledResponse holds the serialized discovery response.
 	marshaledResponse *discovery.DiscoveryResponse
@@ -94,7 +89,7 @@ var _ Response = &RawResponse{}
 // PassthroughResponse is a pre constructed xDS response that need not go through marshalling transformations.
 type PassthroughResponse struct {
 	// Request is the original request.
-	Request discovery.DiscoveryRequest
+	Request *discovery.DiscoveryRequest
 
 	// The discovery response that needs to be sent as is, without any marshalling transformations.
 	DiscoveryResponse *discovery.DiscoveryResponse
@@ -105,55 +100,55 @@ var _ Response = &PassthroughResponse{}
 // GetDiscoveryResponse performs the marshalling the first time its called and uses the cached response subsequently.
 // This is necessary because the marshalled response does not change across the calls.
 // This caching behavior is important in high throughput scenarios because grpc marshalling has a cost and it drives the cpu utilization under load.
-func (r RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
-	if r.isResourceMarshaled {
-		return r.marshaledResponse, nil
+func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
+
+	if r.marshaledResponse == nil {
+
+		marshaledResources := make([]*any.Any, len(r.Resources))
+
+		for i, resource := range r.Resources {
+			marshaledResource, err := MarshalResource(resource)
+			if err != nil {
+				return nil, err
+			}
+			marshaledResources[i] = &any.Any{
+				TypeUrl: r.Request.TypeUrl,
+				Value:   marshaledResource,
+			}
+		}
+
+		r.marshaledResponse = &discovery.DiscoveryResponse{
+			VersionInfo: r.Version,
+			Resources:   marshaledResources,
+			TypeUrl:     r.Request.TypeUrl,
+		}
 	}
 
-	marshaledResources := make([]*any.Any, len(r.Resources))
-
-	for i, resource := range r.Resources {
-		marshaledResource, err := MarshalResource(resource)
-		if err != nil {
-			return nil, err
-		}
-		marshaledResources[i] = &any.Any{
-			TypeUrl: r.Request.TypeUrl,
-			Value:   marshaledResource,
-		}
-	}
-
-	r.isResourceMarshaled = true
-
-	return &discovery.DiscoveryResponse{
-		VersionInfo: r.Version,
-		Resources:   marshaledResources,
-		TypeUrl:     r.Request.TypeUrl,
-	}, nil
+	return r.marshaledResponse, nil
 }
 
 // GetRequest returns the original Discovery Request.
-func (r RawResponse) GetRequest() *discovery.DiscoveryRequest {
-	return &r.Request
+func (r *RawResponse) GetRequest() *discovery.DiscoveryRequest {
+	return r.Request
 }
 
 // GetVersion returns the response version.
-func (r RawResponse) GetVersion() (string, error) {
+func (r *RawResponse) GetVersion() (string, error) {
 	return r.Version, nil
 }
 
 // GetDiscoveryResponse returns the final passthrough Discovery Response.
-func (r PassthroughResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
+func (r *PassthroughResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	return r.DiscoveryResponse, nil
 }
 
 // GetRequest returns the original Discovery Request
-func (r PassthroughResponse) GetRequest() *discovery.DiscoveryRequest {
-	return &r.Request
+func (r *PassthroughResponse) GetRequest() *discovery.DiscoveryRequest {
+	return r.Request
 }
 
 // GetVersion returns the response version.
-func (r PassthroughResponse) GetVersion() (string, error) {
+func (r *PassthroughResponse) GetVersion() (string, error) {
 	if r.DiscoveryResponse != nil {
 		return r.DiscoveryResponse.VersionInfo, nil
 	}

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -80,8 +81,8 @@ type RawResponse struct {
 	// Resources to be included in the response.
 	Resources []types.Resource
 
-	// marshaledResponse holds the serialized discovery response.
-	marshaledResponse *discovery.DiscoveryResponse
+	// marshaledResponse holds an atomic reference to the serialized discovery response.
+	marshaledResponse atomic.Value
 }
 
 var _ Response = &RawResponse{}
@@ -102,7 +103,9 @@ var _ Response = &PassthroughResponse{}
 // This caching behavior is important in high throughput scenarios because grpc marshalling has a cost and it drives the cpu utilization under load.
 func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 
-	if r.marshaledResponse == nil {
+	marshaledResponse := r.marshaledResponse.Load()
+
+	if marshaledResponse == nil {
 
 		marshaledResources := make([]*any.Any, len(r.Resources))
 
@@ -117,14 +120,16 @@ func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, erro
 			}
 		}
 
-		r.marshaledResponse = &discovery.DiscoveryResponse{
+		marshaledResponse = &discovery.DiscoveryResponse{
 			VersionInfo: r.Version,
 			Resources:   marshaledResources,
 			TypeUrl:     r.Request.TypeUrl,
 		}
+
+		r.marshaledResponse.Store(marshaledResponse)
 	}
 
-	return r.marshaledResponse, nil
+	return marshaledResponse.(*discovery.DiscoveryResponse), nil
 }
 
 // GetRequest returns the original Discovery Request.

--- a/pkg/cache/v3/cache_test.go
+++ b/pkg/cache/v3/cache_test.go
@@ -21,7 +21,7 @@ const (
 func TestResponseGetDiscoveryResponse(t *testing.T) {
 	routes := []types.Resource{&route.RouteConfiguration{Name: resourceName}}
 	resp := cache.RawResponse{
-		Request:   discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
+		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
 		Resources: routes,
 	}
@@ -30,6 +30,10 @@ func TestResponseGetDiscoveryResponse(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, discoveryResponse.VersionInfo, resp.Version)
 	assert.Equal(t, len(discoveryResponse.Resources), 1)
+
+	cachedResponse, err := resp.GetDiscoveryResponse()
+	assert.Nil(t, err)
+	assert.Same(t, discoveryResponse, cachedResponse)
 
 	r := &route.RouteConfiguration{}
 	err = ptypes.UnmarshalAny(discoveryResponse.Resources[0], r)
@@ -47,7 +51,7 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 		VersionInfo: "v",
 	}
 	resp := cache.PassthroughResponse{
-		Request:           discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
+		Request:           &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		DiscoveryResponse: dr,
 	}
 

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -85,8 +85,8 @@ func (cache *LinearCache) respond(value chan Response, staleResources []string) 
 			}
 		}
 	}
-	value <- RawResponse{
-		Request:   Request{TypeUrl: cache.typeURL},
+	value <- &RawResponse{
+		Request:   &Request{TypeUrl: cache.typeURL},
 		Resources: resources,
 		Version:   strconv.FormatUint(cache.version, 10),
 	}
@@ -142,7 +142,7 @@ func (cache *LinearCache) DeleteResource(name string) error {
 	return nil
 }
 
-func (cache *LinearCache) CreateWatch(request Request) (chan Response, func()) {
+func (cache *LinearCache) CreateWatch(request *Request) (chan Response, func()) {
 	value := make(chan Response, 1)
 	if request.TypeUrl != cache.typeURL {
 		close(value)
@@ -208,7 +208,7 @@ func (cache *LinearCache) CreateWatch(request Request) (chan Response, func()) {
 	}
 }
 
-func (cache *LinearCache) Fetch(ctx context.Context, request Request) (Response, error) {
+func (cache *LinearCache) Fetch(ctx context.Context, request *Request) (Response, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -72,9 +72,9 @@ func mustBlock(t *testing.T, w <-chan Response) {
 
 func TestLinearInitialResources(t *testing.T) {
 	c := NewLinearCache(testType, map[string]types.Resource{"a": testResource("a"), "b": testResource("b")})
-	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType})
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType})
 	verifyResponse(t, w, "0", 1)
-	w, _ = c.CreateWatch(Request{TypeUrl: testType})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType})
 	verifyResponse(t, w, "0", 2)
 }
 
@@ -85,7 +85,7 @@ func TestLinearCornerCases(t *testing.T) {
 		t.Error("expected error on nil resource")
 	}
 	// create an incorrect type URL request
-	w, _ := c.CreateWatch(Request{TypeUrl: "test"})
+	w, _ := c.CreateWatch(&Request{TypeUrl: "test"})
 	select {
 	case _, more := <-w:
 		if more {
@@ -100,9 +100,9 @@ func TestLinearBasic(t *testing.T) {
 	c := NewLinearCache(testType, nil)
 
 	// Create watches before a resource is ready
-	w1, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	w1, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w1)
-	w, _ := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w, _ := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 2)
 	checkWatchCount(t, c, "b", 1)
@@ -113,44 +113,44 @@ func TestLinearBasic(t *testing.T) {
 	verifyResponse(t, w, "1", 1)
 
 	// Request again, should get same response
-	w, _ = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	checkWatchCount(t, c, "a", 0)
 	verifyResponse(t, w, "1", 1)
-	w, _ = c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	checkWatchCount(t, c, "a", 0)
 	verifyResponse(t, w, "1", 1)
 
 	// Add another element and update the first, response should be different
 	c.UpdateResource("b", testResource("b"))
 	c.UpdateResource("a", testResource("aa"))
-	w, _ = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "3", 1)
-	w, _ = c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "3", 2)
 }
 
 func TestLinearDeletion(t *testing.T) {
 	c := NewLinearCache(testType, map[string]types.Resource{"a": testResource("a"), "b": testResource("b")})
-	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	c.DeleteResource("a")
 	verifyResponse(t, w, "1", 0)
 	checkWatchCount(t, c, "a", 0)
-	w, _ = c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "1", 1)
 	checkWatchCount(t, c, "b", 0)
 	c.DeleteResource("b")
-	w, _ = c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "1"})
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
 	verifyResponse(t, w, "2", 0)
 	checkWatchCount(t, c, "b", 0)
 }
 
 func TestLinearWatchTwo(t *testing.T) {
 	c := NewLinearCache(testType, map[string]types.Resource{"a": testResource("a"), "b": testResource("b")})
-	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"})
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
-	w1, _ := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
+	w1, _ := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w1)
 	c.UpdateResource("a", testResource("aa"))
 	// should only get the modified resource
@@ -163,24 +163,24 @@ func TestLinearCancel(t *testing.T) {
 	c.UpdateResource("a", testResource("a"))
 
 	// cancel watch-all
-	w, cancel := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "1"})
+	w, cancel := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	cancel()
 	checkWatchCount(t, c, "a", 0)
 
 	// cancel watch for "a"
-	w, cancel = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
+	w, cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	cancel()
 	checkWatchCount(t, c, "a", 0)
 
 	// open four watches for "a" and "b" and two for all, cancel one of each, make sure the second one is unaffected
-	w, cancel = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
-	w2, cancel2 := c.CreateWatch(Request{ResourceNames: []string{"b"}, TypeUrl: testType, VersionInfo: "1"})
-	w3, cancel3 := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "1"})
-	w4, cancel4 := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "1"})
+	w, cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
+	w2, cancel2 := c.CreateWatch(&Request{ResourceNames: []string{"b"}, TypeUrl: testType, VersionInfo: "1"})
+	w3, cancel3 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
+	w4, cancel4 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
 	mustBlock(t, w)
 	mustBlock(t, w2)
 	mustBlock(t, w3)
@@ -213,7 +213,7 @@ func TestLinearConcurrentSetWatch(t *testing.T) {
 				} else {
 					id2 := fmt.Sprintf("%d", i-1)
 					t.Logf("request resources %q and %q", id, id2)
-					value, _ := c.CreateWatch(Request{
+					value, _ := c.CreateWatch(&Request{
 						// Only expect one to become stale
 						ResourceNames: []string{id, id2},
 						VersionInfo:   "0",

--- a/pkg/cache/v3/mux.go
+++ b/pkg/cache/v3/mux.go
@@ -35,8 +35,8 @@ type MuxCache struct {
 
 var _ Cache = &MuxCache{}
 
-func (mux *MuxCache) CreateWatch(request Request) (chan Response, func()) {
-	key := mux.Classify(request)
+func (mux *MuxCache) CreateWatch(request *Request) (chan Response, func()) {
+	key := mux.Classify(*request)
 	cache, exists := mux.Caches[key]
 	if !exists {
 		value := make(chan Response, 0)
@@ -46,6 +46,6 @@ func (mux *MuxCache) CreateWatch(request Request) (chan Response, func()) {
 	return cache.CreateWatch(request)
 }
 
-func (mux *MuxCache) Fetch(ctx context.Context, request Request) (Response, error) {
+func (mux *MuxCache) Fetch(ctx context.Context, request *Request) (Response, error) {
 	return nil, errors.New("not implemented")
 }

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -173,7 +173,7 @@ func superset(names map[string]bool, resources map[string]types.Resource) error 
 }
 
 // CreateWatch returns a watch for an xDS request.
-func (cache *snapshotCache) CreateWatch(request Request) (chan Response, func()) {
+func (cache *snapshotCache) CreateWatch(request *Request) (chan Response, func()) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.Lock()
@@ -235,7 +235,7 @@ func (cache *snapshotCache) cancelWatch(nodeID string, watchID int64) func() {
 
 // Respond to a watch with the snapshot value. The value channel should have capacity not to block.
 // TODO(kuat) do not respond always, see issue https://github.com/envoyproxy/go-control-plane/issues/46
-func (cache *snapshotCache) respond(request Request, value chan Response, resources map[string]types.Resource, version string) {
+func (cache *snapshotCache) respond(request *Request, value chan Response, resources map[string]types.Resource, version string) {
 	// for ADS, the request names must match the snapshot names
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.ResourceNames) != 0 && cache.ads {
@@ -254,7 +254,7 @@ func (cache *snapshotCache) respond(request Request, value chan Response, resour
 	value <- createResponse(request, resources, version)
 }
 
-func createResponse(request Request, resources map[string]types.Resource, version string) Response {
+func createResponse(request *Request, resources map[string]types.Resource, version string) Response {
 	filtered := make([]types.Resource, 0, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
@@ -273,7 +273,7 @@ func createResponse(request Request, resources map[string]types.Resource, versio
 		}
 	}
 
-	return RawResponse{
+	return &RawResponse{
 		Request:   request,
 		Version:   version,
 		Resources: filtered,
@@ -282,7 +282,7 @@ func createResponse(request Request, resources map[string]types.Resource, versio
 
 // Fetch implements the cache fetch function.
 // Fetch is called on multiple streams, so responding to individual names with the same version works.
-func (cache *snapshotCache) Fetch(ctx context.Context, request Request) (Response, error) {
+func (cache *snapshotCache) Fetch(ctx context.Context, request *Request) (Response, error) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.RLock()

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -102,7 +102,7 @@ func TestSnapshotCache(t *testing.T) {
 
 	// try to get endpoints with incorrect list of names
 	// should not receive response
-	value, _ := c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{"none"}})
+	value, _ := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{"none"}})
 	select {
 	case out := <-value:
 		t.Errorf("watch for endpoints and mismatched names => got %v, want none", out)
@@ -111,14 +111,14 @@ func TestSnapshotCache(t *testing.T) {
 
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
-			value, _ := c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
+			value, _ := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 			select {
 			case out := <-value:
 				if gotVersion, _ := out.GetVersion(); gotVersion != version {
 					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot.GetResources(typ)) {
-					t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot.GetResources(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResources(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResources(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -135,7 +135,7 @@ func TestSnapshotCacheFetch(t *testing.T) {
 
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
-			resp, err := c.Fetch(context.Background(), discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
+			resp, err := c.Fetch(context.Background(), &discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 			if err != nil || resp == nil {
 				t.Fatal("unexpected error or null response")
 			}
@@ -147,13 +147,13 @@ func TestSnapshotCacheFetch(t *testing.T) {
 
 	// no response for missing snapshot
 	if resp, err := c.Fetch(context.Background(),
-		discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, Node: &core.Node{Id: "oof"}}); resp != nil || err == nil {
+		&discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, Node: &core.Node{Id: "oof"}}); resp != nil || err == nil {
 		t.Errorf("missing snapshot: response is not nil %v", resp)
 	}
 
 	// no response for latest version
 	if resp, err := c.Fetch(context.Background(),
-		discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, VersionInfo: version}); resp != nil || err == nil {
+		&discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, VersionInfo: version}); resp != nil || err == nil {
 		t.Errorf("latest version: response is not nil %v", resp)
 	}
 }
@@ -162,7 +162,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
 	watches := make(map[string]chan cache.Response)
 	for _, typ := range testTypes {
-		watches[typ], _ = c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
+		watches[typ], _ = c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 	}
 	if err := c.SetSnapshot(key, snapshot); err != nil {
 		t.Fatal(err)
@@ -174,8 +174,8 @@ func TestSnapshotCacheWatch(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != version {
 					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot.GetResources(typ)) {
-					t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot.GetResources(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResources(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResources(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -185,7 +185,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 
 	// open new watches with the latest version
 	for _, typ := range testTypes {
-		watches[typ], _ = c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: version})
+		watches[typ], _ = c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: version})
 	}
 	if count := c.GetStatusInfo(key).GetNumWatches(); count != len(testTypes) {
 		t.Errorf("watches should be created for the latest version: %d", count)
@@ -207,8 +207,8 @@ func TestSnapshotCacheWatch(t *testing.T) {
 		if gotVersion, _ := out.GetVersion(); gotVersion != version2 {
 			t.Errorf("got version %q, want %q", gotVersion, version2)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
-			t.Errorf("get resources %v, want %v", out.(cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
+		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
+			t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")
@@ -231,7 +231,7 @@ func TestConcurrentSetWatch(t *testing.T) {
 					if cancel != nil {
 						cancel()
 					}
-					_, cancel = c.CreateWatch(discovery.DiscoveryRequest{
+					_, cancel = c.CreateWatch(&discovery.DiscoveryRequest{
 						Node:    &core.Node{Id: id},
 						TypeUrl: rsrc.EndpointType,
 					})
@@ -244,7 +244,7 @@ func TestConcurrentSetWatch(t *testing.T) {
 func TestSnapshotCacheWatchCancel(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
 	for _, typ := range testTypes {
-		_, cancel := c.CreateWatch(discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
+		_, cancel := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 		cancel()
 	}
 	// should be status info for the node

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -72,7 +72,7 @@ type statusInfo struct {
 // ResponseWatch is a watch record keeping both the request and an open channel for the response.
 type ResponseWatch struct {
 	// Request is the original request for the watch.
-	Request Request
+	Request *Request
 
 	// Response is the channel to push responses to.
 	Response chan Response

--- a/pkg/server/v2/gateway_test.go
+++ b/pkg/server/v2/gateway_test.go
@@ -41,22 +41,28 @@ func (log logger) Errorf(format string, args ...interface{}) { log.t.Logf(format
 
 func TestGateway(t *testing.T) {
 	config := makeMockConfigWatcher()
-	config.responses = map[string][]cache.RawResponse{
-		resource.ClusterType: {{
-			Version:   "2",
-			Resources: []types.Resource{cluster},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
-		}},
-		resource.RouteType: {{
-			Version:   "3",
-			Resources: []types.Resource{route},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
-		}},
-		resource.ListenerType: {{
-			Version:   "4",
-			Resources: []types.Resource{listener},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
-		}},
+	config.responses = map[string][]cache.Response{
+		resource.ClusterType: {
+			&cache.RawResponse{
+				Version:   "2",
+				Resources: []types.Resource{cluster},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
+			},
+		},
+		resource.RouteType: {
+			&cache.RawResponse{
+				Version:   "3",
+				Resources: []types.Resource{route},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
+			},
+		},
+		resource.ListenerType: {
+			&cache.RawResponse{
+				Version:   "4",
+				Resources: []types.Resource{listener},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
+			},
+		},
 	}
 	gtw := server.HTTPGateway{Log: logger{t: t}, Server: server.NewServer(context.Background(), config, nil)}
 

--- a/pkg/server/v2/server.go
+++ b/pkg/server/v2/server.go
@@ -395,42 +395,42 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 					if values.endpointCancel != nil {
 						values.endpointCancel()
 					}
-					values.endpoints, values.endpointCancel = s.cache.CreateWatch(*req)
+					values.endpoints, values.endpointCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.ClusterType:
 				if values.clusterNonce == "" || values.clusterNonce == nonce {
 					if values.clusterCancel != nil {
 						values.clusterCancel()
 					}
-					values.clusters, values.clusterCancel = s.cache.CreateWatch(*req)
+					values.clusters, values.clusterCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.RouteType:
 				if values.routeNonce == "" || values.routeNonce == nonce {
 					if values.routeCancel != nil {
 						values.routeCancel()
 					}
-					values.routes, values.routeCancel = s.cache.CreateWatch(*req)
+					values.routes, values.routeCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.ListenerType:
 				if values.listenerNonce == "" || values.listenerNonce == nonce {
 					if values.listenerCancel != nil {
 						values.listenerCancel()
 					}
-					values.listeners, values.listenerCancel = s.cache.CreateWatch(*req)
+					values.listeners, values.listenerCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.SecretType:
 				if values.secretNonce == "" || values.secretNonce == nonce {
 					if values.secretCancel != nil {
 						values.secretCancel()
 					}
-					values.secrets, values.secretCancel = s.cache.CreateWatch(*req)
+					values.secrets, values.secretCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.RuntimeType:
 				if values.runtimeNonce == "" || values.runtimeNonce == nonce {
 					if values.runtimeCancel != nil {
 						values.runtimeCancel()
 					}
-					values.runtimes, values.runtimeCancel = s.cache.CreateWatch(*req)
+					values.runtimes, values.runtimeCancel = s.cache.CreateWatch(req)
 				}
 			default:
 				responseNonce, seen := values.nonces[req.TypeUrl]
@@ -439,7 +439,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 						cancel()
 					}
 					var watch chan cache.Response
-					watch, values.cancellations[req.TypeUrl] = s.cache.CreateWatch(*req)
+					watch, values.cancellations[req.TypeUrl] = s.cache.CreateWatch(req)
 					// Muxing watches across multiple type URLs onto a single channel requires spawning
 					// a go-routine. Golang does not allow selecting over a dynamic set of channels.
 					go func() {
@@ -524,7 +524,7 @@ func (s *server) Fetch(ctx context.Context, req *discovery.DiscoveryRequest) (*d
 			return nil, err
 		}
 	}
-	resp, err := s.cache.Fetch(ctx, *req)
+	resp, err := s.cache.Fetch(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/v2/server_test.go
+++ b/pkg/server/v2/server_test.go
@@ -35,11 +35,11 @@ import (
 
 type mockConfigWatcher struct {
 	counts     map[string]int
-	responses  map[string][]cache.RawResponse
+	responses  map[string][]cache.Response
 	closeWatch bool
 }
 
-func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (chan cache.Response, func()) {
+func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest) (chan cache.Response, func()) {
 	config.counts[req.TypeUrl] = config.counts[req.TypeUrl] + 1
 	out := make(chan cache.Response, 1)
 	if len(config.responses[req.TypeUrl]) > 0 {
@@ -51,11 +51,11 @@ func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (ch
 	return out, func() {}
 }
 
-func (config *mockConfigWatcher) Fetch(ctx context.Context, req discovery.DiscoveryRequest) (cache.Response, error) {
+func (config *mockConfigWatcher) Fetch(ctx context.Context, req *discovery.DiscoveryRequest) (cache.Response, error) {
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out := config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
-		return &out, nil
+		return out, nil
 	}
 	return nil, errors.New("missing")
 }
@@ -159,44 +159,58 @@ var (
 	}
 )
 
-func makeResponses() map[string][]cache.RawResponse {
-	return map[string][]cache.RawResponse{
-		rsrc.EndpointType: {{
-			Version:   "1",
-			Resources: []types.Resource{endpoint},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
-		}},
-		rsrc.ClusterType: {{
-			Version:   "2",
-			Resources: []types.Resource{cluster},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
-		}},
-		rsrc.RouteType: {{
-			Version:   "3",
-			Resources: []types.Resource{route},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
-		}},
-		rsrc.ListenerType: {{
-			Version:   "4",
-			Resources: []types.Resource{listener},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
-		}},
-		rsrc.SecretType: {{
-			Version:   "5",
-			Resources: []types.Resource{secret},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
-		}},
-		rsrc.RuntimeType: {{
-			Version:   "6",
-			Resources: []types.Resource{runtime},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
-		}},
+func makeResponses() map[string][]cache.Response {
+	return map[string][]cache.Response{
+		rsrc.EndpointType: {
+			&cache.RawResponse{
+				Version:   "1",
+				Resources: []types.Resource{endpoint},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
+			},
+		},
+		rsrc.ClusterType: {
+			&cache.RawResponse{
+				Version:   "2",
+				Resources: []types.Resource{cluster},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
+			},
+		},
+		rsrc.RouteType: {
+			&cache.RawResponse{
+				Version:   "3",
+				Resources: []types.Resource{route},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
+			},
+		},
+		rsrc.ListenerType: {
+			&cache.RawResponse{
+				Version:   "4",
+				Resources: []types.Resource{listener},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
+			},
+		},
+		rsrc.SecretType: {
+			&cache.RawResponse{
+				Version:   "5",
+				Resources: []types.Resource{secret},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
+			},
+		},
+		rsrc.RuntimeType: {
+			&cache.RawResponse{
+				Version:   "6",
+				Resources: []types.Resource{runtime},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
+			},
+		},
 		// Pass-through type (xDS does not exist for this type)
-		opaqueType: {{
-			Version:   "7",
-			Resources: []types.Resource{opaque},
-			Request:   discovery.DiscoveryRequest{TypeUrl: opaqueType},
-		}},
+		opaqueType: {
+			&cache.RawResponse{
+				Version:   "7",
+				Resources: []types.Resource{opaque},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: opaqueType},
+			},
+		},
 	}
 }
 

--- a/pkg/server/v3/gateway_test.go
+++ b/pkg/server/v3/gateway_test.go
@@ -42,22 +42,28 @@ func (log logger) Errorf(format string, args ...interface{}) { log.t.Logf(format
 
 func TestGateway(t *testing.T) {
 	config := makeMockConfigWatcher()
-	config.responses = map[string][]cache.RawResponse{
-		resource.ClusterType: {{
-			Version:   "2",
-			Resources: []types.Resource{cluster},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
-		}},
-		resource.RouteType: {{
-			Version:   "3",
-			Resources: []types.Resource{route},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
-		}},
-		resource.ListenerType: {{
-			Version:   "4",
-			Resources: []types.Resource{listener},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
-		}},
+	config.responses = map[string][]cache.Response{
+		resource.ClusterType: {
+			&cache.RawResponse{
+				Version:   "2",
+				Resources: []types.Resource{cluster},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
+			},
+		},
+		resource.RouteType: {
+			&cache.RawResponse{
+				Version:   "3",
+				Resources: []types.Resource{route},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
+			},
+		},
+		resource.ListenerType: {
+			&cache.RawResponse{
+				Version:   "4",
+				Resources: []types.Resource{listener},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
+			},
+		},
 	}
 	gtw := server.HTTPGateway{Log: logger{t: t}, Server: server.NewServer(context.Background(), config, nil)}
 

--- a/pkg/server/v3/server.go
+++ b/pkg/server/v3/server.go
@@ -396,42 +396,42 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 					if values.endpointCancel != nil {
 						values.endpointCancel()
 					}
-					values.endpoints, values.endpointCancel = s.cache.CreateWatch(*req)
+					values.endpoints, values.endpointCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.ClusterType:
 				if values.clusterNonce == "" || values.clusterNonce == nonce {
 					if values.clusterCancel != nil {
 						values.clusterCancel()
 					}
-					values.clusters, values.clusterCancel = s.cache.CreateWatch(*req)
+					values.clusters, values.clusterCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.RouteType:
 				if values.routeNonce == "" || values.routeNonce == nonce {
 					if values.routeCancel != nil {
 						values.routeCancel()
 					}
-					values.routes, values.routeCancel = s.cache.CreateWatch(*req)
+					values.routes, values.routeCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.ListenerType:
 				if values.listenerNonce == "" || values.listenerNonce == nonce {
 					if values.listenerCancel != nil {
 						values.listenerCancel()
 					}
-					values.listeners, values.listenerCancel = s.cache.CreateWatch(*req)
+					values.listeners, values.listenerCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.SecretType:
 				if values.secretNonce == "" || values.secretNonce == nonce {
 					if values.secretCancel != nil {
 						values.secretCancel()
 					}
-					values.secrets, values.secretCancel = s.cache.CreateWatch(*req)
+					values.secrets, values.secretCancel = s.cache.CreateWatch(req)
 				}
 			case req.TypeUrl == resource.RuntimeType:
 				if values.runtimeNonce == "" || values.runtimeNonce == nonce {
 					if values.runtimeCancel != nil {
 						values.runtimeCancel()
 					}
-					values.runtimes, values.runtimeCancel = s.cache.CreateWatch(*req)
+					values.runtimes, values.runtimeCancel = s.cache.CreateWatch(req)
 				}
 			default:
 				responseNonce, seen := values.nonces[req.TypeUrl]
@@ -440,7 +440,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 						cancel()
 					}
 					var watch chan cache.Response
-					watch, values.cancellations[req.TypeUrl] = s.cache.CreateWatch(*req)
+					watch, values.cancellations[req.TypeUrl] = s.cache.CreateWatch(req)
 					// Muxing watches across multiple type URLs onto a single channel requires spawning
 					// a go-routine. Golang does not allow selecting over a dynamic set of channels.
 					go func() {
@@ -525,7 +525,7 @@ func (s *server) Fetch(ctx context.Context, req *discovery.DiscoveryRequest) (*d
 			return nil, err
 		}
 	}
-	resp, err := s.cache.Fetch(ctx, *req)
+	resp, err := s.cache.Fetch(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -36,11 +36,11 @@ import (
 
 type mockConfigWatcher struct {
 	counts     map[string]int
-	responses  map[string][]cache.RawResponse
+	responses  map[string][]cache.Response
 	closeWatch bool
 }
 
-func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (chan cache.Response, func()) {
+func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest) (chan cache.Response, func()) {
 	config.counts[req.TypeUrl] = config.counts[req.TypeUrl] + 1
 	out := make(chan cache.Response, 1)
 	if len(config.responses[req.TypeUrl]) > 0 {
@@ -52,11 +52,11 @@ func (config *mockConfigWatcher) CreateWatch(req discovery.DiscoveryRequest) (ch
 	return out, func() {}
 }
 
-func (config *mockConfigWatcher) Fetch(ctx context.Context, req discovery.DiscoveryRequest) (cache.Response, error) {
+func (config *mockConfigWatcher) Fetch(ctx context.Context, req *discovery.DiscoveryRequest) (cache.Response, error) {
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out := config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
-		return &out, nil
+		return out, nil
 	}
 	return nil, errors.New("missing")
 }
@@ -160,44 +160,58 @@ var (
 	}
 )
 
-func makeResponses() map[string][]cache.RawResponse {
-	return map[string][]cache.RawResponse{
-		rsrc.EndpointType: {{
-			Version:   "1",
-			Resources: []types.Resource{endpoint},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
-		}},
-		rsrc.ClusterType: {{
-			Version:   "2",
-			Resources: []types.Resource{cluster},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
-		}},
-		rsrc.RouteType: {{
-			Version:   "3",
-			Resources: []types.Resource{route},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
-		}},
-		rsrc.ListenerType: {{
-			Version:   "4",
-			Resources: []types.Resource{listener},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
-		}},
-		rsrc.SecretType: {{
-			Version:   "5",
-			Resources: []types.Resource{secret},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
-		}},
-		rsrc.RuntimeType: {{
-			Version:   "6",
-			Resources: []types.Resource{runtime},
-			Request:   discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
-		}},
+func makeResponses() map[string][]cache.Response {
+	return map[string][]cache.Response{
+		rsrc.EndpointType: {
+			&cache.RawResponse{
+				Version:   "1",
+				Resources: []types.Resource{endpoint},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
+			},
+		},
+		rsrc.ClusterType: {
+			&cache.RawResponse{
+				Version:   "2",
+				Resources: []types.Resource{cluster},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
+			},
+		},
+		rsrc.RouteType: {
+			&cache.RawResponse{
+				Version:   "3",
+				Resources: []types.Resource{route},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
+			},
+		},
+		rsrc.ListenerType: {
+			&cache.RawResponse{
+				Version:   "4",
+				Resources: []types.Resource{listener},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
+			},
+		},
+		rsrc.SecretType: {
+			&cache.RawResponse{
+				Version:   "5",
+				Resources: []types.Resource{secret},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
+			},
+		},
+		rsrc.RuntimeType: {
+			&cache.RawResponse{
+				Version:   "6",
+				Resources: []types.Resource{runtime},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
+			},
+		},
 		// Pass-through type (xDS does not exist for this type)
-		opaqueType: {{
-			Version:   "7",
-			Resources: []types.Resource{opaque},
-			Request:   discovery.DiscoveryRequest{TypeUrl: opaqueType},
-		}},
+		opaqueType: {
+			&cache.RawResponse{
+				Version:   "7",
+				Resources: []types.Resource{opaque},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: opaqueType},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Adds test assertions for caching within the `RawMessage.GetDiscoveryResponse` method and ensures the caching is occurring as intended.