### PR TITLE
Draft: SOTW variants

### DIFF
--- a/pkg/server/sotw/v3/server_default.go
+++ b/pkg/server/sotw/v3/server_default.go
@@ -1,0 +1,303 @@
+package sotw
+
+import (
+	"sync/atomic"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+)
+
+// watches for all xDS resource types
+type watches struct {
+	endpoints        chan cache.Response
+	clusters         chan cache.Response
+	routes           chan cache.Response
+	listeners        chan cache.Response
+	secrets          chan cache.Response
+	runtimes         chan cache.Response
+	extensionConfigs chan cache.Response
+
+	endpointCancel        func()
+	clusterCancel         func()
+	routeCancel           func()
+	listenerCancel        func()
+	secretCancel          func()
+	runtimeCancel         func()
+	extensionConfigCancel func()
+
+	endpointNonce        string
+	clusterNonce         string
+	routeNonce           string
+	listenerNonce        string
+	secretNonce          string
+	runtimeNonce         string
+	extensionConfigNonce string
+
+	// Opaque resources share a muxed channel. Nonces and watch cancellations are indexed by type URL.
+	responses     chan cache.Response
+	cancellations map[string]func()
+	nonces        map[string]string
+}
+
+func newWatches() watches {
+	return watches{
+		responses:     make(chan cache.Response, 5), // muxed channel needs a buffer to release go-routines populating it
+		cancellations: make(map[string]func()),
+		nonces:        make(map[string]string),
+	}
+}
+
+// Cancel all watches
+func (values *watches) Cancel() {
+	if values.endpointCancel != nil {
+		values.endpointCancel()
+	}
+	if values.clusterCancel != nil {
+		values.clusterCancel()
+	}
+	if values.routeCancel != nil {
+		values.routeCancel()
+	}
+	if values.listenerCancel != nil {
+		values.listenerCancel()
+	}
+	if values.secretCancel != nil {
+		values.secretCancel()
+	}
+	if values.runtimeCancel != nil {
+		values.runtimeCancel()
+	}
+	if values.extensionConfigCancel != nil {
+		values.extensionConfigCancel()
+	}
+	for _, cancel := range values.cancellations {
+		if cancel != nil {
+			cancel()
+		}
+	}
+}
+
+// process handles a bi-di stream request
+func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest, defaultTypeURL string) error {
+	sw := streamWrapper{
+		stream:    stream,
+		id:        atomic.AddInt64(&s.streamCount, 1), // increment stream count
+		callbacks: s.callbacks,
+	}
+
+	// a collection of stack allocated watches per request type
+	values := newWatches()
+	defer values.Cancel()
+	defer func() {
+		if s.callbacks != nil {
+			s.callbacks.OnStreamClosed(sw.id)
+		}
+	}()
+
+	if s.callbacks != nil {
+		if err := s.callbacks.OnStreamOpen(stream.Context(), sw.id, defaultTypeURL); err != nil {
+			return err
+		}
+	}
+
+	// node may only be set on the first discovery request
+	var node = &core.Node{}
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return nil
+		// config watcher can send the requested resources types in any order
+		case resp, more := <-values.endpoints:
+			if !more {
+				return status.Errorf(codes.Unavailable, "endpoints watch failed")
+			}
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.endpointNonce = nonce
+
+		case resp, more := <-values.clusters:
+			if !more {
+				return status.Errorf(codes.Unavailable, "clusters watch failed")
+			}
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.clusterNonce = nonce
+
+		case resp, more := <-values.routes:
+			if !more {
+				return status.Errorf(codes.Unavailable, "routes watch failed")
+			}
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.routeNonce = nonce
+
+		case resp, more := <-values.listeners:
+			if !more {
+				return status.Errorf(codes.Unavailable, "listeners watch failed")
+			}
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.listenerNonce = nonce
+
+		case resp, more := <-values.secrets:
+			if !more {
+				return status.Errorf(codes.Unavailable, "secrets watch failed")
+			}
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.secretNonce = nonce
+
+		case resp, more := <-values.runtimes:
+			if !more {
+				return status.Errorf(codes.Unavailable, "runtimes watch failed")
+			}
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.runtimeNonce = nonce
+
+		case resp, more := <-values.extensionConfigs:
+			if !more {
+				return status.Errorf(codes.Unavailable, "extensionConfigs watch failed")
+			}
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.extensionConfigNonce = nonce
+
+		case resp, more := <-values.responses:
+			if more {
+				if resp == errorResponse {
+					return status.Errorf(codes.Unavailable, "resource watch failed")
+				}
+				typeUrl := resp.GetRequest().TypeUrl
+				nonce, err := sw.send(resp)
+				if err != nil {
+					return err
+				}
+				values.nonces[typeUrl] = nonce
+			}
+
+		case req, more := <-reqCh:
+			// input stream ended or errored out
+			if !more {
+				return nil
+			}
+			if req == nil {
+				return status.Errorf(codes.Unavailable, "empty request")
+			}
+
+			// node field in discovery request is delta-compressed
+			if req.Node != nil {
+				node = req.Node
+			} else {
+				req.Node = node
+			}
+
+			// nonces can be reused across streams; we verify nonce only if nonce is not initialized
+			nonce := req.GetResponseNonce()
+
+			// type URL is required for ADS but is implicit for xDS
+			if defaultTypeURL == resource.AnyType {
+				if req.TypeUrl == "" {
+					return status.Errorf(codes.InvalidArgument, "type URL is required for ADS")
+				}
+			} else if req.TypeUrl == "" {
+				req.TypeUrl = defaultTypeURL
+			}
+
+			if s.callbacks != nil {
+				if err := s.callbacks.OnStreamRequest(sw.id, req); err != nil {
+					return err
+				}
+			}
+
+			// cancel existing watches to (re-)request a newer version
+			switch {
+			case req.TypeUrl == resource.EndpointType:
+				if values.endpointNonce == "" || values.endpointNonce == nonce {
+					if values.endpointCancel != nil {
+						values.endpointCancel()
+					}
+					values.endpoints = make(chan cache.Response, 1)
+					values.endpointCancel = s.cache.CreateWatch(req, values.endpoints)
+				}
+			case req.TypeUrl == resource.ClusterType:
+				if values.clusterNonce == "" || values.clusterNonce == nonce {
+					if values.clusterCancel != nil {
+						values.clusterCancel()
+					}
+					values.clusters = make(chan cache.Response, 1)
+					values.clusterCancel = s.cache.CreateWatch(req, values.clusters)
+				}
+			case req.TypeUrl == resource.RouteType:
+				if values.routeNonce == "" || values.routeNonce == nonce {
+					if values.routeCancel != nil {
+						values.routeCancel()
+					}
+					values.routes = make(chan cache.Response, 1)
+					values.routeCancel = s.cache.CreateWatch(req, values.routes)
+				}
+			case req.TypeUrl == resource.ListenerType:
+				if values.listenerNonce == "" || values.listenerNonce == nonce {
+					if values.listenerCancel != nil {
+						values.listenerCancel()
+					}
+					values.listeners = make(chan cache.Response, 1)
+					values.listenerCancel = s.cache.CreateWatch(req, values.listeners)
+				}
+			case req.TypeUrl == resource.SecretType:
+				if values.secretNonce == "" || values.secretNonce == nonce {
+					if values.secretCancel != nil {
+						values.secretCancel()
+					}
+					values.secrets = make(chan cache.Response, 1)
+					values.secretCancel = s.cache.CreateWatch(req, values.secrets)
+				}
+			case req.TypeUrl == resource.RuntimeType:
+				if values.runtimeNonce == "" || values.runtimeNonce == nonce {
+					if values.runtimeCancel != nil {
+						values.runtimeCancel()
+					}
+					values.runtimes = make(chan cache.Response, 1)
+					values.runtimeCancel = s.cache.CreateWatch(req, values.runtimes)
+				}
+			case req.TypeUrl == resource.ExtensionConfigType:
+				if values.extensionConfigNonce == "" || values.extensionConfigNonce == nonce {
+					if values.extensionConfigCancel != nil {
+						values.extensionConfigCancel()
+					}
+					values.extensionConfigs = make(chan cache.Response, 1)
+					values.extensionConfigCancel = s.cache.CreateWatch(req, values.extensionConfigs)
+				}
+			default:
+				typeUrl := req.TypeUrl
+				responseNonce, seen := values.nonces[typeUrl]
+				if !seen || responseNonce == nonce {
+					if cancel, seen := values.cancellations[typeUrl]; seen && cancel != nil {
+						cancel()
+					}
+					values.cancellations[typeUrl] = s.cache.CreateWatch(req, values.responses)
+				}
+			}
+		}
+	}
+}

