### PR TITLE
Add basic golangci-lint integration.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,3 +26,12 @@ linters-settings:
 issues:
   exclude:
   exclude-rules:
+  - text: "SA1019: package github.com/golang/protobuf/jsonpb is deprecated"
+    linters:
+    - staticcheck
+  - text: "SA1019: package github.com/golang/protobuf/proto is deprecated"
+    linters:
+    - staticcheck
+  - text: "SA1019: proto.MessageName is deprecated"
+    linters:
+    - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+  timeout: 10m
+
+linters:
+  enable:
+  - bodyclose
+  - gofmt
+  - goimports
+  - golint
+  - gosec
+  - misspell
+  - revive
+  - unconvert
+  - unparam
+
+linters-settings:
+  misspell:
+    locale: US
+  gofmt:
+    simplify: true
+  unparam:
+    check-exported: false
+  goimports:
+    local-prefixes: github.com/envoyproxy/go-control-plane
+
+issues:
+  exclude:
+  exclude-rules:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,15 @@ format:
 examples:
 	@pushd examples/dyplomat && go build ./... && popd
 
+.PHONY: lint
+lint:
+	docker run \
+		--rm \
+		--volume $$(pwd):/src \
+		--workdir /src \
+		golangci/golangci-lint:v1.41.1 \
+	golangci-lint run -v
+
 #-----------------
 #-- integration
 #-----------------

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint:
 		--volume $$(pwd):/src \
 		--workdir /src \
 		golangci/golangci-lint:v1.41.1 \
-	golangci-lint run -v
+	golangci-lint run
 
 #-----------------
 #-- integration

--- a/internal/example/main/main.go
+++ b/internal/example/main/main.go
@@ -25,12 +25,8 @@ import (
 )
 
 var (
-	l example.Logger
-
-	port     uint
-	basePort uint
-	mode     string
-
+	l      example.Logger
+	port   uint
 	nodeID string
 )
 

--- a/pkg/cache/types/types.go
+++ b/pkg/cache/types/types.go
@@ -12,10 +12,10 @@ type Resource interface {
 }
 
 // ResourceWithTtl is a Resource with an optional TTL.
