### PR TITLE
server: guard response channel sharing with an option

### DIFF
--- a/pkg/cache/v2/cache.go
+++ b/pkg/cache/v2/cache.go
@@ -39,11 +39,14 @@ type ConfigWatcher interface {
 	//
 	// Once the requested resources are available, they should be pushed into
 	// responses channel. If there are any failures - nil should be written into
-	// the responses channel and the server should close the corresponding
+	// the responses channel and the server will close the corresponding
 	// stream. Cache implementation should not close the responses channel.
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.
+	//
+	// Server expects at most one response for a watch. If cancel is called, the
+	// server may expect no response because of channel size limits.
 	CreateWatch(request *Request, responses chan<- Response) (cancel func())
 }
 

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -40,11 +40,14 @@ type ConfigWatcher interface {
 	//
 	// Once the requested resources are available, they should be pushed into
 	// responses channel. If there are any failures - nil should be written into
-	// the responses channel and the server should close the corresponding
+	// the responses channel and the server will close the corresponding
 	// stream. Cache implementation should not close the responses channel.
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.
+	//
+	// Server expects at most one response for a watch. If cancel is called, the
+	// server may expect no response because of channel size limits.
 	CreateWatch(request *Request, responses chan<- Response) (cancel func())
 }
 

--- a/pkg/server/sotw/v2/server.go
+++ b/pkg/server/sotw/v2/server.go
@@ -59,6 +59,7 @@ func NewServer(ctx context.Context, config cache.ConfigWatcher, callbacks Callba
 		ctx:           ctx,
 		xdsBufferSize: 1,
 		muxBufferSize: 8,
+		unordered:     true,
 	}
 	for _, opt := range opts {
 		opt(out)
@@ -84,12 +85,25 @@ func WithXDSBufferSize(size int) ServerOption {
 	}
 }
 
+// WithOrdered enables reuse of the channel between watches which preserves the
+// ordering of responses in the server stream. Because of sharing, there is a
+// risk of a blocked channel if watch is responded twice (e.g. if cancellation
+// is asynchronous).
+// The default is to create a new channel of size 1 for all well-known type
+// watches.
+func WithOrdered() ServerOption {
+	return func(s *server) {
+		s.unordered = false
+	}
+}
+
 type server struct {
 	cache         cache.ConfigWatcher
 	callbacks     Callbacks
 	ctx           context.Context
 	xdsBufferSize int
 	muxBufferSize int
+	unordered     bool
 
 	// streamCount for counting bi-di streams
 	streamCount int64
@@ -108,6 +122,14 @@ type watches struct {
 	responses     chan cache.Response
 	cancellations map[string]func()
 	nonces        map[string]string
+
+	// Per-type channels for unordered watches
+	endpoints chan cache.Response
+	clusters  chan cache.Response
+	routes    chan cache.Response
+	listeners chan cache.Response
+	secrets   chan cache.Response
+	runtimes  chan cache.Response
 }
 
 // Initialize all watches
@@ -124,6 +146,11 @@ func (values *watches) Cancel() {
 			cancel()
 		}
 	}
+}
+
+// Enumerated receiver channels for well-known types. This is needed because
+// Golang does not support dynamic range in select{}.
+type typeChannels struct {
 }
 
 // process handles a bi-di stream request
@@ -211,6 +238,32 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if err := process(resp); err != nil {
 				return err
 			}
+		// legacy per-type watch channels
+		case resp := <-values.endpoints:
+			if err := process(resp); err != nil {
+				return err
+			}
+		case resp := <-values.clusters:
+			if err := process(resp); err != nil {
+				return err
+			}
+		case resp := <-values.routes:
+			if err := process(resp); err != nil {
+				return err
+			}
+		case resp := <-values.listeners:
+			if err := process(resp); err != nil {
+				return err
+			}
+		case resp := <-values.secrets:
+			if err := process(resp); err != nil {
+				return err
+			}
+		case resp := <-values.runtimes:
+			if err := process(resp); err != nil {
+				return err
+			}
+
 		case req, more := <-reqCh:
 			// input stream ended or errored out
 			if !more {
@@ -256,7 +309,30 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 						return err
 					}
 				}
