### PR TITLE
Revert the new draining api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Release v0.9.8
-
-### Changed
-
-- Interface between the server and the cache has been changed to support explicit ordering by the cache.
-
 ## Release v0.9.7
 
 ### Added

--- a/pkg/cache/v2/cache.go
+++ b/pkg/cache/v2/cache.go
@@ -37,10 +37,10 @@ type ConfigWatcher interface {
 	// CreateWatch returns a new open watch from a non-empty request.
 	// An individual consumer normally issues a single open watch by each type URL.
 	//
-	// Once the requested resources are available, they should be pushed into
-	// responses channel. If there are any failures - nil should be written into
-	// the responses channel and the server should close the corresponding
-	// stream. Cache implementation should not close the responses channel.
+	// Once the requested resources are available, they should be pushed into responses channel.
+	// If there are any failures - nil should be written into the responses channel and the consumer should close the
+	// corresponding stream.
+	// Cache implementation should not close responses channel.
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.

--- a/pkg/cache/v2/cache.go
+++ b/pkg/cache/v2/cache.go
@@ -37,14 +37,14 @@ type ConfigWatcher interface {
 	// CreateWatch returns a new open watch from a non-empty request.
 	// An individual consumer normally issues a single open watch by each type URL.
 	//
-	// Once the requested resources are available, they should be pushed into responses channel.
-	// If there are any failures - nil should be written into the responses channel and the consumer should close the
+	// Value channel produces requested resources, once they are available.  If
+	// the channel is closed prior to cancellation of the watch, an unrecoverable
+	// error has occurred in the producer, and the consumer should close the
 	// corresponding stream.
-	// Cache implementation should not close responses channel.
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.
-	CreateWatch(request *Request, responses chan<- Response) (cancel func())
+	CreateWatch(*Request) (value chan Response, cancel func())
 }
 
 // ConfigFetcher fetches configuration resources from cache

--- a/pkg/cache/v2/linear.go
+++ b/pkg/cache/v2/linear.go
@@ -24,7 +24,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
-type watches = map[chan<- Response]struct{}
+type watches = map[chan Response]struct{}
 
 // LinearCache supports collectons of opaque resources. This cache has a
 // single collection indexed by resource names and manages resource versions
@@ -90,7 +90,7 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	return out
 }
 
-func (cache *LinearCache) respond(value chan<- Response, staleResources []string) {
+func (cache *LinearCache) respond(value chan Response, staleResources []string) {
 	var resources []types.Resource
 	// TODO: optimize the resources slice creations across different clients
 	if len(staleResources) == 0 {
@@ -116,7 +116,7 @@ func (cache *LinearCache) respond(value chan<- Response, staleResources []string
 
 func (cache *LinearCache) notifyAll(modified map[string]struct{}) {
 	// de-duplicate watches that need to be responded
-	notifyList := make(map[chan<- Response][]string)
+	notifyList := make(map[chan Response][]string)
 	for name := range modified {
 		for watch := range cache.watches[name] {
 			notifyList[watch] = append(notifyList[watch], name)
@@ -164,10 +164,11 @@ func (cache *LinearCache) DeleteResource(name string) error {
 	return nil
 }
 
-func (cache *LinearCache) CreateWatch(request *Request, value chan<- Response) func() {
+func (cache *LinearCache) CreateWatch(request *Request) (chan Response, func()) {
+	value := make(chan Response, 1)
 	if request.TypeUrl != cache.typeURL {
-		value <- nil
-		return nil
+		close(value)
+		return value, nil
 	}
 	// If the version is not up to date, check whether any requested resource has
 	// been updated between the last version and the current version. This avoids the problem
@@ -203,12 +204,12 @@ func (cache *LinearCache) CreateWatch(request *Request, value chan<- Response) f
 	}
 	if stale {
 		cache.respond(value, staleResources)
-		return nil
+		return value, nil
 	}
 	// Create open watches since versions are up to date.
 	if len(request.ResourceNames) == 0 {
 		cache.watchAll[value] = struct{}{}
-		return func() {
+		return value, func() {
 			cache.mu.Lock()
 			defer cache.mu.Unlock()
 			delete(cache.watchAll, value)
@@ -222,7 +223,7 @@ func (cache *LinearCache) CreateWatch(request *Request, value chan<- Response) f
 		}
 		set[value] = struct{}{}
 	}
-	return func() {
+	return value, func() {
 		cache.mu.Lock()
 		defer cache.mu.Unlock()
 		for _, name := range request.ResourceNames {

--- a/pkg/cache/v2/linear_test.go
+++ b/pkg/cache/v2/linear_test.go
@@ -71,10 +71,9 @@ func mustBlock(t *testing.T, w <-chan Response) {
 
 func TestLinearInitialResources(t *testing.T) {
 	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
-	w := make(chan Response, 1)
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType}, w)
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType})
 	verifyResponse(t, w, "0", 1)
-	c.CreateWatch(&Request{TypeUrl: testType}, w)
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType})
 	verifyResponse(t, w, "0", 2)
 }
 
@@ -85,15 +84,14 @@ func TestLinearCornerCases(t *testing.T) {
 		t.Error("expected error on nil resource")
 	}
 	// create an incorrect type URL request
-	w := make(chan Response, 1)
-	c.CreateWatch(&Request{TypeUrl: "test"}, w)
+	w, _ := c.CreateWatch(&Request{TypeUrl: "test"})
 	select {
-	case resp := <-w:
-		if resp != nil {
-			t.Error("should return nil")
+	case _, more := <-w:
+		if more {
+			t.Error("should be closed by the producer")
 		}
 	default:
-		t.Error("channel should contain response")
+		t.Error("channel should be closed")
 	}
 }
 
@@ -101,12 +99,9 @@ func TestLinearBasic(t *testing.T) {
 	c := NewLinearCache(testType)
 
 	// Create watches before a resource is ready
-	w1 := make(chan Response, 1)
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, w1)
+	w1, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w1)
-
-	w := make(chan Response, 1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 2)
 	checkWatchCount(t, c, "b", 1)
@@ -117,63 +112,59 @@ func TestLinearBasic(t *testing.T) {
 	verifyResponse(t, w, "1", 1)
 
 	// Request again, should get same response
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	checkWatchCount(t, c, "a", 0)
 	verifyResponse(t, w, "1", 1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	checkWatchCount(t, c, "a", 0)
 	verifyResponse(t, w, "1", 1)
 
 	// Add another element and update the first, response should be different
 	c.UpdateResource("b", testResource("b"))
 	c.UpdateResource("a", testResource("aa"))
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "3", 1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "3", 2)
 }
 
 func TestLinearVersionPrefix(t *testing.T) {
 	c := NewLinearCache(testType, WithVersionPrefix("instance1-"))
 
-	w := make(chan Response, 1)
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "instance1-0", 0)
 
 	c.UpdateResource("a", testResource("a"))
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "instance1-1", 1)
 
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "instance1-1"}, w)
+	w, _ = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "instance1-1"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 }
 
 func TestLinearDeletion(t *testing.T) {
 	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
-	w := make(chan Response, 1)
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	c.DeleteResource("a")
 	verifyResponse(t, w, "1", 0)
 	checkWatchCount(t, c, "a", 0)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	verifyResponse(t, w, "1", 1)
 	checkWatchCount(t, c, "b", 0)
 	c.DeleteResource("b")
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, w)
+	w, _ = c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
 	verifyResponse(t, w, "2", 0)
 	checkWatchCount(t, c, "b", 0)
 }
 
 func TestLinearWatchTwo(t *testing.T) {
 	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
-	w := make(chan Response, 1)
-	c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"}, w)
+	w, _ := c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w)
-	w1 := make(chan Response, 1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, w1)
+	w1, _ := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"})
 	mustBlock(t, w1)
 	c.UpdateResource("a", testResource("aa"))
 	// should only get the modified resource
@@ -186,28 +177,24 @@ func TestLinearCancel(t *testing.T) {
 	c.UpdateResource("a", testResource("a"))
 
 	// cancel watch-all
-	w := make(chan Response, 1)
-	cancel := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, w)
+	w, cancel := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	cancel()
 	checkWatchCount(t, c, "a", 0)
 
 	// cancel watch for "a"
-	cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"}, w)
+	w, cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	cancel()
 	checkWatchCount(t, c, "a", 0)
 
 	// open four watches for "a" and "b" and two for all, cancel one of each, make sure the second one is unaffected
-	w2 := make(chan Response, 1)
-	w3 := make(chan Response, 1)
-	w4 := make(chan Response, 1)
-	cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"}, w)
-	cancel2 := c.CreateWatch(&Request{ResourceNames: []string{"b"}, TypeUrl: testType, VersionInfo: "1"}, w2)
-	cancel3 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, w3)
-	cancel4 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, w4)
+	w, cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"})
+	w2, cancel2 := c.CreateWatch(&Request{ResourceNames: []string{"b"}, TypeUrl: testType, VersionInfo: "1"})
+	w3, cancel3 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
+	w4, cancel4 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"})
 	mustBlock(t, w)
 	mustBlock(t, w2)
 	mustBlock(t, w3)