--- a/pkg/server/sotw/v3/server_ordered_ads.go
+++ b/pkg/server/sotw/v3/server_ordered_ads.go
@@ -1,0 +1,150 @@
+package sotw
+
+import (
+	"sync/atomic"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+)
+
+type orderedAdsState struct {
+	// Opaque resources share a muxed channel. Nonces and watch cancellations are indexed by type URL.
+	responses     chan cache.Response
+	cancellations map[string]func()
+	nonces        map[string]string
+}
+
+func newOrderedAdsState() orderedAdsState {
+	return orderedAdsState{
+		responses:     make(chan cache.Response, 8),
+		cancellations: make(map[string]func()),
+		nonces:        make(map[string]string),
+	}
+}
+
+func (v *orderedAdsState) Cancel() {
+	for _, cancel := range v.cancellations {
+		if cancel != nil {
+			cancel()
+		}
+	}
+}
+
+// process handles a bi-di stream request
+func (s *server) processOrderedAds(stream Stream, reqCh <-chan *discovery.DiscoveryRequest, defaultTypeURL string) error {
+	sw := streamWrapper{
+		stream:    stream,
+		id:        atomic.AddInt64(&s.streamCount, 1), // increment stream count
+		callbacks: s.callbacks,
+	}
+
+	// a collection of stack allocated watches per request type
+	values := newOrderedAdsState()
+	defer values.Cancel()
+
+	process := func(resp cache.Response) error {
+		nonce, err := sw.send(resp)
+		if err != nil {
+			return err
+		}
+		typeUrl := resp.GetRequest().TypeUrl
+		values.nonces[typeUrl] = nonce
+		delete(values.cancellations, typeUrl)
+		return nil
+	}
+
+	processAllExcept := func(typeUrl string) error {
+		for {
+			select {
+			case resp := <-values.responses:
+				if resp.GetRequest().TypeUrl != typeUrl {
+					if err := process(resp); err != nil {
+						return err
+					}
+				}
+			default:
+				return nil
+			}
+		}
+	}
+
+	defer func() {
+		if s.callbacks != nil {
+			s.callbacks.OnStreamClosed(sw.id)
+		}
+	}()
+
+	if s.callbacks != nil {
+		if err := s.callbacks.OnStreamOpen(stream.Context(), sw.id, defaultTypeURL); err != nil {
+			return err
+		}
+	}
+
+	// node may only be set on the first discovery request
+	var node = &core.Node{}
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return nil
+		case resp := <-values.responses:
+			req := resp.GetRequest()
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.nonces[req.TypeUrl] = nonce
+		case req, recvOk := <-reqCh:
+			if !recvOk {
+				return nil
+			}
+			if req == nil {
+				return status.Errorf(codes.Unavailable, "empty request")
+			}
+
+			// node field in discovery request is delta-compressed
+			if req.Node != nil {
+				node = req.Node
+			} else {
+				req.Node = node
+			}
+
+			// nonces can be reused across streams; we verify nonce only if nonce is not initialized
+			nonce := req.GetResponseNonce()
+
+			// type URL is required for ADS but is implicit for xDS
+			if defaultTypeURL == resource.AnyType {
+				if req.TypeUrl == "" {
+					return status.Errorf(codes.InvalidArgument, "type URL is required for ADS")
+				}
+			} else if req.TypeUrl == "" {
+				req.TypeUrl = defaultTypeURL
+			}
+
+			if s.callbacks != nil {
+				if err := s.callbacks.OnStreamRequest(sw.id, req); err != nil {
+					return err
+				}
+			}
+
+			typeUrl := req.TypeUrl
+			responseNonce, seen := values.nonces[typeUrl]
+			if !seen || responseNonce == nonce {
+				if cancel, seen := values.cancellations[typeUrl]; seen {
+					if cancel != nil {
+						cancel()
+					}
+					if err := processAllExcept(typeUrl); err != nil {
+						return err
+					}
+				}
+				values.cancellations[typeUrl] = s.cache.CreateWatch(req, values.responses)
+			}
+		}
+	}
+}

