### PR TITLE
Sets cluster DNS lookup to IPv4 only

### DIFF
--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -46,6 +46,7 @@ func makeCluster(clusterName string) *cluster.Cluster {
 		ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_LOGICAL_DNS},
 		LbPolicy:             cluster.Cluster_ROUND_ROBIN,
 		LoadAssignment:       makeEndpoint(clusterName),
+		DnsLookupFamily:      cluster.Cluster_V4_ONLY,
 	}
 }
 


### PR DESCRIPTION
Sets the example cluster DNS lookup family to IPv4 only.

Fixes https://github.com/envoyproxy/go-control-plane/issues/342

/cc @acnodal-tc