### PR TITLE
Add golangci lint integration.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,3 +26,12 @@ linters-settings:
 issues:
   exclude:
   exclude-rules:
+  - text: "SA1019: package github.com/golang/protobuf/jsonpb is deprecated"
+    linters:
+    - staticcheck
+  - text: "SA1019: package github.com/golang/protobuf/proto is deprecated"
+    linters:
+    - staticcheck
+  - text: "SA1019: proto.MessageName is deprecated"
+    linters:
+    - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+  timeout: 10m
+
+linters:
+  enable:
+  - bodyclose
+  - gofmt
+  - goimports
+  - golint
+  - gosec
+  - misspell
+  - revive
+  - unconvert
+  - unparam
+
+linters-settings:
+  misspell:
+    locale: US
+  gofmt:
+    simplify: true
+  unparam:
+    check-exported: false
+  goimports:
+    local-prefixes: github.com/envoyproxy/go-control-plane
+
+issues:
+  exclude:
+  exclude-rules:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,15 @@ format:
 examples:
 	@pushd examples/dyplomat && go build ./... && popd
 
+.PHONY: lint
+lint:
+	docker run \
+		--rm \
+		--volume $$(pwd):/src \
+		--workdir /src \
+		golangci/golangci-lint:v1.41.1 \
+	golangci-lint run
+
 #-----------------
 #-- integration
 #-----------------

--- a/internal/example/main/main.go
+++ b/internal/example/main/main.go
@@ -25,12 +25,8 @@ import (
 )
 
 var (
-	l example.Logger
-
-	port     uint
-	basePort uint
-	mode     string
-
+	l      example.Logger
+	port   uint
 	nodeID string
 )
 

--- a/pkg/cache/types/types.go
+++ b/pkg/cache/types/types.go
@@ -12,10 +12,10 @@ type Resource interface {
 }
 
 // ResourceWithTtl is a Resource with an optional TTL.