-				values.cancellations[typeUrl] = s.cache.CreateWatch(req, values.responses)
+				value := values.responses
+				if s.unordered {
+					switch typeUrl {
+					case resource.EndpointType:
+						values.endpoints = make(chan cache.Response, 1)
+						value = values.endpoints
+					case resource.ClusterType:
+						values.clusters = make(chan cache.Response, 1)
+						value = values.clusters
+					case resource.RouteType:
+						values.routes = make(chan cache.Response, 1)
+						value = values.routes
+					case resource.ListenerType:
+						values.listeners = make(chan cache.Response, 1)
+						value = values.listeners
+					case resource.SecretType:
+						values.secrets = make(chan cache.Response, 1)
+						value = values.secrets
+					case resource.RuntimeType:
+						values.runtimes = make(chan cache.Response, 1)
+						value = values.runtimes
+					}
+				}
+				values.cancellations[typeUrl] = s.cache.CreateWatch(req, value)
 			}
 		}
 	}

--- a/pkg/server/sotw/v2/server.go
+++ b/pkg/server/sotw/v2/server.go
@@ -148,11 +148,6 @@ func (values *watches) Cancel() {
 	}
 }
 
-// Enumerated receiver channels for well-known types. This is needed because
-// Golang does not support dynamic range in select{}.
-type typeChannels struct {
-}
-
 // process handles a bi-di stream request
 func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest, defaultTypeURL string) error {
 	// increment stream count

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -55,12 +55,13 @@ type ServerOption func(*server)
 // NewServer creates handlers from a config watcher and callbacks.
 func NewServer(ctx context.Context, config cache.ConfigWatcher, callbacks Callbacks, opts ...ServerOption) Server {
 	out := &server{
-		cache:         config,
-		callbacks:     callbacks,
-		ctx:           ctx,
-		xdsBufferSize: 1,
-		muxBufferSize: 8,
-		unordered:     true,
+		cache:            config,
+		callbacks:        callbacks,
+		ctx:              ctx,
+		xdsBufferSize:    1,
+		muxBufferSize:    8,
+		unordered:        true,
+		cancelOnResponse: false,
 	}
 	for _, opt := range opts {
 		opt(out)
@@ -98,13 +99,22 @@ func WithOrdered() ServerOption {
 	}
 }
 
+// WithCancelOnResponse calls cancel() even if a response is received.
+func WithCancelOnResponse() ServerOption {
+	return func(s *server) {
+		s.cancelOnResponse = true
+	}
+}
+
 type server struct {
 	cache         cache.ConfigWatcher
 	callbacks     Callbacks
 	ctx           context.Context
 	xdsBufferSize int
 	muxBufferSize int
-	unordered     bool
+
+	unordered        bool
+	cancelOnResponse bool
 
 	// streamCount for counting bi-di streams
 	streamCount int64
@@ -199,7 +209,9 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 		}
 		typeUrl := resp.GetRequest().TypeUrl
 		values.nonces[typeUrl] = nonce
-		values.cancellations[typeUrl] = nil
+		if !s.cancelOnResponse {
+			values.cancellations[typeUrl] = nil
+		}
 		return nil
 	}
 

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -149,11 +149,6 @@ func (values *watches) Cancel() {
 	}
 }
 
-// Enumerated receiver channels for well-known types. This is needed because
-// Golang does not support dynamic range in select{}.
-type typeChannels struct {
-}
-
 // process handles a bi-di stream request
 func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest, defaultTypeURL string) error {
 	// increment stream count


### PR DESCRIPTION
Restore unique channel per watch behavior to support legacy clients that may block if the channel is shared.
It's likely other clients do not expect shared channel as well, so the default is the legacy behavior.

cc @fxposter 