### PR TITLE
cache: add version prefix

### DIFF
--- a/pkg/cache/v2/linear.go
+++ b/pkg/cache/v2/linear.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -42,6 +43,8 @@ type LinearCache struct {
 	watchAll watches
 	// Continously incremented version
 	version uint64
+	// Version prefix to be sent to the clients
+	versionPrefix string
 	// Versions for each resource by name.
 	versionVector map[string]uint64
 	mu            sync.Mutex
@@ -49,20 +52,40 @@ type LinearCache struct {
 
 var _ Cache = &LinearCache{}
 
-func NewLinearCache(typeURL string, initialResources map[string]types.Resource) *LinearCache {
-	if initialResources == nil {
-		initialResources = make(map[string]types.Resource)
+// Options for modifying the behavior of the linear cache.
+type LinearCacheOption func(*LinearCache)
+
+// WithVersionPrefix sets a version prefix of the form "prefixN" in the version info.
+// Version prefix can be used to distinguish replicated instances of the cache, in case
+// a client re-connects to another instance.
+func WithVersionPrefix(prefix string) LinearCacheOption {
+	return func(cache *LinearCache) {
+		cache.versionPrefix = prefix
 	}
+}
+
+// WithInitialResources initializes the initial set of resources.
+func WithInitialResources(resources map[string]types.Resource) LinearCacheOption {
+	return func(cache *LinearCache) {
+		cache.resources = resources
+		for name := range resources {
+			cache.versionVector[name] = 0
+		}
+	}
+}
+
+// NewLinearCache creates a new cache. See the comments on the struct definition.
+func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	out := &LinearCache{
 		typeURL:       typeURL,
-		resources:     initialResources,
+		resources:     make(map[string]types.Resource),
 		watches:       make(map[string]watches),
 		watchAll:      make(watches),
 		version:       0,
 		versionVector: make(map[string]uint64),
 	}
-	for name := range initialResources {
-		out.versionVector[name] = 0
+	for _, opt := range opts {
+		opt(out)
 	}
 	return out
 }
@@ -87,7 +110,7 @@ func (cache *LinearCache) respond(value chan Response, staleResources []string) 
 	value <- RawResponse{
 		Request:   Request{TypeUrl: cache.typeURL},
 		Resources: resources,
-		Version:   strconv.FormatUint(cache.version, 10),
+		Version:   cache.versionPrefix + strconv.FormatUint(cache.version, 10),
 	}
 }
 
@@ -152,7 +175,15 @@ func (cache *LinearCache) CreateWatch(request Request) (chan Response, func()) {
 	// of sending empty updates whenever an irrelevant resource changes.
 	stale := false
 	staleResources := []string{} // empty means all
-	lastVersion, err := strconv.ParseUint(request.VersionInfo, 0, 64)
+
+	// strip version prefix if it is present
+	var lastVersion uint64
+	var err error
+	if strings.HasPrefix(request.VersionInfo, cache.versionPrefix) {
+		lastVersion, err = strconv.ParseUint(request.VersionInfo[len(cache.versionPrefix):], 0, 64)
+	} else {
+		err = errors.New("mis-matched version prefix")
+	}
 
 	cache.mu.Lock()
 	defer cache.mu.Unlock()

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -71,7 +71,7 @@ func mustBlock(t *testing.T, w <-chan Response) {
 }
 
 func TestLinearInitialResources(t *testing.T) {
-	c := NewLinearCache(testType, map[string]types.Resource{"a": testResource("a"), "b": testResource("b")})
+	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
 	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType})
 	verifyResponse(t, w, "0", 1)
 	w, _ = c.CreateWatch(Request{TypeUrl: testType})
@@ -79,7 +79,7 @@ func TestLinearInitialResources(t *testing.T) {
 }
 
 func TestLinearCornerCases(t *testing.T) {
-	c := NewLinearCache(testType, nil)
+	c := NewLinearCache(testType)
 	err := c.UpdateResource("a", nil)
 	if err == nil {
 		t.Error("expected error on nil resource")
@@ -97,7 +97,7 @@ func TestLinearCornerCases(t *testing.T) {
 }
 
 func TestLinearBasic(t *testing.T) {
-	c := NewLinearCache(testType, nil)
+	c := NewLinearCache(testType)
 
 	// Create watches before a resource is ready
 	w1, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
@@ -129,8 +129,23 @@ func TestLinearBasic(t *testing.T) {
 	verifyResponse(t, w, "3", 2)
 }
 
+func TestLinearVersionPrefix(t *testing.T) {
+	c := NewLinearCache(testType, WithVersionPrefix("instance1-"))
+
+	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	verifyResponse(t, w, "instance1-0", 0)
+
+	c.UpdateResource("a", testResource("a"))
+	w, _ = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
+	verifyResponse(t, w, "instance1-1", 1)
+
+	w, _ = c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "instance1-1"})
+	mustBlock(t, w)
+	checkWatchCount(t, c, "a", 1)
+}
+
 func TestLinearDeletion(t *testing.T) {
-	c := NewLinearCache(testType, map[string]types.Resource{"a": testResource("a"), "b": testResource("b")})
+	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
 	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
@@ -147,7 +162,7 @@ func TestLinearDeletion(t *testing.T) {
 }
 
 func TestLinearWatchTwo(t *testing.T) {
-	c := NewLinearCache(testType, map[string]types.Resource{"a": testResource("a"), "b": testResource("b")})
+	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
 	w, _ := c.CreateWatch(Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
 	w1, _ := c.CreateWatch(Request{TypeUrl: testType, VersionInfo: "0"})
@@ -159,7 +174,7 @@ func TestLinearWatchTwo(t *testing.T) {
 }
 
 func TestLinearCancel(t *testing.T) {
-	c := NewLinearCache(testType, nil)
+	c := NewLinearCache(testType)
 	c.UpdateResource("a", testResource("a"))
 
 	// cancel watch-all
@@ -200,7 +215,7 @@ func TestLinearCancel(t *testing.T) {
 }
 
 func TestLinearConcurrentSetWatch(t *testing.T) {
-	c := NewLinearCache(testType, nil)
+	c := NewLinearCache(testType)
 	n := 50
 	for i := 0; i < 2*n; i++ {
 		func(i int) {


### PR DESCRIPTION
Envoy persists versioninfo across re-connections to the control plane servers. If the version is auto-generated as in the linear cache, we should use unique prefixes to distinguish clients joining from other instances of the control plane.
This changes adds a version prefix option.

Signed-off-by: Kuat Yessenov <kuat@google.com>