--- a/pkg/server/sotw/v3/server_unordered_ads.go
+++ b/pkg/server/sotw/v3/server_unordered_ads.go
@@ -1,0 +1,147 @@
+package sotw
+
+import (
+	"reflect"
+	"sync/atomic"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+)
+
+type unorderedAdsState struct {
+	// Opaque resources share a muxed channel. Nonces and watch cancellations are indexed by type URL.
+	selectCasesToTypeUrls map[int]string
+	typeUrlsToSelectCases map[string]int
+	selectCases           []reflect.SelectCase
+	responses             map[string]chan cache.Response
+	cancellations         map[string]func()
+	nonces                map[string]string
+}
+
+func newUnorderedAdsState() unorderedAdsState {
+	return unorderedAdsState{
+		selectCasesToTypeUrls: make(map[int]string),
+		typeUrlsToSelectCases: make(map[string]int),
+		responses:             make(map[string]chan cache.Response),
+		cancellations:         make(map[string]func()),
+		nonces:                make(map[string]string),
+	}
+}
+
+func (v *unorderedAdsState) Cancel() {
+	for _, cancel := range v.cancellations {
+		if cancel != nil {
+			cancel()
+		}
+	}
+}
+
+// process handles a bi-di stream request
+func (s *server) processUnorderedAds(stream Stream, reqCh <-chan *discovery.DiscoveryRequest, defaultTypeURL string) error {
+	sw := streamWrapper{
+		stream:    stream,
+		id:        atomic.AddInt64(&s.streamCount, 1), // increment stream count
+		callbacks: s.callbacks,
+	}
+
+	// a collection of stack allocated watches per request type
+	values := newUnorderedAdsState()
+	defer values.Cancel()
+	defer func() {
+		if s.callbacks != nil {
+			s.callbacks.OnStreamClosed(sw.id)
+		}
+	}()
+
+	if s.callbacks != nil {
+		if err := s.callbacks.OnStreamOpen(stream.Context(), sw.id, defaultTypeURL); err != nil {
+			return err
+		}
+	}
+
+	// node may only be set on the first discovery request
+	var node = &core.Node{}
+
+	values.selectCases = append(values.selectCases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(s.ctx.Done()),
+	})
+	values.selectCases = append(values.selectCases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(reqCh),
+	})
+
+	for {
+		chosen, recv, recvOk := reflect.Select(values.selectCases)
+		if chosen == 0 { // done
+			return nil
+		} else if chosen == 1 { // req
+			if !recvOk {
+				return nil
+			}
+			req := recv.Interface().(*discovery.DiscoveryRequest)
+
+			if req == nil {
+				return status.Errorf(codes.Unavailable, "empty request")
+			}
+
+			// node field in discovery request is delta-compressed
+			if req.Node != nil {
+				node = req.Node
+			} else {
+				req.Node = node
+			}
+
+			// nonces can be reused across streams; we verify nonce only if nonce is not initialized
+			nonce := req.GetResponseNonce()
+
+			// type URL is required for ADS but is implicit for xDS
+			if defaultTypeURL == resource.AnyType {
+				if req.TypeUrl == "" {
+					return status.Errorf(codes.InvalidArgument, "type URL is required for ADS")
+				}
+			} else if req.TypeUrl == "" {
+				req.TypeUrl = defaultTypeURL
+			}
+
+			if s.callbacks != nil {
+				if err := s.callbacks.OnStreamRequest(sw.id, req); err != nil {
+					return err
+				}
+			}
+
+			typeUrl := req.TypeUrl
+			responseNonce, seen := values.nonces[typeUrl]
+			if !seen || responseNonce == nonce {
+				if cancel, seen := values.cancellations[typeUrl]; seen && cancel != nil {
+					cancel()
+				}
+				values.responses[typeUrl] = make(chan cache.Response, 1)
+				if !seen {
+					values.selectCases = append(values.selectCases, reflect.SelectCase{
+						Dir:  reflect.SelectRecv,
+						Chan: reflect.ValueOf(values.responses[typeUrl]),
+					})
+					values.selectCasesToTypeUrls[len(values.selectCases)-1] = typeUrl
+					values.typeUrlsToSelectCases[typeUrl] = len(values.selectCases) - 1
+				} else {
+					values.selectCases[values.typeUrlsToSelectCases[typeUrl]].Chan = reflect.ValueOf(values.responses[typeUrl])
+				}
+				values.cancellations[typeUrl] = s.cache.CreateWatch(req, values.responses[typeUrl])
+			}
+		} else {
+			resp := recv.Interface().(cache.Response)
+			req := resp.GetRequest()
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.nonces[req.TypeUrl] = nonce
+		}
+	}
+}

