### PR TITLE
Remove personal email

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -6,4 +6,4 @@ right place.
 * Kuat Yessenov ([kyessenov](https://github.com/kyessenov)) (kuat@google.com)
 * Yangmin Zhu ([yangminzhu](https://github.com/yangminzhu)) (ymzhu@google.com)
 * Snow Pettersen ([snowp](https://github.com/snowp)) (snowp@lyft.com)
-* Alec Holmes ([alecholmez](https://github.com/alecholmez)) (alecholmez@me.com)
+* Alec Holmes ([alecholmez](https://github.com/alecholmez)) (alec.holmes@greymatter.io)


### PR DESCRIPTION
Signed-off-by: Alec Holmes <alecholmez@me.com>


Sorry y'all. I didn't realize my personal email was displayed on my github account, is it okay if I use this one instead? 