### PR TITLE
integration tests: add option to use pprof profiler

### DIFF
--- a/build/integration.sh
+++ b/build/integration.sh
@@ -13,6 +13,9 @@ MESSAGE=$'Hi, there!\n'
 # Management server type. Valid values are "ads", "xds", "rest", "delta", or "delta-ads"
 XDS=${XDS:-ads}
 
+# pprof profiler. True means turn on profiling
+PPROF=${PPROF:-false}
+
 # Number of RTDS layers.
 if [ "$XDS" = "ads" ]; then
   RUNTIMES=2
@@ -40,4 +43,4 @@ function cleanup() {
 trap cleanup EXIT
 
 # run the test suite (which also contains the control plane)
-bin/test --xds=${XDS} --runtimes=${RUNTIMES} -debug -message="$MESSAGE" "$@"
+bin/test --xds=${XDS} --runtimes=${RUNTIMES} --pprof=${PPROF} -debug -message="$MESSAGE" "$@"

--- a/pkg/test/main/README.md
+++ b/pkg/test/main/README.md
@@ -37,3 +37,16 @@ eventually converges to use the latest pushed configuration) for each run.
 
 You can run ```bin/test -help``` to get a list of the cli flags that
 the test program accepts.  There are also comments in ```main.go```.
+
+## Using the pprof profiler
+
+One customization is to run the go language profiler [pprof](https://github.com/DataDog/go-profiler-notes/blob/main/pprof.md). See also <https://golang.org/pkg/runtime/pprof/>.
+
+The profiler is normally off because it adds overhead to the tests. You can turn 
+it on with the command line option `--pprof`. There is an environment variable 
+`PPROF` for the `make` commands shown above. For example:
+
+    (export PPROF=true; make integration.xds)
+
+The test will then write files of the form `block_profile_xds.pb.gz`. 
+You can use `go tool pprof bin/test <file name>` to analyze the profile data. 

--- a/pkg/test/main/README.md
+++ b/pkg/test/main/README.md
@@ -48,5 +48,7 @@ it on with the command line option `--pprof`. There is an environment variable
 
     (export PPROF=true; make integration.xds)
 
-The test will then write files of the form `block_profile_xds.pb.gz`. 
+The test will then write files of the form `block_profile_xds.pb.gz`. The files
+get written to the root of the project, in the same place as the envoy logs.
+
 You can use `go tool pprof bin/test <file name>` to analyze the profile data. 

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -24,6 +24,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"runtime"
+	"runtime/pprof"
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -56,6 +58,8 @@ var (
 	mux           bool
 
 	nodeID string
+
+	pprof_enabled bool
 )
 
 func init() {
@@ -133,12 +137,39 @@ func init() {
 
 	// Enable a muxed cache with partial snapshots
 	flag.BoolVar(&mux, "mux", false, "Enable muxed linear cache for EDS")
+
+	//
+	// These parameters control the the use of the pprof profiler
+	//
+
+	// Enable use of the pprof profiler
+	flag.BoolVar(&pprof_enabled, "pprof", false, "Enable use of the pprof profiler")
+
 }
 
 // main returns code 1 if any of the batches failed to pass all requests
 func main() {
 	flag.Parse()
 	ctx := context.Background()
+
+	if pprof_enabled {
+		// turn on the block profiler
+		log.Println("turn on pprof block profiler")
+		runtime.SetBlockProfileRate(1)
+		if pprof.Lookup("block") == nil {
+			pprof.NewProfile("block")
+		}
+
+		log.Println("turn on pprof goroutine profiler")
+		if pprof.Lookup("goroutine") == nil {
+			pprof.NewProfile("goroutine")
+		}
+
+		log.Println("turn on pprof mutex profiler")
+		if pprof.Lookup("mutex") == nil {
+			pprof.NewProfile("mutex")
+		}
+	}
 
 	// create a cache
 	signal := make(chan struct{})
@@ -240,6 +271,21 @@ func main() {
 		if !pass {
 			log.Printf("failed all requests in a run %d\n", i)
 			os.Exit(1)
+		}
+	}
+
+	if pprof_enabled {
+
+		for _, prof := range []string{"block", "goroutine", "mutex"} {
+			p := pprof.Lookup(prof)
+			filePath := fmt.Sprintf("%s_profile_%s.pb.gz", prof, mode)
+			log.Printf("storing %s profile for %s in %s", prof, mode, filePath)
+			f, err := os.Create(filePath)
+			if err != nil {
+				log.Fatalf("could not create %s profile %s: %s", prof, filePath, err)
+			}
+			p.WriteTo(f, 1)
+			f.Close()
 		}
 	}
 

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -153,21 +153,12 @@ func main() {
 	ctx := context.Background()
 
 	if pprofEnabled {
-		// turn on the block profiler
-		log.Println("turn on pprof block profiler")
 		runtime.SetBlockProfileRate(1)
-		if pprof.Lookup("block") == nil {
-			pprof.NewProfile("block")
-		}
-
-		log.Println("turn on pprof goroutine profiler")
-		if pprof.Lookup("goroutine") == nil {
-			pprof.NewProfile("goroutine")
-		}
-
-		log.Println("turn on pprof mutex profiler")
-		if pprof.Lookup("mutex") == nil {
-			pprof.NewProfile("mutex")
+		for _, prof := range []string{"block", "goroutine", "mutex"} {
+			log.Printf("turn on pprof %s profiler", prof)
+			if pprof.Lookup(prof) == nil {
+				pprof.NewProfile(prof)
+			}
 		}
 	}
 

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -59,7 +59,7 @@ var (
 
 	nodeID string
 
-	pprof_enabled bool
+	pprofEnabled bool
 )
 
 func init() {
@@ -143,7 +143,7 @@ func init() {
 	//
 
 	// Enable use of the pprof profiler
-	flag.BoolVar(&pprof_enabled, "pprof", false, "Enable use of the pprof profiler")
+	flag.BoolVar(&pprofEnabled, "pprof", false, "Enable use of the pprof profiler")
 
 }
 
@@ -152,7 +152,7 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 
-	if pprof_enabled {
+	if pprofEnabled {
 		// turn on the block profiler
 		log.Println("turn on pprof block profiler")
 		runtime.SetBlockProfileRate(1)
@@ -274,8 +274,7 @@ func main() {
 		}
 	}
 
-	if pprof_enabled {
-
+	if pprofEnabled {
 		for _, prof := range []string{"block", "goroutine", "mutex"} {
 			p := pprof.Lookup(prof)
 			filePath := fmt.Sprintf("%s_profile_%s.pb.gz", prof, mode)


### PR DESCRIPTION
Signed-off-by: dougfort <doug.fort@greymatter.io>

This patch enables the use of the go language pprof profiler in integration tests.