@@ -240,13 +227,12 @@ func TestLinearConcurrentSetWatch(t *testing.T) {
 				} else {
 					id2 := fmt.Sprintf("%d", i-1)
 					t.Logf("request resources %q and %q", id, id2)
-					value := make(chan Response, 1)
-					c.CreateWatch(&Request{
+					value, _ := c.CreateWatch(&Request{
 						// Only expect one to become stale
 						ResourceNames: []string{id, id2},
 						VersionInfo:   "0",
 						TypeUrl:       testType,
-					}, value)
+					})
 					// wait until all updates apply
 					verifyResponse(t, value, "", 1)
 				}

--- a/pkg/cache/v2/mux.go
+++ b/pkg/cache/v2/mux.go
@@ -34,14 +34,15 @@ type MuxCache struct {
 
 var _ Cache = &MuxCache{}
 
-func (mux *MuxCache) CreateWatch(request *Request, value chan<- Response) func() {
+func (mux *MuxCache) CreateWatch(request *Request) (chan Response, func()) {
 	key := mux.Classify(*request)
 	cache, exists := mux.Caches[key]
 	if !exists {
-		value <- nil
-		return nil
+		value := make(chan Response, 0)
+		close(value)
+		return value, nil
 	}
-	return cache.CreateWatch(request, value)
+	return cache.CreateWatch(request)
 }
 
 func (mux *MuxCache) Fetch(ctx context.Context, request *Request) (Response, error) {

--- a/pkg/cache/v2/simple.go
+++ b/pkg/cache/v2/simple.go
@@ -175,7 +175,7 @@ func superset(names map[string]bool, resources map[string]types.Resource) error 
 }
 
 // CreateWatch returns a watch for an xDS request.
-func (cache *snapshotCache) CreateWatch(request *Request, value chan<- Response) func() {
+func (cache *snapshotCache) CreateWatch(request *Request) (chan Response, func()) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.Lock()
@@ -192,6 +192,9 @@ func (cache *snapshotCache) CreateWatch(request *Request, value chan<- Response)
 	info.lastWatchRequestTime = time.Now()
 	info.mu.Unlock()
 
+	// allocate capacity 1 to allow one-time non-blocking use
+	value := make(chan Response, 1)
+
 	snapshot, exists := cache.snapshots[nodeID]
 	version := snapshot.GetVersion(request.TypeUrl)
 
@@ -205,13 +208,13 @@ func (cache *snapshotCache) CreateWatch(request *Request, value chan<- Response)
 		info.mu.Lock()
 		info.watches[watchID] = ResponseWatch{Request: request, Response: value}
 		info.mu.Unlock()
-		return cache.cancelWatch(nodeID, watchID)
+		return value, cache.cancelWatch(nodeID, watchID)
 	}
 
 	// otherwise, the watch may be responded immediately
 	cache.respond(request, value, snapshot.GetResources(request.TypeUrl), version)
 
-	return nil
+	return value, nil
 }
 
 func (cache *snapshotCache) nextWatchID() int64 {
@@ -234,7 +237,7 @@ func (cache *snapshotCache) cancelWatch(nodeID string, watchID int64) func() {
 
 // Respond to a watch with the snapshot value. The value channel should have capacity not to block.
 // TODO(kuat) do not respond always, see issue https://github.com/envoyproxy/go-control-plane/issues/46
-func (cache *snapshotCache) respond(request *Request, value chan<- Response, resources map[string]types.Resource, version string) {
+func (cache *snapshotCache) respond(request *Request, value chan Response, resources map[string]types.Resource, version string) {
 	// for ADS, the request names must match the snapshot names
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.ResourceNames) != 0 && cache.ads {

--- a/pkg/cache/v2/simple_test.go
+++ b/pkg/cache/v2/simple_test.go
@@ -101,8 +101,7 @@ func TestSnapshotCache(t *testing.T) {
 
 	// try to get endpoints with incorrect list of names
 	// should not receive response
-	value := make(chan cache.Response, 1)
-	c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{"none"}}, value)
+	value, _ := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{"none"}})
 	select {
 	case out := <-value:
 		t.Errorf("watch for endpoints and mismatched names => got %v, want none", out)
@@ -111,8 +110,7 @@ func TestSnapshotCache(t *testing.T) {
 
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
-			value := make(chan cache.Response, 1)
-			c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}, value)
+			value, _ := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 			select {
 			case out := <-value:
 				if gotVersion, _ := out.GetVersion(); gotVersion != version {
@@ -163,8 +161,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
 	watches := make(map[string]chan cache.Response)
 	for _, typ := range testTypes {
-		watches[typ] = make(chan cache.Response, 1)
-		c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}, watches[typ])
+		watches[typ], _ = c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 	}
 	if err := c.SetSnapshot(key, snapshot); err != nil {
 		t.Fatal(err)
@@ -187,8 +184,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 
 	// open new watches with the latest version
 	for _, typ := range testTypes {
-		watches[typ] = make(chan cache.Response, 1)
-		c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: version}, watches[typ])
+		watches[typ], _ = c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: version})
 	}
 	if count := c.GetStatusInfo(key).GetNumWatches(); count != len(testTypes) {
 		t.Errorf("watches should be created for the latest version: %d", count)
@@ -226,7 +222,6 @@ func TestConcurrentSetWatch(t *testing.T) {
 				t.Parallel()
 				id := fmt.Sprintf("%d", i%2)
 				var cancel func()
-				value := make(chan cache.Response, 1)
 				if i < 25 {
 					snap := cache.Snapshot{}
 					snap.Resources[types.Endpoint] = cache.NewResources(fmt.Sprintf("v%d", i), []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
@@ -235,10 +230,10 @@ func TestConcurrentSetWatch(t *testing.T) {
 					if cancel != nil {
 						cancel()
 					}
-					cancel = c.CreateWatch(&discovery.DiscoveryRequest{
+					_, cancel = c.CreateWatch(&discovery.DiscoveryRequest{
 						Node:    &core.Node{Id: id},
 						TypeUrl: rsrc.EndpointType,
-					}, value)
+					})
 				}
 			})
 		}(i)
@@ -248,8 +243,7 @@ func TestConcurrentSetWatch(t *testing.T) {
 func TestSnapshotCacheWatchCancel(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
 	for _, typ := range testTypes {
-		value := make(chan cache.Response, 1)
-		cancel := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}, value)
+		_, cancel := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]})
 		cancel()
 	}
 	// should be status info for the node