--- a/pkg/server/sotw/v3/server_xds.go
+++ b/pkg/server/sotw/v3/server_xds.go
@@ -1,0 +1,114 @@
+package sotw
+
+import (
+	"sync/atomic"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+)
+
+type xdsState struct {
+	responses chan cache.Response
+	nonce     string
+	cancel    func()
+}
+
+func newXdsState() xdsState {
+	return xdsState{}
+}
+
+func (v *xdsState) Cancel() {
+	if v.cancel != nil {
+		v.cancel()
+	}
+}
+
+// process handles a bi-di stream request
+func (s *server) processXds(stream Stream, reqCh <-chan *discovery.DiscoveryRequest, defaultTypeURL string) error {
+	sw := streamWrapper{
+		stream:    stream,
+		id:        atomic.AddInt64(&s.streamCount, 1), // increment stream count
+		callbacks: s.callbacks,
+	}
+
+	// a collection of stack allocated watches per request type
+	values := newXdsState()
+	defer values.Cancel()
+	defer func() {
+		if s.callbacks != nil {
+			s.callbacks.OnStreamClosed(sw.id)
+		}
+	}()
+
+	if s.callbacks != nil {
+		if err := s.callbacks.OnStreamOpen(stream.Context(), sw.id, defaultTypeURL); err != nil {
+			return err
+		}
+	}
+
+	// node may only be set on the first discovery request
+	var node = &core.Node{}
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return nil
+		// config watcher can send the requested resources types in any order
+		case resp, more := <-values.responses:
+			if !more {
+				return status.Errorf(codes.Unavailable, "resource watch failed")
+			}
+			nonce, err := sw.send(resp)
+			if err != nil {
+				return err
+			}
+			values.nonce = nonce
+
+		case req, more := <-reqCh:
+			// input stream ended or errored out
+			if !more {
+				return nil
+			}
+			if req == nil {
+				return status.Errorf(codes.Unavailable, "empty request")
+			}
+
+			// node field in discovery request is delta-compressed
+			if req.Node != nil {
+				node = req.Node
+			} else {
+				req.Node = node
+			}
+
+			// nonces can be reused across streams; we verify nonce only if nonce is not initialized
+			nonce := req.GetResponseNonce()
+
+			// type URL is required for ADS but is implicit for xDS
+			if defaultTypeURL == resource.AnyType {
+				if req.TypeUrl == "" {
+					return status.Errorf(codes.InvalidArgument, "type URL is required for ADS")
+				}
+			} else if req.TypeUrl == "" {
+				req.TypeUrl = defaultTypeURL
+			}
+
+			if s.callbacks != nil {
+				if err := s.callbacks.OnStreamRequest(sw.id, req); err != nil {
+					return err
+				}
+			}
+
+			// cancel existing watches to (re-)request a newer version
+			if values.nonce == "" || values.nonce == nonce {
+				values.Cancel()
+				values.responses = make(chan cache.Response, 1)
+				values.cancel = s.cache.CreateWatch(req, values.responses)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is basically a continuation of https://github.com/envoyproxy/go-control-plane/pull/357, which instead of replacing current `sotw.Server#process` implementation - adds 3 more implementations and ability to switch between them.

After https://github.com/envoyproxy/go-control-plane/pull/443 is merged - go-control-plane can support my original goals of being able not to have traffic drops when you have multiple resource types changed in a single "step", ie: if you change both CDS and EDS resource at the same time the only correct way to send these resources down the line is to send CDS first and EDS second (https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#eventual-consistency-considerations).

Currently the user of this library cannot do this at all, cause if they pushe both CDS and EDS responses into their channels on  the cache side in order - the select loop here (https://github.com/envoyproxy/go-control-plane/blob/main/pkg/server/sotw/v3/server.go#L195) does not guarantee that CDS will be selected first and EDS next.

Now, to actual implementations:
1. `server_default.go` - it is a copy of original `sotw.Server#process` implementation, to be able to "fall back to good state"
2. `server_xds.go` - works in the same way as the default one (responses channel is recreated on every valid incoming request), but only supports single resource type, which covers non-ADS protocol part. it is simpler than default one and (probably) a bit faster, given the fact that it just removes a bunch of stuff that non-ADS requests do not need.
3. `server_ordered_ads.go` - completely different implementation for ADS, that instead of creating a separate channel for each incoming request and abandoning the old one - uses (and reuses) single channel for all request types. the main benefit is that you no longer have a select that breaks ordering, so that if cache pushes CDS first and EDS second - this implementation guarantees that server will actually send updates to the wire in this order. Downside (as was discussed in previous PRs) - you no longer have backpressure per resource. ie: in default implementation if cache decides to send 2 CDS updates - the second one will be blocked, cause the channel has buffer of size 1 and second push to the channel will be blocked, but pushes to channels of other type urls can succeed as long as corresponding channels are empty. This implementation due to channel reuse and the fact that the channel is shared between type urls - if your cache implementation sends many EDS updates, for example - it might be blocked on channel push when there is a CDS update.
4. `server_unordered_ads.go` - reimplementation of the default behaviour, but based on reflect.Select, which eliminates duplication in original implementation and allows having any number of type urls supported without the need to fall back to either shared channel for non-LDS/RDS/CDS/EDS and does not require any additional goroutines if there is a need for same "backpressure semantics" for these non-main type urls.