### PR TITLE
cache: log ignoring watch at warn level

### DIFF
--- a/pkg/cache/v2/simple.go
+++ b/pkg/cache/v2/simple.go
@@ -326,7 +326,7 @@ func (cache *snapshotCache) respond(request *Request, value chan Response, resou
 	if len(request.ResourceNames) != 0 && cache.ads {
 		if err := superset(nameSet(request.ResourceNames), resources); err != nil {
 			if cache.log != nil {
-				cache.log.Debugf("ADS mode: not responding to request: %v", err)
+				cache.log.Warnf("ADS mode: not responding to request: %v", err)
 			}
 			return
 		}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -327,7 +327,7 @@ func (cache *snapshotCache) respond(request *Request, value chan Response, resou
 	if len(request.ResourceNames) != 0 && cache.ads {
 		if err := superset(nameSet(request.ResourceNames), resources); err != nil {
 			if cache.log != nil {
-				cache.log.Debugf("ADS mode: not responding to request: %v", err)
+				cache.log.Warnf("ADS mode: not responding to request: %v", err)
 			}
 			return
 		}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -327,7 +327,7 @@ func (cache *snapshotCache) respond(request *Request, value chan Response, resou
 	if len(request.ResourceNames) != 0 && cache.ads {
 		if err := superset(nameSet(request.ResourceNames), resources); err != nil {
 			if cache.log != nil {
-				cache.log.Infof("ADS mode: not responding to request: %v", err)
+				cache.log.Debugf("ADS mode: not responding to request: %v", err)
 			}
 			return
 		}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -327,7 +327,7 @@ func (cache *snapshotCache) respond(request *Request, value chan Response, resou
 	if len(request.ResourceNames) != 0 && cache.ads {
 		if err := superset(nameSet(request.ResourceNames), resources); err != nil {
 			if cache.log != nil {
-				cache.log.Debugf("ADS mode: not responding to request: %v", err)
+				cache.log.Infof("ADS mode: not responding to request: %v", err)
 			}
 			return
 		}


### PR DESCRIPTION
https://github.com/envoyproxy/go-control-plane/pull/250 caused quite some surprises which suppressed several
useful "info" logs on watch registration/response in the cache.

While it's debatable whether we should bring all of them back, at least the log on rejecting the ADS watch
should be logged at a higher level -- we've seen a few outages caused by a combination of that and the Envoy data plane
failing to establish new watches, leading to missing updates. So the log was super useful in identifying the root cause.

Log it at warn level, because it's not frequent and potentially can cause above issues.