-type ResourceWithTtl struct {
+type ResourceWithTtl struct { // nolint:golint,revive
 	Resource Resource
 
-	Ttl *time.Duration
+	Ttl *time.Duration // nolint:golint,revive
 }
 
 // MarshaledResource is an alias for the serialized binary array.

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -191,7 +191,7 @@ func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, erro
 		marshaledResources := make([]*any.Any, len(r.Resources))
 
 		for i, resource := range r.Resources {
-			maybeTtldResource, resourceType, err := r.maybeCreateTtlResource(resource)
+			maybeTtldResource, resourceType, err := r.maybeCreateTTLResource(resource)
 			if err != nil {
 				return nil, err
 			}
@@ -285,7 +285,7 @@ func (r *RawDeltaResponse) GetNextVersionMap() map[string]string {
 
 var deltaResourceTypeURL = "type.googleapis.com/" + proto.MessageName(&discovery.Resource{})
 
-func (r *RawResponse) maybeCreateTtlResource(resource types.ResourceWithTtl) (types.Resource, string, error) {
+func (r *RawResponse) maybeCreateTTLResource(resource types.ResourceWithTtl) (types.Resource, string, error) {
 	if resource.Ttl != nil {
 		wrappedResource := &discovery.Resource{
 			Name: GetResourceName(resource.Resource),

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -40,7 +40,7 @@ type DeltaRequest = discovery.DeltaDiscoveryRequest
 
 // ConfigWatcher requests watches for configuration resources by a node, last
 // applied version identifier, and resource names hint. The watch should send
-// the responses when they are ready. The watch can be cancelled by the
+// the responses when they are ready. The watch can be canceled by the
 // consumer, in effect terminating the watch for the request.
 // ConfigWatcher implementation must be thread-safe.
 type ConfigWatcher interface {
@@ -155,16 +155,16 @@ type RawDeltaResponse struct {
 var _ Response = &RawResponse{}
 var _ DeltaResponse = &RawDeltaResponse{}
 
-// PassthroughResponse is a pre constructed xDS response that need not go through marshalling transformations.
+// PassthroughResponse is a pre constructed xDS response that need not go through marshaling transformations.
 type PassthroughResponse struct {
 	// Request is the original request.
 	Request *discovery.DiscoveryRequest
 
-	// The discovery response that needs to be sent as is, without any marshalling transformations.
+	// The discovery response that needs to be sent as is, without any marshaling transformations.
 	DiscoveryResponse *discovery.DiscoveryResponse
 }
 
-// DeltaPassthroughResponse is a pre constructed xDS response that need not go through marshalling transformations.
+// DeltaPassthroughResponse is a pre constructed xDS response that need not go through marshaling transformations.
 type DeltaPassthroughResponse struct {
 	// Request is the latest delta request on the stream
 	DeltaRequest *discovery.DeltaDiscoveryRequest
@@ -172,16 +172,16 @@ type DeltaPassthroughResponse struct {
 	// NextVersionMap consists of updated version mappings after this response is applied
 	NextVersionMap map[string]string
 
-	// This discovery response that needs to be sent as is, without any marshalling transformations
+	// This discovery response that needs to be sent as is, without any marshaling transformations
 	DeltaDiscoveryResponse *discovery.DeltaDiscoveryResponse
 }
 
 var _ Response = &PassthroughResponse{}
 var _ DeltaResponse = &DeltaPassthroughResponse{}
 
-// GetDiscoveryResponse performs the marshalling the first time its called and uses the cached response subsequently.
-// This is necessary because the marshalled response does not change across the calls.
-// This caching behavior is important in high throughput scenarios because grpc marshalling has a cost and it drives the cpu utilization under load.
+// GetDiscoveryResponse performs the marshaling the first time its called and uses the cached response subsequently.
+// This is necessary because the marshaled response does not change across the calls.
+// This caching behavior is important in high throughput scenarios because grpc marshaling has a cost and it drives the cpu utilization under load.
 func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 
 	marshaledResponse := r.marshaledResponse.Load()
@@ -217,9 +217,9 @@ func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, erro
 	return marshaledResponse.(*discovery.DiscoveryResponse), nil
 }
 
-// GetDeltaDiscoveryResponse performs the marshalling the first time its called and uses the cached response subsequently.
-// We can do this because the marshalled response does not change across the calls.
-// This caching behavior is important in high throughput scenarios because grpc marshalling has a cost and it drives the cpu utilization under load.
+// GetDeltaDiscoveryResponse performs the marshaling the first time its called and uses the cached response subsequently.
+// We can do this because the marshaled response does not change across the calls.
+// This caching behavior is important in high throughput scenarios because grpc marshaling has a cost and it drives the cpu utilization under load.
 func (r *RawDeltaResponse) GetDeltaDiscoveryResponse() (*discovery.DeltaDiscoveryResponse, error) {
 	marshaledResponse := r.marshaledResponse.Load()
 

--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -22,13 +22,7 @@ import (
 
 // Respond to a delta watch with the provided snapshot value. If the response is nil, there has been no state change.
 func respondDelta(request *DeltaRequest, value chan DeltaResponse, state stream.StreamState, snapshot Snapshot, log log.Logger) *RawDeltaResponse {
-	resp, err := createDeltaResponse(request, state, snapshot, log)
-	if err != nil {
-		if log != nil {
-			log.Errorf("Error creating delta response: %v", err)
-		}
-		return nil
-	}
+	resp := createDeltaResponse(request, state, snapshot, log)
 
 	// Only send a response if there were changes
 	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 {
@@ -42,7 +36,7 @@ func respondDelta(request *DeltaRequest, value chan DeltaResponse, state stream.
 	return nil
 }
 
-func createDeltaResponse(req *DeltaRequest, state stream.StreamState, snapshot Snapshot, log log.Logger) (*RawDeltaResponse, error) {
+func createDeltaResponse(req *DeltaRequest, state stream.StreamState, snapshot Snapshot, _ log.Logger) *RawDeltaResponse {
 	resources := snapshot.GetResources((req.TypeUrl))
 
 	// variables to build our response with
@@ -89,5 +83,5 @@ func createDeltaResponse(req *DeltaRequest, state stream.StreamState, snapshot S
 		RemovedResources:  toRemove,
 		NextVersionMap:    nextVersionMap,
 		SystemVersionInfo: snapshot.GetVersion(req.TypeUrl),
-	}, nil
+	}
 }

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -156,7 +158,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 
 		// make sure the version maps are different since we no longer are tracking any endpoint resources
 		if reflect.DeepEqual(versionMap[testTypes[0]], nextVersionMap) {
-			t.Fatalf("versionMap for the endpoint resource type did not change, received: %v, instead of an emtpy map", nextVersionMap)
+			t.Fatalf("versionMap for the endpoint resource type did not change, received: %v, instead of an empty map", nextVersionMap)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")
@@ -175,7 +177,7 @@ func TestConcurrentSetDeltaWatch(t *testing.T) {
 				if i < 25 {
 					snap := cache.Snapshot{}
 					snap.Resources[types.Endpoint] = cache.NewResources(version, []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
-					c.SetSnapshot(id, snap)
+					require.NoError(t, c.SetSnapshot(id, snap))
 				} else {
 					if cancel != nil {
 						cancel()

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -27,7 +27,7 @@ import (
 
 type watches = map[chan Response]struct{}
 
-// LinearCache supports collectons of opaque resources. This cache has a
+// LinearCache supports collections of opaque resources. This cache has a
 // single collection indexed by resource names and manages resource versions
 // internally. It implements the cache interface for a single type URL and
 // should be combined with other caches via type URL muxing. It can be used to

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -42,7 +42,7 @@ type LinearCache struct {
 	watches map[string]watches
 	// Set of watches for all resources in the collection
 	watchAll watches
-	// Continously incremented version
+	// Continuously incremented version.
 	version uint64
 	// Version prefix to be sent to the clients
 	versionPrefix string
@@ -141,7 +141,7 @@ func (cache *LinearCache) UpdateResource(name string, res types.Resource) error 
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	cache.version += 1
+	cache.version++
 	cache.versionVector[name] = cache.version
 	cache.resources[name] = res
 
@@ -156,7 +156,7 @@ func (cache *LinearCache) DeleteResource(name string) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	cache.version += 1
+	cache.version++
 	delete(cache.versionVector, name)
 	delete(cache.resources, name)
 
@@ -172,7 +172,7 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	cache.version += 1
+	cache.version++
 
 	modified := map[string]struct{}{}
 	// Collect deleted resource names.

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -61,10 +61,6 @@ type SnapshotCache interface {
 	GetStatusKeys() []string
 }
 
-type heartbeatHandle struct {
-	cancel func()
-}
-
 type snapshotCache struct {
 	// watchCount and deltaWatchCount are atomic counters incremented for each watch respectively. They need to
 	// be the first fields in the struct to guarantee 64-bit alignment,
@@ -212,7 +208,9 @@ func (cache *snapshotCache) SetSnapshot(node string, snapshot Snapshot) error {
 			}
 		}
 
-		// We only calculate version hashes when using delta. We don't want to do this when using SOTW so we can avoid unecessary computational cost if not using delta.
+		// We only calculate version hashes when using delta. We don't
+		// want to do this when using SOTW so we can avoid unnecessary
+		// computational cost if not using delta.
 		if len(info.deltaWatches) > 0 {
 			err := snapshot.ConstructVersionMap()
 			if err != nil {

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -150,7 +150,7 @@ func NewSnapshotCacheWithHeartbeating(ctx context.Context, ads bool, hash NodeHa
 	return cache
 }
 
-func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
+func (cache *snapshotCache) sendHeartbeats(_ context.Context, node string) {
 	snapshot := cache.snapshots[node]
 	if info, ok := cache.status[node]; ok {
 		info.mu.Lock()
@@ -160,21 +160,21 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 			resources := snapshot.GetResourcesAndTtl(watch.Request.TypeUrl)
 
 			// TODO(snowp): Construct this once per type instead of once per watch.
-			resourcesWithTtl := map[string]types.ResourceWithTtl{}
+			resourcesWithTTL := map[string]types.ResourceWithTtl{}
 			for k, v := range resources {
 				if v.Ttl != nil {
-					resourcesWithTtl[k] = v
+					resourcesWithTTL[k] = v
 				}
 			}
 
-			if len(resourcesWithTtl) == 0 {
+			if len(resourcesWithTTL) == 0 {
 				continue
 			}
 			if cache.log != nil {
 				cache.log.Debugf("respond open watch %d%v with heartbeat for version %q", id, watch.Request.ResourceNames, version)
 			}
 
-			cache.respond(watch.Request, watch.Response, resourcesWithTtl, version, true)
+			cache.respond(watch.Request, watch.Response, resourcesWithTTL, version, true)
 
 			// The watch must be deleted and we must rely on the client to ack this response to create a new watch.
 			delete(info.watches, id)
@@ -417,7 +417,6 @@ func (cache *snapshotCache) CreateDeltaWatch(request *DeltaRequest, state stream
 		err := snapshot.ConstructVersionMap()
 		if err != nil {
 			cache.log.Errorf("failed to compute version for snapshot resources inline, waiting for next snapshot update")
-			delayedResponse = true
 		}
 		delayedResponse = respondDelta(request, value, state, snapshot, cache.log) == nil
 	}

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -66,15 +66,15 @@ func IndexRawResourcesByName(items []types.Resource) map[string]types.Resource {
 
 // NewResources creates a new resource group.
 func NewResources(version string, items []types.Resource) Resources {
-	itemsWithTtl := []types.ResourceWithTtl{}
+	itemsWithTTL := []types.ResourceWithTtl{}
 	for _, item := range items {
-		itemsWithTtl = append(itemsWithTtl, types.ResourceWithTtl{Resource: item})
+		itemsWithTTL = append(itemsWithTTL, types.ResourceWithTtl{Resource: item})
 	}
-	return NewResourcesWithTtl(version, itemsWithTtl)
+	return NewResourcesWithTtl(version, itemsWithTTL)
 }
 
 // NewResources creates a new resource group.
-func NewResourcesWithTtl(version string, items []types.ResourceWithTtl) Resources {
+func NewResourcesWithTtl(version string, items []types.ResourceWithTtl) Resources { // nolint:golint,revive
 	return Resources{
 		Version: version,
 		Items:   IndexResourcesByName(items),
@@ -137,9 +137,9 @@ func NewSnapshotWithResources(version string, resources SnapshotResources) Snaps
 	return out
 }
 
-type ResourceWithTtl struct {
+type ResourceWithTtl struct { // nolint:golint,revive
 	Resources []types.Resource
-	Ttl       *time.Duration
+	Ttl       *time.Duration // nolint:golint,revive
 }
 
 func NewSnapshotWithTtls(version string,
@@ -193,17 +193,17 @@ func (s *Snapshot) GetResources(typeURL string) map[string]types.Resource {
 		return nil
 	}
 
-	withoutTtl := make(map[string]types.Resource, len(resources))
+	withoutTTL := make(map[string]types.Resource, len(resources))
 
 	for k, v := range resources {
-		withoutTtl[k] = v.Resource
+		withoutTTL[k] = v.Resource
 	}
 
-	return withoutTtl
+	return withoutTTL
 }
 
 // GetResourcesAndTtl selects snapshot resources by type, returning the map of resources and the associated TTL.
-func (s *Snapshot) GetResourcesAndTtl(typeURL string) map[string]types.ResourceWithTtl {
+func (s *Snapshot) GetResourcesAndTtl(typeURL string) map[string]types.ResourceWithTtl { // nolint:golint,revive
 	if s == nil {
 		return nil
 	}

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -254,7 +254,7 @@ func (s *Snapshot) ConstructVersionMap() error {
 		}
 
 		for _, r := range resources.Items {
-			// hash our verison in here and build the version map
+			// hash our version in here and build the version map
 			marshaledResource, err := MarshalResource(r.Resource)
 			if err != nil {
 				return err

--- a/pkg/conversion/struct_test.go
+++ b/pkg/conversion/struct_test.go
@@ -36,10 +36,10 @@ func TestConversion(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 	pbst := map[string]*pstruct.Value{
-		"version_info": &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: "test"}},
-		"node": &pstruct.Value{Kind: &pstruct.Value_StructValue{StructValue: &pstruct.Struct{
+		"version_info": {Kind: &pstruct.Value_StringValue{StringValue: "test"}},
+		"node": {Kind: &pstruct.Value_StructValue{StructValue: &pstruct.Struct{
 			Fields: map[string]*pstruct.Value{
-				"id": &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: "proxy"}},
+				"id": {Kind: &pstruct.Value_StringValue{StringValue: "proxy"}},
 			},
 		}}},
 	}

--- a/pkg/integration/ttl_integration_test.go
+++ b/pkg/integration/ttl_integration_test.go
@@ -29,7 +29,7 @@ func (log logger) Infof(format string, args ...interface{})  { log.t.Logf(format
 func (log logger) Warnf(format string, args ...interface{})  { log.t.Logf(format, args...) }
 func (log logger) Errorf(format string, args ...interface{}) { log.t.Logf(format, args...) }
 
-func TestTtlResponse(t *testing.T) {
+func TestTTLResponse(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -41,11 +41,11 @@ func TestTtlResponse(t *testing.T) {
 	grpcServer := grpc.NewServer()
 	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
 
-	l, err := net.Listen("tcp", ":9999")
+	l, err := net.Listen("tcp", ":9999") // nolint:gosec
 	assert.NoError(t, err)
 
 	go func() {
-		grpcServer.Serve(l)
+		assert.NoError(t, grpcServer.Serve(l))
 	}()
 	defer grpcServer.Stop()
 

--- a/pkg/resource/v3/resource.go
+++ b/pkg/resource/v3/resource.go
@@ -43,7 +43,7 @@ func GetHTTPConnectionManager(filter *listener.Filter) *hcm.HttpConnectionManage
 
 	// use typed config if available
 	if typedConfig := filter.GetTypedConfig(); typedConfig != nil {
-		ptypes.UnmarshalAny(typedConfig, config)
+		_ = ptypes.UnmarshalAny(typedConfig, config)
 	}
 	return config
 }

--- a/pkg/resource/v3/resource.go
+++ b/pkg/resource/v3/resource.go
@@ -29,7 +29,7 @@ const (
 	FetchClusters         = "/v3/discovery:clusters"
 	FetchListeners        = "/v3/discovery:listeners"
 	FetchRoutes           = "/v3/discovery:routes"
-	FetchSecrets          = "/v3/discovery:secrets"
+	FetchSecrets          = "/v3/discovery:secrets" //nolint:gosec
 	FetchRuntimes         = "/v3/discovery:runtime"
 	FetchExtensionConfigs = "/v3/discovery:extension_configs"
 )

--- a/pkg/server/delta/v3/server.go
+++ b/pkg/server/delta/v3/server.go
@@ -173,7 +173,7 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 				watch.responses, watch.cancel = s.cache.CreateDeltaWatch(req, watch.state)
 
 				// Go does not allow for selecting over a dynamic set of channels
-				// so we introduce a termination chan to handle cancelling any watches.
+				// so we introduce a termination chan to handle canceling any watches.
 				terminate := make(chan struct{})
 				watch.termination = terminate
 				watches.deltaWatches[typeURL] = watch
@@ -183,7 +183,7 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 						if more {
 							watches.deltaMuxedResponses <- resp
 						} else {
-							// Check again if the watch is cancelled.
+							// Check again if the watch is canceled.
 							select {
 							case <-terminate: // do nothing
 							default:

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -157,7 +157,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 	}()
 
 	// sends a response by serializing to protobuf Any
-	send := func(resp cache.Response, typeURL string) (string, error) {
+	send := func(resp cache.Response) (string, error) {
 		if resp == nil {
 			return "", errors.New("missing response")
 		}
@@ -194,7 +194,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "endpoints watch failed")
 			}
-			nonce, err := send(resp, resource.EndpointType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -204,7 +204,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "clusters watch failed")
 			}
-			nonce, err := send(resp, resource.ClusterType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -214,7 +214,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "routes watch failed")
 			}
-			nonce, err := send(resp, resource.RouteType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "listeners watch failed")
 			}
-			nonce, err := send(resp, resource.ListenerType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -234,7 +234,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "secrets watch failed")
 			}
-			nonce, err := send(resp, resource.SecretType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -244,7 +244,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "runtimes watch failed")
 			}
-			nonce, err := send(resp, resource.RuntimeType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -255,12 +255,12 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 				if resp == errorResponse {
 					return status.Errorf(codes.Unavailable, "resource watch failed")
 				}
-				typeUrl := resp.GetRequest().TypeUrl
-				nonce, err := send(resp, typeUrl)
+				typeURL := resp.GetRequest().TypeUrl
+				nonce, err := send(resp)
 				if err != nil {
 					return err
 				}
-				values.nonces[typeUrl] = nonce
+				values.nonces[typeURL] = nonce
 			}
 
 		case req, more := <-reqCh:
@@ -348,13 +348,13 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 					values.runtimeCancel = s.cache.CreateWatch(req, values.runtimes)
 				}
 			default:
-				typeUrl := req.TypeUrl
-				responseNonce, seen := values.nonces[typeUrl]
+				typeURL := req.TypeUrl
+				responseNonce, seen := values.nonces[typeURL]
 				if !seen || responseNonce == nonce {
-					if cancel, seen := values.cancellations[typeUrl]; seen && cancel != nil {
+					if cancel, seen := values.cancellations[typeURL]; seen && cancel != nil {
 						cancel()
 					}
-					values.cancellations[typeUrl] = s.cache.CreateWatch(req, values.responses)
+					values.cancellations[typeURL] = s.cache.CreateWatch(req, values.responses)
 				}
 			}
 		}

--- a/pkg/server/stream/v3/stream.go
+++ b/pkg/server/stream/v3/stream.go
@@ -22,7 +22,7 @@ type DeltaStream interface {
 }
 
 // StreamState will keep track of resource state per type on a stream.
-type StreamState struct {
+type StreamState struct { // nolint:golint,revive
 	// Indicates whether the original DeltaRequest was a wildcard LDS/RDS request.
 	Wildcard bool
 

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -66,10 +66,10 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 	} else if config.closeWatch {
 		close(out)
 	} else {
-		config.deltaWatches += 1
+		config.deltaWatches++
 		return out, func() {
 			close(out)
-			config.deltaWatches -= 1
+			config.deltaWatches--
 		}
 	}
 

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -405,7 +405,7 @@ func TestDeltaCancellations(t *testing.T) {
 		t.Errorf("DeltaAggregatedResources() => got %v, want no error", err)
 	}
 	if config.watches != 0 {
-		t.Errorf("Expect all watches cancelled, got %q", config.watches)
+		t.Errorf("Expect all watches canceled, got %q", config.watches)
 	}
 }
 
@@ -425,7 +425,7 @@ func TestDeltaOpaqueRequestsChannelMuxing(t *testing.T) {
 		t.Errorf("DeltaAggregatedResources() => got %v, want no error", err)
 	}
 	if config.watches != 0 {
-		t.Errorf("Expect all watches cancelled, got %q", config.watches)
+		t.Errorf("Expect all watches canceled, got %q", config.watches)
 	}
 }
 

--- a/pkg/server/v3/gateway_test.go
+++ b/pkg/server/v3/gateway_test.go
@@ -100,7 +100,7 @@ func TestGateway(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, code, err := gtw.ServeHTTP(req)
+		resp, code, _ := gtw.ServeHTTP(req)
 		if resp != nil {
 			t.Errorf("handler returned wrong response")
 		}
@@ -114,7 +114,7 @@ func TestGateway(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, code, err := gtw.ServeHTTP(req)
+		resp, code, _ := gtw.ServeHTTP(req)
 		if resp == nil {
 			t.Errorf("handler returned wrong response")
 		}

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -52,9 +52,9 @@ func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, ou
 		out <- config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
 	} else {
-		config.watches += 1
+		config.watches++
 		return func() {
-			config.watches -= 1
+			config.watches--
 		}
 	}
 	return nil

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -577,7 +577,7 @@ func TestCancellations(t *testing.T) {
 		t.Errorf("StreamAggregatedResources() => got %v, want no error", err)
 	}
 	if config.watches != 0 {
-		t.Errorf("Expect all watches cancelled, got %q", config.watches)
+		t.Errorf("Expect all watches canceled, got %q", config.watches)
 	}
 }
 
@@ -598,7 +598,7 @@ func TestOpaqueRequestsChannelMuxing(t *testing.T) {
 		t.Errorf("StreamAggregatedResources() => got %v, want no error", err)
 	}
 	if config.watches != 0 {
-		t.Errorf("Expect all watches cancelled, got %q", config.watches)
+		t.Errorf("Expect all watches canceled, got %q", config.watches)
 	}
 }
 

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -151,7 +151,7 @@ func main() {
 	eds := cache.NewLinearCache(typeURL)
 	if mux {
 		configCache = &cache.MuxCache{
-			Classify: func(req cache.Request) string {
+			Classify: func(req cache.Request) string { // nolint:govet
 				if req.TypeUrl == typeURL {
 					return "eds"
 				}
@@ -211,7 +211,11 @@ func main() {
 
 		if mux {
 			for name, res := range snapshot.GetResources(typeURL) {
-				eds.UpdateResource(name, res)
+				if err := eds.UpdateResource(name, res); err != nil {
+					log.Printf("update error %q for %+v\n", err, name)
+					os.Exit(1)
+
+				}
 			}
 		}
 
@@ -259,7 +263,7 @@ func callEcho() (int, int) {
 			client := http.Client{
 				Timeout: 100 * time.Millisecond,
 				Transport: &http.Transport{
-					TLSClientConfig: &cryptotls.Config{InsecureSkipVerify: true},
+					TLSClientConfig: &cryptotls.Config{InsecureSkipVerify: true}, // nolint:gosec
 				},
 			}
 			proto := "http"
@@ -271,7 +275,7 @@ func callEcho() (int, int) {
 				ch <- err
 				return
 			}
-			defer req.Body.Close()
+			defer func() { _ = req.Body.Close() }()
 			body, err := ioutil.ReadAll(req.Body)
 			if err != nil {
 				ch <- err

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -111,7 +111,7 @@ func RunManagementGateway(ctx context.Context, srv server.Server, port uint, lg 
 	<-ctx.Done()
 
 	// Cleanup our gateway if we receive a shutdown
-	server.Shutdown(ctx)
+	_ = server.Shutdown(ctx)
 }
 
 func (h *HTTPGateway) ServeHTTP(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -86,9 +86,13 @@ const (
 	// ProxyProtocol listener filter
 	ProxyProtocol = "envoy.filters.listener.proxy_protocol"
 	// TlsInspector listener filter
-	TlsInspector = "envoy.filters.listener.tls_inspector"
+	TlsInspector = "envoy.filters.listener.tls_inspector" // nolint:golint,revive
+	// TLSInspector listener filter
+	TLSInspector = "envoy.filters.listener.tls_inspector" // nolint:golint,revive
 	// HttpInspector listener filter
-	HttpInspector = "envoy.filters.listener.http_inspector"
+	HttpInspector = "envoy.filters.listener.http_inspector" // nolint:golint,revive
+	// HTTPInspector listener filter
+	HTTPInspector = "envoy.filters.listener.http_inspector"
 )
 
 // Tracing provider names
@@ -130,7 +134,9 @@ const (
 	// TransportSocket RawBuffer
 	TransportSocketRawBuffer = "envoy.transport_sockets.raw_buffer"
 	// TransportSocket Tls
-	TransportSocketTls = "envoy.transport_sockets.tls"
+	TransportSocketTls = "envoy.transport_sockets.tls" // nolint:golint,revive
+	// TransportSocketTLS labels the "envoy.transport_sockets.tls" filter.
+	TransportSocketTLS = "envoy.transport_sockets.tls"
 	// TransportSocket Quic
 	TransportSocketQuic = "envoy.transport_sockets.quic"
 )


### PR DESCRIPTION
Add a "lint" target to the build that runs golangci-lint. This needs to
be run manually for now. CI can be wired up later once the issues are
fixed and there is consensus on the set of linters to run.

This updates #414.

Signed-off-by: James Peach <jpeach@apache.org>