--- a/pkg/cache/v2/status.go
+++ b/pkg/cache/v2/status.go
@@ -74,7 +74,7 @@ type ResponseWatch struct {
 	Request *Request
 
 	// Response is the channel to push responses to.
-	Response chan<- Response
+	Response chan Response
 }
 
 // newStatusInfo initializes a status info data structure.

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -38,10 +38,10 @@ type ConfigWatcher interface {
 	// CreateWatch returns a new open watch from a non-empty request.
 	// An individual consumer normally issues a single open watch by each type URL.
 	//
-	// Once the requested resources are available, they should be pushed into
-	// responses channel. If there are any failures - nil should be written into
-	// the responses channel and the server should close the corresponding
-	// stream. Cache implementation should not close the responses channel.
+	// Once the requested resources are available, they should be pushed into responses channel.
+	// If there are any failures - nil should be written into the responses channel and the consumer should close the
+	// corresponding stream.
+	// Cache implementation should not close responses channel.
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -38,14 +38,14 @@ type ConfigWatcher interface {
 	// CreateWatch returns a new open watch from a non-empty request.
 	// An individual consumer normally issues a single open watch by each type URL.
 	//
-	// Once the requested resources are available, they should be pushed into responses channel.
-	// If there are any failures - nil should be written into the responses channel and the consumer should close the
+	// Value channel produces requested resources, once they are available.  If
+	// the channel is closed prior to cancellation of the watch, an unrecoverable
+	// error has occurred in the producer, and the consumer should close the
 	// corresponding stream.
-	// Cache implementation should not close responses channel.
 	//
 	// Cancel is an optional function to release resources in the producer. If
 	// provided, the consumer may call this function multiple times.
-	CreateWatch(request *Request, responses chan<- Response) (cancel func())
+	CreateWatch(*Request) (value chan Response, cancel func())
 }
 
 // ConfigFetcher fetches configuration resources from cache

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -25,7 +25,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
-type watches = map[chan<- Response]struct{}
+type watches = map[chan Response]struct{}
 
 // LinearCache supports collectons of opaque resources. This cache has a
 // single collection indexed by resource names and manages resource versions
@@ -91,7 +91,7 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	return out
 }
 
