### PR TITLE
cache: Make `watchCount` the first field of `snapshotCache`.

### DIFF
--- a/pkg/cache/v2/simple.go
+++ b/pkg/cache/v2/simple.go
@@ -61,6 +61,12 @@ type SnapshotCache interface {
 }
 
 type snapshotCache struct {
+	// watchCount is an atomic counter incremented for each watch. This needs to
+	// be the first field in the struct to guarantee that it is 64-bit aligned,
+	// which is a requirement for atomic operations on 64-bit operands to work on
+	// 32-bit machines.
+	watchCount int64
+
 	log log.Logger
 
 	// ads flag to hold responses until all resources are named
@@ -74,9 +80,6 @@ type snapshotCache struct {
 
 	// hash is the hashing function for Envoy nodes
 	hash NodeHash
-
-	// watchCount is an atomic counter incremented for each watch
-	watchCount int64
 
 	mu sync.RWMutex
 }

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -62,6 +62,12 @@ type SnapshotCache interface {
 }
 
 type snapshotCache struct {
+	// watchCount is an atomic counter incremented for each watch. This needs to
+	// be the first field in the struct to guarantee that it is 64-bit aligned,
+	// which is a requirement for atomic operations on 64-bit operands to work on
+	// 32-bit machines.
+	watchCount int64
+
 	log log.Logger
 
 	// ads flag to hold responses until all resources are named
@@ -75,9 +81,6 @@ type snapshotCache struct {
 
 	// hash is the hashing function for Envoy nodes
 	hash NodeHash
-
-	// watchCount is an atomic counter incremented for each watch
-	watchCount int64
 
 	mu sync.RWMutex
 }


### PR DESCRIPTION
This makes sure that the watchCount field is 64-bit aligned on 32-bit
machines, thereby making sure that atomic operations work properly.

Fixes: https://github.com/envoyproxy/go-control-plane/issues/366

Signed-off-by: Easwar Swaminathan <easwars@google.com>