### PR TITLE
fix: add v3 accesslog to test server

### DIFF
--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -41,6 +41,7 @@ func RunAccessLogServer(ctx context.Context, alsv2 *testv2.AccessLogService, als
 	}
 
 	testv2.RegisterAccessLogServer(grpcServer, alsv2)
+	testv3.RegisterAccessLogServer(grpcServer, alsv3)
 	log.Printf("access log server listening on %d\n", alsPort)
 
 	go func() {


### PR DESCRIPTION
when I test all the v3 APIs, I  found test server miss register v3 access log,but alsv3 was in the parameters.
add register for v3 accesslog