### PR TITLE
pkg/wellknown: Update gzip wellknown name

### DIFF
--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -32,7 +32,7 @@ const (
 	// GRPCWeb HTTP filter
 	GRPCWeb = "envoy.filters.http.grpc_web"
 	// Gzip HTTP filter
-	Gzip = "envoy.filters.http.gzip"
+	Gzip = "envoy.filters.http.compressor"
 	// IPTagging HTTP filter
 	IPTagging = "envoy.filters.http.ip_tagging"
 	// HTTPRateLimit filter


### PR DESCRIPTION
This bumps the the Gzip HTTP filter wellknown name. 

Signed-off-by: Steve Sloka <slokas@vmware.com>