-func (cache *LinearCache) respond(value chan<- Response, staleResources []string) {
+func (cache *LinearCache) respond(value chan Response, staleResources []string) {
 	var resources []types.Resource
 	// TODO: optimize the resources slice creations across different clients
 	if len(staleResources) == 0 {
@@ -117,7 +117,7 @@ func (cache *LinearCache) respond(value chan<- Response, staleResources []string
 
 func (cache *LinearCache) notifyAll(modified map[string]struct{}) {
 	// de-duplicate watches that need to be responded
-	notifyList := make(map[chan<- Response][]string)
+	notifyList := make(map[chan Response][]string)
 	for name := range modified {
 		for watch := range cache.watches[name] {
 			notifyList[watch] = append(notifyList[watch], name)
@@ -165,10 +165,11 @@ func (cache *LinearCache) DeleteResource(name string) error {
 	return nil
 }
 
-func (cache *LinearCache) CreateWatch(request *Request, value chan<- Response) func() {
+func (cache *LinearCache) CreateWatch(request *Request) (chan Response, func()) {
+	value := make(chan Response, 1)
 	if request.TypeUrl != cache.typeURL {
-		value <- nil
-		return nil
+		close(value)
+		return value, nil
 	}
 	// If the version is not up to date, check whether any requested resource has
 	// been updated between the last version and the current version. This avoids the problem
@@ -204,12 +205,12 @@ func (cache *LinearCache) CreateWatch(request *Request, value chan<- Response) f
 	}
 	if stale {
 		cache.respond(value, staleResources)
-		return nil
+		return value, nil
 	}
 	// Create open watches since versions are up to date.
 	if len(request.ResourceNames) == 0 {
 		cache.watchAll[value] = struct{}{}
-		return func() {
+		return value, func() {
 			cache.mu.Lock()
 			defer cache.mu.Unlock()
 			delete(cache.watchAll, value)
@@ -223,7 +224,7 @@ func (cache *LinearCache) CreateWatch(request *Request, value chan<- Response) f
 		}
 		set[value] = struct{}{}
 	}
-	return func() {
+	return value, func() {
 		cache.mu.Lock()
 		defer cache.mu.Unlock()
 		for _, name := range request.ResourceNames {

--- a/pkg/cache/v3/mux.go
+++ b/pkg/cache/v3/mux.go
@@ -35,14 +35,15 @@ type MuxCache struct {
 
 var _ Cache = &MuxCache{}
 
-func (mux *MuxCache) CreateWatch(request *Request, value chan<- Response) func() {
+func (mux *MuxCache) CreateWatch(request *Request) (chan Response, func()) {
 	key := mux.Classify(*request)
 	cache, exists := mux.Caches[key]
 	if !exists {
-		value <- nil
-		return nil
+		value := make(chan Response, 0)
+		close(value)
+		return value, nil
 	}
-	return cache.CreateWatch(request, value)
+	return cache.CreateWatch(request)
 }
 
 func (mux *MuxCache) Fetch(ctx context.Context, request *Request) (Response, error) {

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -176,7 +176,7 @@ func superset(names map[string]bool, resources map[string]types.Resource) error 
 }
 
 // CreateWatch returns a watch for an xDS request.
-func (cache *snapshotCache) CreateWatch(request *Request, value chan<- Response) func() {
+func (cache *snapshotCache) CreateWatch(request *Request) (chan Response, func()) {
 	nodeID := cache.hash.ID(request.Node)
 
 	cache.mu.Lock()
@@ -193,6 +193,9 @@ func (cache *snapshotCache) CreateWatch(request *Request, value chan<- Response)
 	info.lastWatchRequestTime = time.Now()
 	info.mu.Unlock()
 
+	// allocate capacity 1 to allow one-time non-blocking use
+	value := make(chan Response, 1)
+
 	snapshot, exists := cache.snapshots[nodeID]
 	version := snapshot.GetVersion(request.TypeUrl)
 
@@ -206,13 +209,13 @@ func (cache *snapshotCache) CreateWatch(request *Request, value chan<- Response)
 		info.mu.Lock()
 		info.watches[watchID] = ResponseWatch{Request: request, Response: value}
 		info.mu.Unlock()
-		return cache.cancelWatch(nodeID, watchID)
+		return value, cache.cancelWatch(nodeID, watchID)
 	}
 
 	// otherwise, the watch may be responded immediately
 	cache.respond(request, value, snapshot.GetResources(request.TypeUrl), version)
 
-	return nil
+	return value, nil
 }
 
 func (cache *snapshotCache) nextWatchID() int64 {
@@ -235,7 +238,7 @@ func (cache *snapshotCache) cancelWatch(nodeID string, watchID int64) func() {
 
 // Respond to a watch with the snapshot value. The value channel should have capacity not to block.
 // TODO(kuat) do not respond always, see issue https://github.com/envoyproxy/go-control-plane/issues/46
-func (cache *snapshotCache) respond(request *Request, value chan<- Response, resources map[string]types.Resource, version string) {
+func (cache *snapshotCache) respond(request *Request, value chan Response, resources map[string]types.Resource, version string) {
 	// for ADS, the request names must match the snapshot names
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.ResourceNames) != 0 && cache.ads {

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -75,7 +75,7 @@ type ResponseWatch struct {
 	Request *Request
 
 	// Response is the channel to push responses to.
-	Response chan<- Response
+	Response chan Response
 }
 
 // newStatusInfo initializes a status info data structure.

--- a/pkg/server/sotw/v2/server.go
+++ b/pkg/server/sotw/v2/server.go
@@ -72,16 +72,41 @@ type Stream interface {
 
 // watches for all xDS resource types
 type watches struct {
+	endpoints chan cache.Response
+	clusters  chan cache.Response
+	routes    chan cache.Response
+	listeners chan cache.Response
+	secrets   chan cache.Response
+	runtimes  chan cache.Response
+
+	endpointCancel func()
+	clusterCancel  func()
+	routeCancel    func()
+	listenerCancel func()
+	secretCancel   func()
+	runtimeCancel  func()
+
+	endpointNonce string
+	clusterNonce  string
+	routeNonce    string
+	listenerNonce string
+	secretNonce   string
+	runtimeNonce  string
+
+	// Opaque resources share a muxed channel. Nonces and watch cancellations are indexed by type URL.
 	responses     chan cache.Response
 	cancellations map[string]func()
 	nonces        map[string]string
+	terminations  map[string]chan struct{}
 }
 
 // Initialize all watches
-func (values *watches) Init(bufferSize int) {
-	values.responses = make(chan cache.Response, bufferSize)
+func (values *watches) Init() {
+	// muxed channel needs a buffer to release go-routines populating it
+	values.responses = make(chan cache.Response, 5)
 	values.cancellations = make(map[string]func())
 	values.nonces = make(map[string]string)
+	values.terminations = make(map[string]chan struct{})
 }
 
 // Token response value used to signal a watch failure in muxed watches.
@@ -89,10 +114,31 @@ var errorResponse = &cache.RawResponse{}
 
 // Cancel all watches
 func (values *watches) Cancel() {
+	if values.endpointCancel != nil {
+		values.endpointCancel()
+	}
+	if values.clusterCancel != nil {
+		values.clusterCancel()
+	}
+	if values.routeCancel != nil {
+		values.routeCancel()
+	}
+	if values.listenerCancel != nil {
+		values.listenerCancel()
+	}
+	if values.secretCancel != nil {
+		values.secretCancel()
+	}
+	if values.runtimeCancel != nil {
+		values.runtimeCancel()
+	}
 	for _, cancel := range values.cancellations {
 		if cancel != nil {
 			cancel()
 		}
+	}
+	for _, terminate := range values.terminations {
+		close(terminate)
 	}
 }
 
@@ -107,11 +153,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 
 	// a collection of stack allocated watches per request type
 	var values watches
-	bufferSize := 1
-	if defaultTypeURL == resource.AnyType {
-		bufferSize = 8
-	}
-	values.Init(bufferSize)
+	values.Init()
 	defer func() {
 		values.Cancel()
 		if s.callbacks != nil {
@@ -120,7 +162,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 	}()
 
 	// sends a response by serializing to protobuf Any
-	send := func(resp cache.Response) (string, error) {
+	send := func(resp cache.Response, typeURL string) (string, error) {
 		if resp == nil {
 			return "", errors.New("missing response")
 		}
@@ -139,30 +181,6 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 		return out.Nonce, stream.Send(out)
 	}
 
-	process := func(resp cache.Response) error {
-		nonce, err := send(resp)
-		if err != nil {
-			return err
-		}
-		typeUrl := resp.GetRequest().TypeUrl
-		values.nonces[typeUrl] = nonce
-		values.cancellations[typeUrl] = nil
-		return nil
-	}
-
-	processAll := func() error {
-		for {
-			select {
-			case resp := <-values.responses:
-				if err := process(resp); err != nil {
-					return err
-				}
-			default:
-				return nil
-			}
-		}
-	}
-
 	if s.callbacks != nil {
 		if err := s.callbacks.OnStreamOpen(stream.Context(), streamID, defaultTypeURL); err != nil {
 			return err
@@ -177,10 +195,79 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 		case <-s.ctx.Done():
 			return nil
 		// config watcher can send the requested resources types in any order
-		case resp := <-values.responses:
-			if err := process(resp); err != nil {
+		case resp, more := <-values.endpoints:
+			if !more {
+				return status.Errorf(codes.Unavailable, "endpoints watch failed")
+			}
+			nonce, err := send(resp, resource.EndpointType)
+			if err != nil {
 				return err
 			}
+			values.endpointNonce = nonce
+
+		case resp, more := <-values.clusters:
+			if !more {
+				return status.Errorf(codes.Unavailable, "clusters watch failed")
+			}
+			nonce, err := send(resp, resource.ClusterType)
+			if err != nil {
+				return err
+			}
+			values.clusterNonce = nonce
+
+		case resp, more := <-values.routes:
+			if !more {
+				return status.Errorf(codes.Unavailable, "routes watch failed")
+			}
+			nonce, err := send(resp, resource.RouteType)
+			if err != nil {
+				return err
+			}
+			values.routeNonce = nonce
+
+		case resp, more := <-values.listeners:
+			if !more {
+				return status.Errorf(codes.Unavailable, "listeners watch failed")
+			}
+			nonce, err := send(resp, resource.ListenerType)
+			if err != nil {
+				return err
+			}
+			values.listenerNonce = nonce
+
+		case resp, more := <-values.secrets:
+			if !more {
+				return status.Errorf(codes.Unavailable, "secrets watch failed")
+			}
+			nonce, err := send(resp, resource.SecretType)
+			if err != nil {
+				return err
+			}
+			values.secretNonce = nonce
+
+		case resp, more := <-values.runtimes:
+			if !more {
+				return status.Errorf(codes.Unavailable, "runtimes watch failed")
+			}
+			nonce, err := send(resp, resource.RuntimeType)
+			if err != nil {
+				return err
+			}
+			values.runtimeNonce = nonce
+
+		case resp, more := <-values.responses:
+			if more {
+				if resp == errorResponse {
+					return status.Errorf(codes.Unavailable, "resource watch failed")
+				}
+				typeUrl := resp.GetRequest().TypeUrl
+				nonce, err := send(resp, typeUrl)
+				if err != nil {
+					return err
+				}
+				values.nonces[typeUrl] = nonce
+			}
+
 		case req, more := <-reqCh:
 			// input stream ended or errored out
 			if !more {
@@ -215,16 +302,89 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 				}
 			}
 
-			typeUrl := req.TypeUrl
-			responseNonce, seen := values.nonces[typeUrl]
-			if !seen || responseNonce == nonce {
-				if cancel, seen := values.cancellations[typeUrl]; seen && cancel != nil {
-					cancel()
-					if err := processAll(); err != nil {
-						return err
+			// cancel existing watches to (re-)request a newer version
+			switch {
+			case req.TypeUrl == resource.EndpointType:
+				if values.endpointNonce == "" || values.endpointNonce == nonce {
+					if values.endpointCancel != nil {
+						values.endpointCancel()
 					}
+					values.endpoints, values.endpointCancel = s.cache.CreateWatch(req)
 				}
-				values.cancellations[typeUrl] = s.cache.CreateWatch(req, values.responses)
+			case req.TypeUrl == resource.ClusterType:
+				if values.clusterNonce == "" || values.clusterNonce == nonce {
+					if values.clusterCancel != nil {
+						values.clusterCancel()
+					}
+					values.clusters, values.clusterCancel = s.cache.CreateWatch(req)
+				}
+			case req.TypeUrl == resource.RouteType:
+				if values.routeNonce == "" || values.routeNonce == nonce {
+					if values.routeCancel != nil {
+						values.routeCancel()
+					}
+					values.routes, values.routeCancel = s.cache.CreateWatch(req)
+				}
+			case req.TypeUrl == resource.ListenerType:
+				if values.listenerNonce == "" || values.listenerNonce == nonce {
+					if values.listenerCancel != nil {
+						values.listenerCancel()
+					}
+					values.listeners, values.listenerCancel = s.cache.CreateWatch(req)
+				}
+			case req.TypeUrl == resource.SecretType:
+				if values.secretNonce == "" || values.secretNonce == nonce {
+					if values.secretCancel != nil {
+						values.secretCancel()
+					}
+					values.secrets, values.secretCancel = s.cache.CreateWatch(req)
+				}
+			case req.TypeUrl == resource.RuntimeType:
+				if values.runtimeNonce == "" || values.runtimeNonce == nonce {
+					if values.runtimeCancel != nil {
+						values.runtimeCancel()
+					}
+					values.runtimes, values.runtimeCancel = s.cache.CreateWatch(req)
+				}
+			default:
+				typeUrl := req.TypeUrl
+				responseNonce, seen := values.nonces[typeUrl]
+				if !seen || responseNonce == nonce {
+					// We must signal goroutine termination to prevent a race between the cancel closing the watch
+					// and the producer closing the watch.
+					if terminate, exists := values.terminations[typeUrl]; exists {
+						close(terminate)
+					}
+					if cancel, seen := values.cancellations[typeUrl]; seen && cancel != nil {
+						cancel()
+					}
+					var watch chan cache.Response
+					watch, values.cancellations[typeUrl] = s.cache.CreateWatch(req)
+					// Muxing watches across multiple type URLs onto a single channel requires spawning
+					// a go-routine. Golang does not allow selecting over a dynamic set of channels.
+					terminate := make(chan struct{})
+					values.terminations[typeUrl] = terminate
+					go func() {
+						select {
+						case resp, more := <-watch:
+							if more {
+								values.responses <- resp
+							} else {
+								// Check again if the watch is cancelled.
+								select {
+								case <-terminate: // do nothing
+								default:
+									// We cannot close the responses channel since it can be closed twice.
+									// Instead we send a fake error response.
+									values.responses <- errorResponse
+								}
+							}
+							break
+						case <-terminate:
+							break
+						}
+					}()
+				}
 			}
 		}
 	}

--- a/pkg/server/sotw/v2/server.go
+++ b/pkg/server/sotw/v2/server.go
@@ -48,48 +48,15 @@ type Callbacks interface {
 	OnStreamResponse(int64, *discovery.DiscoveryRequest, *discovery.DiscoveryResponse)
 }
 
-// Options for modifying the behavior of the server.
-type ServerOption func(*server)
-
 // NewServer creates handlers from a config watcher and callbacks.
-func NewServer(ctx context.Context, config cache.ConfigWatcher, callbacks Callbacks, opts ...ServerOption) Server {
-	out := &server{
-		cache:         config,
-		callbacks:     callbacks,
-		ctx:           ctx,
-		xdsBufferSize: 1,
-		muxBufferSize: 8,
-	}
-	for _, opt := range opts {
-		opt(out)
-	}
-	return out
-}
-
-// WithADSBufferSize changes the size of the response channel for ADS handlers
-// from the default 8. The size must be at least the number of different types
-// on ADS to prevent dead locks between cache write and server read.
-func WithADSBufferSize(size int) ServerOption {
-	return func(s *server) {
-		s.muxBufferSize = size
-	}
-}
-
-// WithXDSBufferSize changes the size of the response channel for each xDS handler
-// from the default 1. This buffer must be increased to support deferred cancellations
-// for caches that can emit responses after cancel is called.
-func WithXDSBufferSize(size int) ServerOption {
-	return func(s *server) {
-		s.xdsBufferSize = size
-	}
+func NewServer(ctx context.Context, config cache.ConfigWatcher, callbacks Callbacks) Server {
+	return &server{cache: config, callbacks: callbacks, ctx: ctx}
 }
 
 type server struct {
-	cache         cache.ConfigWatcher
-	callbacks     Callbacks
-	ctx           context.Context
-	xdsBufferSize int
-	muxBufferSize int
+	cache     cache.ConfigWatcher
+	callbacks Callbacks
+	ctx       context.Context
 
 	// streamCount for counting bi-di streams
 	streamCount int64
@@ -117,6 +84,9 @@ func (values *watches) Init(bufferSize int) {
 	values.nonces = make(map[string]string)
 }
 
+// Token response value used to signal a watch failure in muxed watches.
+var errorResponse = &cache.RawResponse{}
+
 // Cancel all watches
 func (values *watches) Cancel() {
 	for _, cancel := range values.cancellations {
@@ -137,9 +107,9 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 
 	// a collection of stack allocated watches per request type
 	var values watches
-	bufferSize := s.xdsBufferSize
+	bufferSize := 1
 	if defaultTypeURL == resource.AnyType {
-		bufferSize = s.muxBufferSize
+		bufferSize = 8
 	}
 	values.Init(bufferSize)
 	defer func() {
@@ -250,8 +220,6 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !seen || responseNonce == nonce {
 				if cancel, seen := values.cancellations[typeUrl]; seen && cancel != nil {
 					cancel()
-					// Some responses may have made it to the channel prior to cancel,
-					// hence drain it to avoid channel buffer overrun.
 					if err := processAll(); err != nil {
 						return err
 					}

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -73,16 +73,41 @@ type Stream interface {
 
 // watches for all xDS resource types
 type watches struct {
+	endpoints chan cache.Response
+	clusters  chan cache.Response
+	routes    chan cache.Response
+	listeners chan cache.Response
+	secrets   chan cache.Response
+	runtimes  chan cache.Response
+
+	endpointCancel func()
+	clusterCancel  func()
+	routeCancel    func()
+	listenerCancel func()
+	secretCancel   func()
+	runtimeCancel  func()
+
+	endpointNonce string
+	clusterNonce  string
+	routeNonce    string
+	listenerNonce string
+	secretNonce   string
+	runtimeNonce  string
+
+	// Opaque resources share a muxed channel. Nonces and watch cancellations are indexed by type URL.
 	responses     chan cache.Response
 	cancellations map[string]func()
 	nonces        map[string]string
+	terminations  map[string]chan struct{}
 }
 
 // Initialize all watches
-func (values *watches) Init(bufferSize int) {
-	values.responses = make(chan cache.Response, bufferSize)
+func (values *watches) Init() {
+	// muxed channel needs a buffer to release go-routines populating it
+	values.responses = make(chan cache.Response, 5)
 	values.cancellations = make(map[string]func())
 	values.nonces = make(map[string]string)
+	values.terminations = make(map[string]chan struct{})
 }
 
 // Token response value used to signal a watch failure in muxed watches.
@@ -90,10 +115,31 @@ var errorResponse = &cache.RawResponse{}
 
 // Cancel all watches
 func (values *watches) Cancel() {
+	if values.endpointCancel != nil {
+		values.endpointCancel()
+	}
+	if values.clusterCancel != nil {
+		values.clusterCancel()
+	}
+	if values.routeCancel != nil {
+		values.routeCancel()
+	}
+	if values.listenerCancel != nil {
+		values.listenerCancel()
+	}
+	if values.secretCancel != nil {
+		values.secretCancel()
+	}
+	if values.runtimeCancel != nil {
+		values.runtimeCancel()
+	}
 	for _, cancel := range values.cancellations {
 		if cancel != nil {
 			cancel()
 		}
+	}
+	for _, terminate := range values.terminations {
+		close(terminate)
 	}
 }
 
@@ -108,11 +154,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 
 	// a collection of stack allocated watches per request type
 	var values watches
-	bufferSize := 1
-	if defaultTypeURL == resource.AnyType {
-		bufferSize = 8
-	}
-	values.Init(bufferSize)
+	values.Init()
 	defer func() {
 		values.Cancel()
 		if s.callbacks != nil {
@@ -121,7 +163,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 	}()
 
 	// sends a response by serializing to protobuf Any
-	send := func(resp cache.Response) (string, error) {
+	send := func(resp cache.Response, typeURL string) (string, error) {
 		if resp == nil {
 			return "", errors.New("missing response")
 		}
@@ -140,30 +182,6 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 		return out.Nonce, stream.Send(out)
 	}
 
-	process := func(resp cache.Response) error {
-		nonce, err := send(resp)
-		if err != nil {
-			return err
-		}
-		typeUrl := resp.GetRequest().TypeUrl
-		values.nonces[typeUrl] = nonce
-		values.cancellations[typeUrl] = nil
-		return nil
-	}
-
-	processAll := func() error {
-		for {
-			select {
-			case resp := <-values.responses:
-				if err := process(resp); err != nil {
-					return err
-				}
-			default:
-				return nil
-			}
-		}
-	}
-
 	if s.callbacks != nil {
 		if err := s.callbacks.OnStreamOpen(stream.Context(), streamID, defaultTypeURL); err != nil {
 			return err
@@ -178,10 +196,79 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 		case <-s.ctx.Done():
 			return nil
 		// config watcher can send the requested resources types in any order
-		case resp := <-values.responses:
-			if err := process(resp); err != nil {
+		case resp, more := <-values.endpoints:
+			if !more {
+				return status.Errorf(codes.Unavailable, "endpoints watch failed")
+			}
+			nonce, err := send(resp, resource.EndpointType)
+			if err != nil {
 				return err
 			}
+			values.endpointNonce = nonce
+
+		case resp, more := <-values.clusters:
+			if !more {
+				return status.Errorf(codes.Unavailable, "clusters watch failed")
+			}
+			nonce, err := send(resp, resource.ClusterType)
+			if err != nil {
+				return err
+			}
+			values.clusterNonce = nonce
+
+		case resp, more := <-values.routes:
+			if !more {
+				return status.Errorf(codes.Unavailable, "routes watch failed")
+			}
+			nonce, err := send(resp, resource.RouteType)
+			if err != nil {
+				return err
+			}
+			values.routeNonce = nonce
+
+		case resp, more := <-values.listeners:
+			if !more {
+				return status.Errorf(codes.Unavailable, "listeners watch failed")
+			}
+			nonce, err := send(resp, resource.ListenerType)
+			if err != nil {
+				return err
+			}
+			values.listenerNonce = nonce
+
+		case resp, more := <-values.secrets:
+			if !more {
+				return status.Errorf(codes.Unavailable, "secrets watch failed")
+			}
+			nonce, err := send(resp, resource.SecretType)
+			if err != nil {
+				return err
+			}
+			values.secretNonce = nonce
+
+		case resp, more := <-values.runtimes:
+			if !more {
+				return status.Errorf(codes.Unavailable, "runtimes watch failed")
+			}
+			nonce, err := send(resp, resource.RuntimeType)
+			if err != nil {
+				return err
+			}
+			values.runtimeNonce = nonce
+
+		case resp, more := <-values.responses:
+			if more {
+				if resp == errorResponse {
+					return status.Errorf(codes.Unavailable, "resource watch failed")
+				}
+				typeUrl := resp.GetRequest().TypeUrl
+				nonce, err := send(resp, typeUrl)
+				if err != nil {
+					return err
+				}
+				values.nonces[typeUrl] = nonce
+			}
+
 		case req, more := <-reqCh:
 			// input stream ended or errored out
 			if !more {
@@ -216,16 +303,89 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 				}
 			}
 
-			typeUrl := req.TypeUrl
-			responseNonce, seen := values.nonces[typeUrl]
-			if !seen || responseNonce == nonce {
-				if cancel, seen := values.cancellations[typeUrl]; seen && cancel != nil {
-					cancel()
-					if err := processAll(); err != nil {
-						return err
+			// cancel existing watches to (re-)request a newer version
+			switch {
+			case req.TypeUrl == resource.EndpointType:
+				if values.endpointNonce == "" || values.endpointNonce == nonce {
+					if values.endpointCancel != nil {
+						values.endpointCancel()
 					}
+					values.endpoints, values.endpointCancel = s.cache.CreateWatch(req)
 				}
-				values.cancellations[typeUrl] = s.cache.CreateWatch(req, values.responses)
+			case req.TypeUrl == resource.ClusterType:
+				if values.clusterNonce == "" || values.clusterNonce == nonce {
+					if values.clusterCancel != nil {
+						values.clusterCancel()
+					}
+					values.clusters, values.clusterCancel = s.cache.CreateWatch(req)
+				}
+			case req.TypeUrl == resource.RouteType:
+				if values.routeNonce == "" || values.routeNonce == nonce {
+					if values.routeCancel != nil {
+						values.routeCancel()
+					}
+					values.routes, values.routeCancel = s.cache.CreateWatch(req)
+				}
+			case req.TypeUrl == resource.ListenerType:
+				if values.listenerNonce == "" || values.listenerNonce == nonce {
+					if values.listenerCancel != nil {
+						values.listenerCancel()
+					}
+					values.listeners, values.listenerCancel = s.cache.CreateWatch(req)
+				}
+			case req.TypeUrl == resource.SecretType:
+				if values.secretNonce == "" || values.secretNonce == nonce {
+					if values.secretCancel != nil {
+						values.secretCancel()
+					}
+					values.secrets, values.secretCancel = s.cache.CreateWatch(req)
+				}
+			case req.TypeUrl == resource.RuntimeType:
+				if values.runtimeNonce == "" || values.runtimeNonce == nonce {
+					if values.runtimeCancel != nil {
+						values.runtimeCancel()
+					}
+					values.runtimes, values.runtimeCancel = s.cache.CreateWatch(req)
+				}
+			default:
+				typeUrl := req.TypeUrl
+				responseNonce, seen := values.nonces[typeUrl]
+				if !seen || responseNonce == nonce {
+					// We must signal goroutine termination to prevent a race between the cancel closing the watch
+					// and the producer closing the watch.
+					if terminate, exists := values.terminations[typeUrl]; exists {
+						close(terminate)
+					}
+					if cancel, seen := values.cancellations[typeUrl]; seen && cancel != nil {
+						cancel()
+					}
+					var watch chan cache.Response
+					watch, values.cancellations[typeUrl] = s.cache.CreateWatch(req)
+					// Muxing watches across multiple type URLs onto a single channel requires spawning
+					// a go-routine. Golang does not allow selecting over a dynamic set of channels.
+					terminate := make(chan struct{})
+					values.terminations[typeUrl] = terminate
+					go func() {
+						select {
+						case resp, more := <-watch:
+							if more {
+								values.responses <- resp
+							} else {
+								// Check again if the watch is cancelled.
+								select {
+								case <-terminate: // do nothing
+								default:
+									// We cannot close the responses channel since it can be closed twice.
+									// Instead we send a fake error response.
+									values.responses <- errorResponse
+								}
+							}
+							break
+						case <-terminate:
+							break
+						}
+					}()
+				}
 			}
 		}
 	}

--- a/pkg/server/v2/server_test.go
+++ b/pkg/server/v2/server_test.go
@@ -34,26 +34,29 @@ import (
 )
 
 type mockConfigWatcher struct {
-	counts    map[string]int
-	responses map[string][]cache.Response
-	failWatch bool
-	watches   int
+	counts     map[string]int
+	responses  map[string][]cache.Response
+	closeWatch bool
+	watches    int
 }
 
-func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, out chan<- cache.Response) func() {
+func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest) (chan cache.Response, func()) {
 	config.counts[req.TypeUrl] = config.counts[req.TypeUrl] + 1
+	out := make(chan cache.Response, 1)
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out <- config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
-	} else if config.failWatch {
-		out <- nil
+	} else if config.closeWatch {
+		close(out)
 	} else {
 		config.watches += 1
-		return func() {
+		return out, func() {
+			// it is ok to close the channel after cancellation and not wait for it to be garbage collected
+			close(out)
 			config.watches -= 1
 		}
 	}
-	return nil
+	return out, nil
 }
 
 func (config *mockConfigWatcher) Fetch(ctx context.Context, req *discovery.DiscoveryRequest) (cache.Response, error) {
@@ -424,7 +427,7 @@ func TestWatchClosed(t *testing.T) {
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
 			config := makeMockConfigWatcher()
-			config.failWatch = true
+			config.closeWatch = true
 			s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
 
 			// make a request

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -35,26 +35,29 @@ import (
 )
 
 type mockConfigWatcher struct {
-	counts    map[string]int
-	responses map[string][]cache.Response
-	failWatch bool
-	watches   int
+	counts     map[string]int
+	responses  map[string][]cache.Response
+	closeWatch bool
+	watches    int
 }
 
-func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, out chan<- cache.Response) func() {
+func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest) (chan cache.Response, func()) {
 	config.counts[req.TypeUrl] = config.counts[req.TypeUrl] + 1
+	out := make(chan cache.Response, 1)
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out <- config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
-	} else if config.failWatch {
-		out <- nil
+	} else if config.closeWatch {
+		close(out)
 	} else {
 		config.watches += 1
-		return func() {
+		return out, func() {
+			// it is ok to close the channel after cancellation and not wait for it to be garbage collected
+			close(out)
 			config.watches -= 1
 		}
 	}
-	return nil
+	return out, nil
 }
 
 func (config *mockConfigWatcher) Fetch(ctx context.Context, req *discovery.DiscoveryRequest) (cache.Response, error) {
@@ -425,7 +428,7 @@ func TestWatchClosed(t *testing.T) {
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
 			config := makeMockConfigWatcher()
-			config.failWatch = true
+			config.closeWatch = true
 			s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
 
 			// make a request


### PR DESCRIPTION
While trying out the new draining api https://github.com/envoyproxy/go-control-plane/pull/357 , we realized that we are not able to make xdsrelay work with it(results described in https://github.com/envoyproxy/go-control-plane/pull/374) 
I propose to revert them to keep master clean and bring the changes back with more testing in production environments.