-type ResourceWithTtl struct {
+type ResourceWithTtl struct { // nolint:golint,revive
 	Resource Resource
 
-	Ttl *time.Duration
+	Ttl *time.Duration // nolint:golint,revive
 }
 
 // MarshaledResource is an alias for the serialized binary array.

--- a/pkg/cache/types/types.go
+++ b/pkg/cache/types/types.go
@@ -11,11 +11,10 @@ type Resource interface {
 	proto.Message
 }
 
-// ResourceWithTtl is a Resource with an optional TTL.
-type ResourceWithTtl struct { // nolint:golint,revive
+// ResourceWithTTL is a Resource with an optional TTL.
+type ResourceWithTTL struct {
 	Resource Resource
-
-	Ttl *time.Duration // nolint:golint,revive
+	TTL      *time.Duration
 }
 
 // MarshaledResource is an alias for the serialized binary array.

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -121,7 +121,7 @@ type RawResponse struct {
 	Version string
 
 	// Resources to be included in the response.
-	Resources []types.ResourceWithTtl
+	Resources []types.ResourceWithTTL
 
 	// Whether this is a heartbeat response. For xDS versions that support TTL, this
 	// will be converted into a response that doesn't contain the actual resource protobuf.
@@ -306,11 +306,11 @@ func (r *RawDeltaResponse) GetContext() context.Context {
 
 var deltaResourceTypeURL = "type.googleapis.com/" + proto.MessageName(&discovery.Resource{})
 
-func (r *RawResponse) maybeCreateTTLResource(resource types.ResourceWithTtl) (types.Resource, string, error) {
-	if resource.Ttl != nil {
+func (r *RawResponse) maybeCreateTTLResource(resource types.ResourceWithTTL) (types.Resource, string, error) {
+	if resource.TTL != nil {
 		wrappedResource := &discovery.Resource{
 			Name: GetResourceName(resource.Resource),
-			Ttl:  ptypes.DurationProto(*resource.Ttl),
+			Ttl:  ptypes.DurationProto(*resource.TTL),
 		}
 
 		if !r.Heartbeat {

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -40,7 +40,7 @@ type DeltaRequest = discovery.DeltaDiscoveryRequest
 
 // ConfigWatcher requests watches for configuration resources by a node, last
 // applied version identifier, and resource names hint. The watch should send
-// the responses when they are ready. The watch can be cancelled by the
+// the responses when they are ready. The watch can be canceled by the
 // consumer, in effect terminating the watch for the request.
 // ConfigWatcher implementation must be thread-safe.
 type ConfigWatcher interface {
@@ -164,18 +164,18 @@ type RawDeltaResponse struct {
 var _ Response = &RawResponse{}
 var _ DeltaResponse = &RawDeltaResponse{}
 
-// PassthroughResponse is a pre constructed xDS response that need not go through marshalling transformations.
+// PassthroughResponse is a pre constructed xDS response that need not go through marshaling transformations.
 type PassthroughResponse struct {
 	// Request is the original request.
 	Request *discovery.DiscoveryRequest
 
-	// The discovery response that needs to be sent as is, without any marshalling transformations.
+	// The discovery response that needs to be sent as is, without any marshaling transformations.
 	DiscoveryResponse *discovery.DiscoveryResponse
 
 	ctx context.Context
 }
 
-// DeltaPassthroughResponse is a pre constructed xDS response that need not go through marshalling transformations.
+// DeltaPassthroughResponse is a pre constructed xDS response that need not go through marshaling transformations.
 type DeltaPassthroughResponse struct {
 	// Request is the latest delta request on the stream
 	DeltaRequest *discovery.DeltaDiscoveryRequest
@@ -183,7 +183,7 @@ type DeltaPassthroughResponse struct {
 	// NextVersionMap consists of updated version mappings after this response is applied
 	NextVersionMap map[string]string
 
-	// This discovery response that needs to be sent as is, without any marshalling transformations
+	// This discovery response that needs to be sent as is, without any marshaling transformations
 	DeltaDiscoveryResponse *discovery.DeltaDiscoveryResponse
 
 	ctx context.Context
@@ -192,9 +192,9 @@ type DeltaPassthroughResponse struct {
 var _ Response = &PassthroughResponse{}
 var _ DeltaResponse = &DeltaPassthroughResponse{}
 
-// GetDiscoveryResponse performs the marshalling the first time its called and uses the cached response subsequently.
-// This is necessary because the marshalled response does not change across the calls.
-// This caching behavior is important in high throughput scenarios because grpc marshalling has a cost and it drives the cpu utilization under load.
+// GetDiscoveryResponse performs the marshaling the first time its called and uses the cached response subsequently.
+// This is necessary because the marshaled response does not change across the calls.
+// This caching behavior is important in high throughput scenarios because grpc marshaling has a cost and it drives the cpu utilization under load.
 func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 
 	marshaledResponse := r.marshaledResponse.Load()
@@ -204,7 +204,7 @@ func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, erro
 		marshaledResources := make([]*any.Any, len(r.Resources))
 
 		for i, resource := range r.Resources {
-			maybeTtldResource, resourceType, err := r.maybeCreateTtlResource(resource)
+			maybeTtldResource, resourceType, err := r.maybeCreateTTLResource(resource)
 			if err != nil {
 				return nil, err
 			}
@@ -230,9 +230,9 @@ func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, erro
 	return marshaledResponse.(*discovery.DiscoveryResponse), nil
 }
 
-// GetDeltaDiscoveryResponse performs the marshalling the first time its called and uses the cached response subsequently.
-// We can do this because the marshalled response does not change across the calls.
-// This caching behavior is important in high throughput scenarios because grpc marshalling has a cost and it drives the cpu utilization under load.
+// GetDeltaDiscoveryResponse performs the marshaling the first time its called and uses the cached response subsequently.
+// We can do this because the marshaled response does not change across the calls.
+// This caching behavior is important in high throughput scenarios because grpc marshaling has a cost and it drives the cpu utilization under load.
 func (r *RawDeltaResponse) GetDeltaDiscoveryResponse() (*discovery.DeltaDiscoveryResponse, error) {
 	marshaledResponse := r.marshaledResponse.Load()
 
@@ -306,7 +306,7 @@ func (r *RawDeltaResponse) GetContext() context.Context {
 
 var deltaResourceTypeURL = "type.googleapis.com/" + proto.MessageName(&discovery.Resource{})
 
-func (r *RawResponse) maybeCreateTtlResource(resource types.ResourceWithTtl) (types.Resource, string, error) {
+func (r *RawResponse) maybeCreateTTLResource(resource types.ResourceWithTtl) (types.Resource, string, error) {
 	if resource.Ttl != nil {
 		wrappedResource := &discovery.Resource{
 			Name: GetResourceName(resource.Resource),

--- a/pkg/cache/v3/cache_test.go
+++ b/pkg/cache/v3/cache_test.go
@@ -19,7 +19,7 @@ const (
 )
 
 func TestResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []types.ResourceWithTtl{{Resource: &route.RouteConfiguration{Name: resourceName}}}
+	routes := []types.ResourceWithTTL{{Resource: &route.RouteConfiguration{Name: resourceName}}}
 	resp := cache.RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
@@ -68,7 +68,7 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 }
 
 func TestHeartbeatResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []types.ResourceWithTtl{{Resource: &route.RouteConfiguration{Name: resourceName}}}
+	routes := []types.ResourceWithTTL{{Resource: &route.RouteConfiguration{Name: resourceName}}}
 	resp := cache.RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",

--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -24,7 +24,7 @@ import (
 
 // Respond to a delta watch with the provided snapshot value. If the response is nil, there has been no state change.
 func respondDelta(ctx context.Context, request *DeltaRequest, value chan DeltaResponse, state stream.StreamState, snapshot Snapshot, log log.Logger) (*RawDeltaResponse, error) {
-	resp, err := createDeltaResponse(ctx, request, state, snapshot, log)
+	resp, err := createDeltaResponse(ctx, request, state, snapshot)
 	if err != nil {
 		if log != nil {
 			log.Errorf("Error creating delta response: %v", err)
@@ -33,7 +33,7 @@ func respondDelta(ctx context.Context, request *DeltaRequest, value chan DeltaRe
 	}
 
 	// Only send a response if there were changes
-	// We want to respond immediatly for the first wildcard request in a stream, even if the response is empty
+	// We want to respond immediately for the first wildcard request in a stream, even if the response is empty
 	// otherwise, envoy won't complete initialization
 	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 || (state.IsWildcard() && state.IsFirst()) {
 		if log != nil {
@@ -50,7 +50,8 @@ func respondDelta(ctx context.Context, request *DeltaRequest, value chan DeltaRe
 	return nil, nil
 }
 
-func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.StreamState, snapshot Snapshot, log log.Logger) (*RawDeltaResponse, error) {
+// nolint:unparam // result 1 (error) is always nil (unparam)
+func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.StreamState, snapshot Snapshot) (*RawDeltaResponse, error) {
 	resources := snapshot.GetResources((req.TypeUrl))
 
 	// variables to build our response with

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -165,7 +165,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 
 		// make sure the version maps are different since we no longer are tracking any endpoint resources
 		if reflect.DeepEqual(streams[testTypes[0]].GetResourceVersions(), nextVersionMap) {
-			t.Fatalf("versionMap for the endpoint resource type did not change, received: %v, instead of an emtpy map", nextVersionMap)
+			t.Fatalf("versionMap for the endpoint resource type did not change, received: %v, instead of an empty map", nextVersionMap)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -92,19 +92,19 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 }
 
 func (cache *LinearCache) respond(value chan Response, staleResources []string) {
-	var resources []types.ResourceWithTtl
+	var resources []types.ResourceWithTTL
 	// TODO: optimize the resources slice creations across different clients
 	if len(staleResources) == 0 {
-		resources = make([]types.ResourceWithTtl, 0, len(cache.resources))
+		resources = make([]types.ResourceWithTTL, 0, len(cache.resources))
 		for _, resource := range cache.resources {
-			resources = append(resources, types.ResourceWithTtl{Resource: resource})
+			resources = append(resources, types.ResourceWithTTL{Resource: resource})
 		}
 	} else {
-		resources = make([]types.ResourceWithTtl, 0, len(staleResources))
+		resources = make([]types.ResourceWithTTL, 0, len(staleResources))
 		for _, name := range staleResources {
 			resource := cache.resources[name]
 			if resource != nil {
-				resources = append(resources, types.ResourceWithTtl{Resource: resource})
+				resources = append(resources, types.ResourceWithTTL{Resource: resource})
 			}
 		}
 	}

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -27,7 +27,7 @@ import (
 
 type watches = map[chan Response]struct{}
 
-// LinearCache supports collectons of opaque resources. This cache has a
+// LinearCache supports collections of opaque resources. This cache has a
 // single collection indexed by resource names and manages resource versions
 // internally. It implements the cache interface for a single type URL and
 // should be combined with other caches via type URL muxing. It can be used to
@@ -42,7 +42,7 @@ type LinearCache struct {
 	watches map[string]watches
 	// Set of watches for all resources in the collection
 	watchAll watches
-	// Continously incremented version
+	// Continuously incremented version.
 	version uint64
 	// Version prefix to be sent to the clients
 	versionPrefix string
@@ -141,7 +141,7 @@ func (cache *LinearCache) UpdateResource(name string, res types.Resource) error 
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	cache.version += 1
+	cache.version++
 	cache.versionVector[name] = cache.version
 	cache.resources[name] = res
 
@@ -156,7 +156,7 @@ func (cache *LinearCache) DeleteResource(name string) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	cache.version += 1
+	cache.version++
 	delete(cache.versionVector, name)
 	delete(cache.resources, name)
 
@@ -172,7 +172,7 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	cache.version += 1
+	cache.version++
 
 	modified := map[string]struct{}{}
 	// Collect deleted resource names.

--- a/pkg/cache/v3/mux.go
+++ b/pkg/cache/v3/mux.go
@@ -37,6 +37,16 @@ type MuxCache struct {
 var _ Cache = &MuxCache{}
 
 func (mux *MuxCache) CreateWatch(request *Request, value chan Response) func() {
+	// Passing a Request by value to Classify triggers a govet copylocks
+	// error. This is because protobuf messages specifically embed
+	// a Mutex in order to trigger this check (i.e. not for actually
+	// locking fields).
+	//
+	// So in this specific case, it happens to be safe to copy the
+	// lock. Fixing this would require adding a new API to classify
+	// requests, and deprecating Classify.
+	//
+	// nolint:govet
 	key := mux.Classify(*request)
 	cache, exists := mux.Caches[key]
 	if !exists {
@@ -46,7 +56,7 @@ func (mux *MuxCache) CreateWatch(request *Request, value chan Response) func() {
 	return cache.CreateWatch(request, value)
 }
 
-func (cache *MuxCache) CreateDeltaWatch(request *DeltaRequest, state stream.StreamState, value chan DeltaResponse) func() {
+func (mux *MuxCache) CreateDeltaWatch(request *DeltaRequest, state stream.StreamState, value chan DeltaResponse) func() {
 	return nil
 }
 

--- a/pkg/cache/v3/mux.go
+++ b/pkg/cache/v3/mux.go
@@ -29,7 +29,7 @@ import (
 // making sure there is always a matching cache.
 type MuxCache struct {
 	// Classification functions.
-	Classify func(Request) string
+	Classify func(*Request) string
 	// Muxed caches.
 	Caches map[string]Cache
 }
@@ -37,17 +37,7 @@ type MuxCache struct {
 var _ Cache = &MuxCache{}
 
 func (mux *MuxCache) CreateWatch(request *Request, value chan Response) func() {
-	// Passing a Request by value to Classify triggers a govet copylocks
-	// error. This is because protobuf messages specifically embed
-	// a Mutex in order to trigger this check (i.e. not for actually
-	// locking fields).
-	//
-	// So in this specific case, it happens to be safe to copy the
-	// lock. Fixing this would require adding a new API to classify
-	// requests, and deprecating Classify.
-	//
-	// nolint:govet
-	key := mux.Classify(*request)
+	key := mux.Classify(request)
 	cache, exists := mux.Caches[key]
 	if !exists {
 		value <- nil

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -113,7 +113,7 @@ func MarshalResource(resource types.Resource) (types.MarshaledResource, error) {
 
 // GetResourceReferences returns the names for dependent resources (EDS cluster
 // names for CDS, RDS routes names for LDS).
-func GetResourceReferences(resources map[string]types.ResourceWithTtl) map[string]bool {
+func GetResourceReferences(resources map[string]types.ResourceWithTTL) map[string]bool {
 	out := make(map[string]bool)
 	for _, res := range resources {
 		if res.Resource == nil {

--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -139,7 +139,7 @@ func TestGetResourceReferences(t *testing.T) {
 		},
 	}
 	for _, cs := range cases {
-		names := cache.GetResourceReferences(cache.IndexResourcesByName([]types.ResourceWithTtl{{Resource: cs.in}}))
+		names := cache.GetResourceReferences(cache.IndexResourcesByName([]types.ResourceWithTTL{{Resource: cs.in}}))
 		if !reflect.DeepEqual(names, cs.out) {
 			t.Errorf("GetResourceReferences(%v) => got %v, want %v", cs.in, names, cs.out)
 		}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -160,9 +160,9 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 			resources := snapshot.GetResourcesAndTtl(watch.Request.TypeUrl)
 
 			// TODO(snowp): Construct this once per type instead of once per watch.
-			resourcesWithTTL := map[string]types.ResourceWithTtl{}
+			resourcesWithTTL := map[string]types.ResourceWithTTL{}
 			for k, v := range resources {
-				if v.Ttl != nil {
+				if v.TTL != nil {
 					resourcesWithTTL[k] = v
 				}
 			}
@@ -174,7 +174,7 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 				cache.log.Debugf("respond open watch %d%v with heartbeat for version %q", id, watch.Request.ResourceNames, version)
 			}
 
-			cache.respond(ctx, watch.Request, watch.Response, resourcesWithTtl, version, true)
+			cache.respond(ctx, watch.Request, watch.Response, resourcesWithTTL, version, true)
 
 			// The watch must be deleted and we must rely on the client to ack this response to create a new watch.
 			delete(info.watches, id)
@@ -277,7 +277,7 @@ func nameSet(names []string) map[string]bool {
 }
 
 // superset checks that all resources are listed in the names set.
-func superset(names map[string]bool, resources map[string]types.ResourceWithTtl) error {
+func superset(names map[string]bool, resources map[string]types.ResourceWithTTL) error {
 	for resourceName := range resources {
 		if _, exists := names[resourceName]; !exists {
 			return fmt.Errorf("%q not listed", resourceName)
@@ -347,7 +347,7 @@ func (cache *snapshotCache) cancelWatch(nodeID string, watchID int64) func() {
 
 // Respond to a watch with the snapshot value. The value channel should have capacity not to block.
 // TODO(kuat) do not respond always, see issue https://github.com/envoyproxy/go-control-plane/issues/46
-func (cache *snapshotCache) respond(ctx context.Context, request *Request, value chan Response, resources map[string]types.ResourceWithTtl, version string, heartbeat bool) error {
+func (cache *snapshotCache) respond(ctx context.Context, request *Request, value chan Response, resources map[string]types.ResourceWithTTL, version string, heartbeat bool) error {
 	// for ADS, the request names must match the snapshot names
 	// if they do not, then the watch is never responded, and it is expected that envoy makes another request
 	if len(request.ResourceNames) != 0 && cache.ads {
@@ -371,8 +371,8 @@ func (cache *snapshotCache) respond(ctx context.Context, request *Request, value
 	}
 }
 
-func createResponse(ctx context.Context, request *Request, resources map[string]types.ResourceWithTtl, version string, heartbeat bool) Response {
-	filtered := make([]types.ResourceWithTtl, 0, len(resources))
+func createResponse(ctx context.Context, request *Request, resources map[string]types.ResourceWithTTL, version string, heartbeat bool) Response {
+	filtered := make([]types.ResourceWithTTL, 0, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
 	// individually in a separate stream. It is ok to reply with the same version

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -174,7 +174,7 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 				cache.log.Debugf("respond open watch %d%v with heartbeat for version %q", id, watch.Request.ResourceNames, version)
 			}
 
-			cache.respond(ctx, watch.Request, watch.Response, resourcesWithTTL, version, true)
+			_ = cache.respond(ctx, watch.Request, watch.Response, resourcesWithTTL, version, true)
 
 			// The watch must be deleted and we must rely on the client to ack this response to create a new watch.
 			delete(info.watches, id)
@@ -322,7 +322,7 @@ func (cache *snapshotCache) CreateWatch(request *Request, value chan Response) f
 
 	// otherwise, the watch may be responded immediately
 	resources := snapshot.GetResourcesAndTtl(request.TypeUrl)
-	cache.respond(context.Background(), request, value, resources, version, false)
+	_ = cache.respond(context.Background(), request, value, resources, version, false)
 
 	return nil
 }
@@ -432,7 +432,6 @@ func (cache *snapshotCache) CreateDeltaWatch(request *DeltaRequest, state stream
 		response, err := respondDelta(context.Background(), request, value, state, snapshot, cache.log)
 		if err != nil {
 			cache.log.Errorf("failed to respond with delta response, waiting for next snapshot update: %s", err)
-			delayedResponse = true
 		}
 
 		delayedResponse = response == nil

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -61,12 +61,12 @@ var (
 	ttl = 2 * time.Second
 
 	snapshotWithTTL = cache.NewSnapshotWithTtls(version,
-		[]types.ResourceWithTtl{{Resource: testEndpoint, Ttl: &ttl}},
-		[]types.ResourceWithTtl{{Resource: testCluster}},
-		[]types.ResourceWithTtl{{Resource: testRoute}},
-		[]types.ResourceWithTtl{{Resource: testListener}},
-		[]types.ResourceWithTtl{{Resource: testRuntime}},
-		[]types.ResourceWithTtl{{Resource: testSecret[0]}})
+		[]types.ResourceWithTTL{{Resource: testEndpoint, TTL: &ttl}},
+		[]types.ResourceWithTTL{{Resource: testCluster}},
+		[]types.ResourceWithTTL{{Resource: testRoute}},
+		[]types.ResourceWithTTL{{Resource: testListener}},
+		[]types.ResourceWithTTL{{Resource: testRuntime}},
+		[]types.ResourceWithTTL{{Resource: testSecret[0]}})
 
 	names = map[string][]string{
 		rsrc.EndpointType: {clusterName},

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -66,15 +66,15 @@ func IndexRawResourcesByName(items []types.Resource) map[string]types.Resource {
 
 // NewResources creates a new resource group.
 func NewResources(version string, items []types.Resource) Resources {
-	itemsWithTtl := []types.ResourceWithTtl{}
+	itemsWithTTL := []types.ResourceWithTtl{}
 	for _, item := range items {
-		itemsWithTtl = append(itemsWithTtl, types.ResourceWithTtl{Resource: item})
+		itemsWithTTL = append(itemsWithTTL, types.ResourceWithTtl{Resource: item})
 	}
-	return NewResourcesWithTtl(version, itemsWithTtl)
+	return NewResourcesWithTtl(version, itemsWithTTL)
 }
 
 // NewResources creates a new resource group.
-func NewResourcesWithTtl(version string, items []types.ResourceWithTtl) Resources {
+func NewResourcesWithTtl(version string, items []types.ResourceWithTtl) Resources { // nolint:golint,revive
 	return Resources{
 		Version: version,
 		Items:   IndexResourcesByName(items),
@@ -139,9 +139,9 @@ func NewSnapshotWithResources(version string, resources SnapshotResources) Snaps
 	return out
 }
 
-type ResourceWithTtl struct {
+type ResourceWithTtl struct { // nolint:golint,revive
 	Resources []types.Resource
-	Ttl       *time.Duration
+	Ttl       *time.Duration // nolint:golint,revive
 }
 
 func NewSnapshotWithTtls(version string,
@@ -195,17 +195,17 @@ func (s *Snapshot) GetResources(typeURL string) map[string]types.Resource {
 		return nil
 	}
 
-	withoutTtl := make(map[string]types.Resource, len(resources))
+	withoutTTL := make(map[string]types.Resource, len(resources))
 
 	for k, v := range resources {
-		withoutTtl[k] = v.Resource
+		withoutTTL[k] = v.Resource
 	}
 
-	return withoutTtl
+	return withoutTTL
 }
 
 // GetResourcesAndTtl selects snapshot resources by type, returning the map of resources and the associated TTL.
-func (s *Snapshot) GetResourcesAndTtl(typeURL string) map[string]types.ResourceWithTtl {
+func (s *Snapshot) GetResourcesAndTtl(typeURL string) map[string]types.ResourceWithTtl { // nolint:golint,revive
 	if s == nil {
 		return nil
 	}
@@ -256,7 +256,7 @@ func (s *Snapshot) ConstructVersionMap() error {
 		}
 
 		for _, r := range resources.Items {
-			// hash our verison in here and build the version map
+			// hash our version in here and build the version map
 			marshaledResource, err := MarshalResource(r.Resource)
 			if err != nil {
 				return err

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -17,7 +17,6 @@ package cache
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
@@ -28,7 +27,7 @@ type Resources struct {
 	Version string
 
 	// Items in the group indexed by name.
-	Items map[string]types.ResourceWithTtl
+	Items map[string]types.ResourceWithTTL
 }
 
 // DeltaResources is a versioned group of resources which also contains individual resource versions per the incremental xDS protocol
@@ -43,12 +42,12 @@ type DeltaResources struct {
 // resourceItems contain the lower level versioned resource map
 type resourceItems struct {
 	Version string
-	Items   map[string]types.ResourceWithTtl
+	Items   map[string]types.ResourceWithTTL
 }
 
 // IndexResourcesByName creates a map from the resource name to the resource.
-func IndexResourcesByName(items []types.ResourceWithTtl) map[string]types.ResourceWithTtl {
-	indexed := make(map[string]types.ResourceWithTtl)
+func IndexResourcesByName(items []types.ResourceWithTTL) map[string]types.ResourceWithTTL {
+	indexed := make(map[string]types.ResourceWithTTL)
 	for _, item := range items {
 		indexed[GetResourceName(item.Resource)] = item
 	}
@@ -66,15 +65,15 @@ func IndexRawResourcesByName(items []types.Resource) map[string]types.Resource {
 
 // NewResources creates a new resource group.
 func NewResources(version string, items []types.Resource) Resources {
-	itemsWithTTL := []types.ResourceWithTtl{}
+	itemsWithTTL := []types.ResourceWithTTL{}
 	for _, item := range items {
-		itemsWithTTL = append(itemsWithTTL, types.ResourceWithTtl{Resource: item})
+		itemsWithTTL = append(itemsWithTTL, types.ResourceWithTTL{Resource: item})
 	}
 	return NewResourcesWithTtl(version, itemsWithTTL)
 }
 
 // NewResources creates a new resource group.
-func NewResourcesWithTtl(version string, items []types.ResourceWithTtl) Resources { // nolint:golint,revive
+func NewResourcesWithTtl(version string, items []types.ResourceWithTTL) Resources { // nolint:golint,revive
 	return Resources{
 		Version: version,
 		Items:   IndexResourcesByName(items),
@@ -139,18 +138,13 @@ func NewSnapshotWithResources(version string, resources SnapshotResources) Snaps
 	return out
 }
 
-type ResourceWithTtl struct { // nolint:golint,revive
-	Resources []types.Resource
-	Ttl       *time.Duration // nolint:golint,revive
-}
-
 func NewSnapshotWithTtls(version string,
-	endpoints []types.ResourceWithTtl,
-	clusters []types.ResourceWithTtl,
-	routes []types.ResourceWithTtl,
-	listeners []types.ResourceWithTtl,
-	runtimes []types.ResourceWithTtl,
-	secrets []types.ResourceWithTtl) Snapshot {
+	endpoints []types.ResourceWithTTL,
+	clusters []types.ResourceWithTTL,
+	routes []types.ResourceWithTTL,
+	listeners []types.ResourceWithTTL,
+	runtimes []types.ResourceWithTTL,
+	secrets []types.ResourceWithTTL) Snapshot {
 	out := Snapshot{}
 	out.Resources[types.Endpoint] = NewResourcesWithTtl(version, endpoints)
 	out.Resources[types.Cluster] = NewResourcesWithTtl(version, clusters)
@@ -205,7 +199,7 @@ func (s *Snapshot) GetResources(typeURL string) map[string]types.Resource {
 }
 
 // GetResourcesAndTtl selects snapshot resources by type, returning the map of resources and the associated TTL.
-func (s *Snapshot) GetResourcesAndTtl(typeURL string) map[string]types.ResourceWithTtl { // nolint:golint,revive
+func (s *Snapshot) GetResourcesAndTtl(typeURL string) map[string]types.ResourceWithTTL { // nolint:golint,revive
 	if s == nil {
 		return nil
 	}
@@ -256,7 +250,7 @@ func (s *Snapshot) ConstructVersionMap() error {
 		}
 
 		for _, r := range resources.Items {
-			// hash our version in here and build the version map
+			// Hash our version in here and build the version map.
 			marshaledResource, err := MarshalResource(r.Resource)
 			if err != nil {
 				return err

--- a/pkg/conversion/struct_test.go
+++ b/pkg/conversion/struct_test.go
@@ -36,10 +36,10 @@ func TestConversion(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 	pbst := map[string]*pstruct.Value{
-		"version_info": &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: "test"}},
-		"node": &pstruct.Value{Kind: &pstruct.Value_StructValue{StructValue: &pstruct.Struct{
+		"version_info": {Kind: &pstruct.Value_StringValue{StringValue: "test"}},
+		"node": {Kind: &pstruct.Value_StructValue{StructValue: &pstruct.Struct{
 			Fields: map[string]*pstruct.Value{
-				"id": &pstruct.Value{Kind: &pstruct.Value_StringValue{StringValue: "proxy"}},
+				"id": {Kind: &pstruct.Value_StringValue{StringValue: "proxy"}},
 			},
 		}}},
 	}

--- a/pkg/integration/ttl_integration_test.go
+++ b/pkg/integration/ttl_integration_test.go
@@ -29,7 +29,7 @@ func (log logger) Infof(format string, args ...interface{})  { log.t.Logf(format
 func (log logger) Warnf(format string, args ...interface{})  { log.t.Logf(format, args...) }
 func (log logger) Errorf(format string, args ...interface{}) { log.t.Logf(format, args...) }
 
-func TestTtlResponse(t *testing.T) {
+func TestTTLResponse(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -41,11 +41,11 @@ func TestTtlResponse(t *testing.T) {
 	grpcServer := grpc.NewServer()
 	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
 
-	l, err := net.Listen("tcp", ":9999")
+	l, err := net.Listen("tcp", ":9999") // nolint:gosec
 	assert.NoError(t, err)
 
 	go func() {
-		grpcServer.Serve(l)
+		assert.NoError(t, grpcServer.Serve(l))
 	}()
 	defer grpcServer.Stop()
 

--- a/pkg/integration/ttl_integration_test.go
+++ b/pkg/integration/ttl_integration_test.go
@@ -67,9 +67,9 @@ func TestTTLResponse(t *testing.T) {
 
 	oneSecond := time.Second
 	cla := &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "resource"}
-	err = snapshotCache.SetSnapshot(context.Background(), "test", cache.NewSnapshotWithTtls("1", []types.ResourceWithTtl{{
+	err = snapshotCache.SetSnapshot(context.Background(), "test", cache.NewSnapshotWithTtls("1", []types.ResourceWithTTL{{
 		Resource: cla,
-		Ttl:      &oneSecond,
+		TTL:      &oneSecond,
 	}}, nil, nil, nil, nil, nil))
 	assert.NoError(t, err)
 

--- a/pkg/resource/v3/resource.go
+++ b/pkg/resource/v3/resource.go
@@ -29,7 +29,7 @@ const (
 	FetchClusters         = "/v3/discovery:clusters"
 	FetchListeners        = "/v3/discovery:listeners"
 	FetchRoutes           = "/v3/discovery:routes"
-	FetchSecrets          = "/v3/discovery:secrets"
+	FetchSecrets          = "/v3/discovery:secrets" //nolint:gosec
 	FetchRuntimes         = "/v3/discovery:runtime"
 	FetchExtensionConfigs = "/v3/discovery:extension_configs"
 )
@@ -43,7 +43,7 @@ func GetHTTPConnectionManager(filter *listener.Filter) *hcm.HttpConnectionManage
 
 	// use typed config if available
 	if typedConfig := filter.GetTypedConfig(); typedConfig != nil {
-		ptypes.UnmarshalAny(typedConfig, config)
+		_ = ptypes.UnmarshalAny(typedConfig, config)
 	}
 	return config
 }

--- a/pkg/resource/v3/resource.go
+++ b/pkg/resource/v3/resource.go
@@ -37,13 +37,16 @@ const (
 // DefaultAPIVersion is the api version
 const DefaultAPIVersion = core.ApiVersion_V3
 
-// GetHTTPConnectionManager creates a HttpConnectionManager from filter
+// GetHTTPConnectionManager creates a HttpConnectionManager
+// from filter. Returns nil if the filter doesn't have a valid
+// HttpConnectionManager configuration.
 func GetHTTPConnectionManager(filter *listener.Filter) *hcm.HttpConnectionManager {
-	config := &hcm.HttpConnectionManager{}
-
-	// use typed config if available
 	if typedConfig := filter.GetTypedConfig(); typedConfig != nil {
-		_ = ptypes.UnmarshalAny(typedConfig, config)
+		config := &hcm.HttpConnectionManager{}
+		if err := ptypes.UnmarshalAny(typedConfig, config); err == nil {
+			return config
+		}
 	}
-	return config
+
+	return nil
 }

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -163,7 +163,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 	}()
 
 	// sends a response by serializing to protobuf Any
-	send := func(resp cache.Response, typeURL string) (string, error) {
+	send := func(resp cache.Response) (string, error) {
 		if resp == nil {
 			return "", errors.New("missing response")
 		}
@@ -200,7 +200,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "endpoints watch failed")
 			}
-			nonce, err := send(resp, resource.EndpointType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -210,7 +210,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "clusters watch failed")
 			}
-			nonce, err := send(resp, resource.ClusterType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -220,7 +220,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "routes watch failed")
 			}
-			nonce, err := send(resp, resource.RouteType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -230,7 +230,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "listeners watch failed")
 			}
-			nonce, err := send(resp, resource.ListenerType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -240,7 +240,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "secrets watch failed")
 			}
-			nonce, err := send(resp, resource.SecretType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -250,7 +250,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "runtimes watch failed")
 			}
-			nonce, err := send(resp, resource.RuntimeType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -260,7 +260,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 			if !more {
 				return status.Errorf(codes.Unavailable, "extensionConfigs watch failed")
 			}
-			nonce, err := send(resp, resource.ExtensionConfigType)
+			nonce, err := send(resp)
 			if err != nil {
 				return err
 			}
@@ -271,12 +271,12 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 				if resp == errorResponse {
 					return status.Errorf(codes.Unavailable, "resource watch failed")
 				}
-				typeUrl := resp.GetRequest().TypeUrl
-				nonce, err := send(resp, typeUrl)
+				typeURL := resp.GetRequest().TypeUrl
+				nonce, err := send(resp)
 				if err != nil {
 					return err
 				}
-				values.nonces[typeUrl] = nonce
+				values.nonces[typeURL] = nonce
 			}
 
 		case req, more := <-reqCh:
@@ -372,13 +372,13 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 					values.extensionConfigCancel = s.cache.CreateWatch(req, values.extensionConfigs)
 				}
 			default:
-				typeUrl := req.TypeUrl
-				responseNonce, seen := values.nonces[typeUrl]
+				typeURL := req.TypeUrl
+				responseNonce, seen := values.nonces[typeURL]
 				if !seen || responseNonce == nonce {
-					if cancel, seen := values.cancellations[typeUrl]; seen && cancel != nil {
+					if cancel, seen := values.cancellations[typeURL]; seen && cancel != nil {
 						cancel()
 					}
-					values.cancellations[typeUrl] = s.cache.CreateWatch(req, values.responses)
+					values.cancellations[typeURL] = s.cache.CreateWatch(req, values.responses)
 				}
 			}
 		}

--- a/pkg/server/stream/v3/stream.go
+++ b/pkg/server/stream/v3/stream.go
@@ -22,7 +22,7 @@ type DeltaStream interface {
 }
 
 // StreamState will keep track of resource state per type on a stream.
-type StreamState struct {
+type StreamState struct { // nolint:golint,revive
 	// Indicates whether the original DeltaRequest was a wildcard LDS/RDS request.
 	wildcard bool
 

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -61,9 +61,9 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 			NextVersionMap:    state.GetResourceVersions(),
 		}
 	} else {
-		config.deltaWatches += 1
+		config.deltaWatches++
 		return func() {
-			config.deltaWatches -= 1
+			config.deltaWatches--
 		}
 	}
 
@@ -386,7 +386,7 @@ func TestDeltaCancellations(t *testing.T) {
 		t.Errorf("DeltaAggregatedResources() => got %v, want no error", err)
 	}
 	if config.watches != 0 {
-		t.Errorf("Expect all watches cancelled, got %q", config.watches)
+		t.Errorf("Expect all watches canceled, got %q", config.watches)
 	}
 }
 
@@ -406,7 +406,7 @@ func TestDeltaOpaqueRequestsChannelMuxing(t *testing.T) {
 		t.Errorf("DeltaAggregatedResources() => got %v, want no error", err)
 	}
 	if config.watches != 0 {
-		t.Errorf("Expect all watches cancelled, got %q", config.watches)
+		t.Errorf("Expect all watches canceled, got %q", config.watches)
 	}
 }
 

--- a/pkg/server/v3/gateway_test.go
+++ b/pkg/server/v3/gateway_test.go
@@ -100,7 +100,7 @@ func TestGateway(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, code, err := gtw.ServeHTTP(req)
+		resp, code, _ := gtw.ServeHTTP(req)
 		if resp != nil {
 			t.Errorf("handler returned wrong response")
 		}
@@ -114,7 +114,7 @@ func TestGateway(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, code, err := gtw.ServeHTTP(req)
+		resp, code, _ := gtw.ServeHTTP(req)
 		if resp == nil {
 			t.Errorf("handler returned wrong response")
 		}

--- a/pkg/server/v3/gateway_test.go
+++ b/pkg/server/v3/gateway_test.go
@@ -44,21 +44,21 @@ func TestGateway(t *testing.T) {
 		resource.ClusterType: {
 			&cache.RawResponse{
 				Version:   "2",
-				Resources: []types.ResourceWithTtl{{Resource: cluster}},
+				Resources: []types.ResourceWithTTL{{Resource: cluster}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: resource.ClusterType},
 			},
 		},
 		resource.RouteType: {
 			&cache.RawResponse{
 				Version:   "3",
-				Resources: []types.ResourceWithTtl{{Resource: route}},
+				Resources: []types.ResourceWithTTL{{Resource: route}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 			},
 		},
 		resource.ListenerType: {
 			&cache.RawResponse{
 				Version:   "4",
-				Resources: []types.ResourceWithTtl{{Resource: listener}},
+				Resources: []types.ResourceWithTTL{{Resource: listener}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: resource.ListenerType},
 			},
 		},
@@ -100,7 +100,10 @@ func TestGateway(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, code, _ := gtw.ServeHTTP(req)
+		resp, code, err := gtw.ServeHTTP(req)
+		if err == nil {
+			t.Errorf("ServeHTTP succeeded, but should have failed")
+		}
 		if resp != nil {
 			t.Errorf("handler returned wrong response")
 		}
@@ -114,7 +117,10 @@ func TestGateway(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, code, _ := gtw.ServeHTTP(req)
+		resp, code, err := gtw.ServeHTTP(req)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if resp == nil {
 			t.Errorf("handler returned wrong response")
 		}

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -39,7 +39,6 @@ type mockConfigWatcher struct {
 	deltaCounts    map[string]int
 	responses      map[string][]cache.Response
 	deltaResponses map[string][]cache.DeltaResponse
-	closeWatch     bool
 	watches        int
 	deltaWatches   int
 
@@ -52,9 +51,9 @@ func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, ou
 		out <- config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
 	} else {
-		config.watches += 1
+		config.watches++
 		return func() {
-			config.watches -= 1
+			config.watches--
 		}
 	}
 	return nil
@@ -597,7 +596,7 @@ func TestCancellations(t *testing.T) {
 		t.Errorf("StreamAggregatedResources() => got %v, want no error", err)
 	}
 	if config.watches != 0 {
-		t.Errorf("Expect all watches cancelled, got %q", config.watches)
+		t.Errorf("Expect all watches canceled, got %q", config.watches)
 	}
 }
 
@@ -618,7 +617,7 @@ func TestOpaqueRequestsChannelMuxing(t *testing.T) {
 		t.Errorf("StreamAggregatedResources() => got %v, want no error", err)
 	}
 	if config.watches != 0 {
-		t.Errorf("Expect all watches cancelled, got %q", config.watches)
+		t.Errorf("Expect all watches canceled, got %q", config.watches)
 	}
 }
 

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -177,49 +177,49 @@ func makeResponses() map[string][]cache.Response {
 		rsrc.EndpointType: {
 			&cache.RawResponse{
 				Version:   "1",
-				Resources: []types.ResourceWithTtl{{Resource: endpoint}},
+				Resources: []types.ResourceWithTTL{{Resource: endpoint}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
 			},
 		},
 		rsrc.ClusterType: {
 			&cache.RawResponse{
 				Version:   "2",
-				Resources: []types.ResourceWithTtl{{Resource: cluster}},
+				Resources: []types.ResourceWithTTL{{Resource: cluster}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
 			},
 		},
 		rsrc.RouteType: {
 			&cache.RawResponse{
 				Version:   "3",
-				Resources: []types.ResourceWithTtl{{Resource: route}},
+				Resources: []types.ResourceWithTTL{{Resource: route}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
 			},
 		},
 		rsrc.ListenerType: {
 			&cache.RawResponse{
 				Version:   "4",
-				Resources: []types.ResourceWithTtl{{Resource: listener}},
+				Resources: []types.ResourceWithTTL{{Resource: listener}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
 			},
 		},
 		rsrc.SecretType: {
 			&cache.RawResponse{
 				Version:   "5",
-				Resources: []types.ResourceWithTtl{{Resource: secret}},
+				Resources: []types.ResourceWithTTL{{Resource: secret}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
 			},
 		},
 		rsrc.RuntimeType: {
 			&cache.RawResponse{
 				Version:   "6",
-				Resources: []types.ResourceWithTtl{{Resource: runtime}},
+				Resources: []types.ResourceWithTTL{{Resource: runtime}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
 			},
 		},
 		rsrc.ExtensionConfigType: {
 			&cache.RawResponse{
 				Version:   "7",
-				Resources: []types.ResourceWithTtl{{Resource: extensionConfig}},
+				Resources: []types.ResourceWithTTL{{Resource: extensionConfig}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
 			},
 		},
@@ -227,7 +227,7 @@ func makeResponses() map[string][]cache.Response {
 		opaqueType: {
 			&cache.RawResponse{
 				Version:   "8",
-				Resources: []types.ResourceWithTtl{{Resource: opaque}},
+				Resources: []types.ResourceWithTTL{{Resource: opaque}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: opaqueType},
 			},
 		},

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -176,7 +176,7 @@ func main() {
 	eds := cache.NewLinearCache(typeURL)
 	if mux {
 		configCache = &cache.MuxCache{
-			Classify: func(req cache.Request) string {
+			Classify: func(req cache.Request) string { // nolint:govet
 				if req.TypeUrl == typeURL {
 					return "eds"
 				}
@@ -237,7 +237,11 @@ func main() {
 
 		if mux {
 			for name, res := range snapshot.GetResources(typeURL) {
-				eds.UpdateResource(name, res)
+				if err := eds.UpdateResource(name, res); err != nil {
+					log.Printf("update error %q for %+v\n", err, name)
+					os.Exit(1)
+
+				}
 			}
 		}
 
@@ -278,7 +282,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("could not create %s profile %s: %s", prof, filePath, err)
 			}
-			p.WriteTo(f, 1)
+			p.WriteTo(f, 1) // nolint:errcheck
 			f.Close()
 		}
 	}
@@ -299,7 +303,7 @@ func callEcho() (int, int) {
 			client := http.Client{
 				Timeout: 100 * time.Millisecond,
 				Transport: &http.Transport{
-					TLSClientConfig: &cryptotls.Config{InsecureSkipVerify: true},
+					TLSClientConfig: &cryptotls.Config{InsecureSkipVerify: true}, // nolint:gosec
 				},
 			}
 			proto := "http"
@@ -311,7 +315,7 @@ func callEcho() (int, int) {
 				ch <- err
 				return
 			}
-			defer req.Body.Close()
+			defer func() { _ = req.Body.Close() }()
 			body, err := ioutil.ReadAll(req.Body)
 			if err != nil {
 				ch <- err

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -176,7 +176,7 @@ func main() {
 	eds := cache.NewLinearCache(typeURL)
 	if mux {
 		configCache = &cache.MuxCache{
-			Classify: func(req cache.Request) string { // nolint:govet
+			Classify: func(req *cache.Request) string {
 				if req.TypeUrl == typeURL {
 					return "eds"
 				}
@@ -315,9 +315,13 @@ func callEcho() (int, int) {
 				ch <- err
 				return
 			}
-			defer func() { _ = req.Body.Close() }()
 			body, err := ioutil.ReadAll(req.Body)
 			if err != nil {
+				req.Body.Close()
+				ch <- err
+				return
+			}
+			if err := req.Body.Close(); err != nil {
 				ch <- err
 				return
 			}

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -105,13 +105,15 @@ func RunManagementGateway(ctx context.Context, srv server.Server, port uint, lg 
 	}
 	go func() {
 		if err := server.ListenAndServe(); err != nil {
-			log.Println(err)
+			log.Printf("failed to start listening: %s", err)
 		}
 	}()
 	<-ctx.Done()
 
 	// Cleanup our gateway if we receive a shutdown
-	_ = server.Shutdown(ctx)
+	if err := server.Shutdown(ctx); err != nil {
+		log.Printf("failed to shut down: %s", err)
+	}
 }
 
 func (h *HTTPGateway) ServeHTTP(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -111,7 +111,7 @@ func RunManagementGateway(ctx context.Context, srv server.Server, port uint, lg 
 	<-ctx.Done()
 
 	// Cleanup our gateway if we receive a shutdown
-	server.Shutdown(ctx)
+	_ = server.Shutdown(ctx)
 }
 
 func (h *HTTPGateway) ServeHTTP(resp http.ResponseWriter, req *http.Request) {

--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -86,9 +86,13 @@ const (
 	// ProxyProtocol listener filter
 	ProxyProtocol = "envoy.filters.listener.proxy_protocol"
 	// TlsInspector listener filter
-	TlsInspector = "envoy.filters.listener.tls_inspector"
+	TlsInspector = "envoy.filters.listener.tls_inspector" // nolint:golint,revive
+	// TLSInspector listener filter
+	TLSInspector = "envoy.filters.listener.tls_inspector" // nolint:golint,revive
 	// HttpInspector listener filter
-	HttpInspector = "envoy.filters.listener.http_inspector"
+	HttpInspector = "envoy.filters.listener.http_inspector" // nolint:golint,revive
+	// HTTPInspector listener filter
+	HTTPInspector = "envoy.filters.listener.http_inspector"
 )
 
 // Tracing provider names
@@ -130,7 +134,9 @@ const (
 	// TransportSocket RawBuffer
 	TransportSocketRawBuffer = "envoy.transport_sockets.raw_buffer"
 	// TransportSocket Tls
-	TransportSocketTls = "envoy.transport_sockets.tls"
+	TransportSocketTls = "envoy.transport_sockets.tls" // nolint:golint,revive
+	// TransportSocketTLS labels the "envoy.transport_sockets.tls" filter.
+	TransportSocketTLS = "envoy.transport_sockets.tls"
 	// TransportSocket Quic
 	TransportSocketQuic = "envoy.transport_sockets.quic"
 )


### PR DESCRIPTION
Add golangci-lint integration and fix or ignore all the resulting issues. In general, the things I ignored were names that can't be changed without a deprecation and migration.

This updates #414.