### PR TITLE
add context.Context param to SetSnapshot

### DIFF
--- a/internal/example/main/main.go
+++ b/internal/example/main/main.go
@@ -61,7 +61,7 @@ func main() {
 	l.Debugf("will serve snapshot %+v", snapshot)
 
 	// Add the snapshot to the cache
-	if err := cache.SetSnapshot(nodeID, snapshot); err != nil {
+	if err := cache.SetSnapshot(context.Background(), nodeID, snapshot); err != nil {
 		l.Errorf("snapshot error %q for %+v", err, snapshot)
 		os.Exit(1)
 	}

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -86,7 +86,7 @@ type Response interface {
 	// Get the version in the Response.
 	GetVersion() (string, error)
 
-	// Get the context provided during response creation/
+	// Get the context provided during response creation.
 	GetContext() context.Context
 }
 
@@ -106,7 +106,7 @@ type DeltaResponse interface {
 	// The version map consists of updated version mappings after this response is applied
 	GetNextVersionMap() map[string]string
 
-	// Get the context provided during response creation/
+	// Get the context provided during response creation
 	GetContext() context.Context
 }
 
@@ -128,6 +128,8 @@ type RawResponse struct {
 	// This allows for more lightweight updates that server only to update the TTL timer.
 	Heartbeat bool
 
+	// Context provided at the time of response creation. This allows associating additional
+	// information with a generated response.
 	Ctx context.Context
 
 	// marshaledResponse holds an atomic reference to the serialized discovery response.
@@ -151,6 +153,8 @@ type RawDeltaResponse struct {
 	// NextVersionMap consists of updated version mappings after this response is applied
 	NextVersionMap map[string]string
 
+	// Context provided at the time of response creation. This allows associating additional
+	// information with a generated response.
 	Ctx context.Context
 
 	// Marshaled Resources to be included in the response.

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -214,7 +214,7 @@ func TestSnapshotDeltaCacheWatchTimeout(t *testing.T) {
 		},
 		TypeUrl:                rsrc.EndpointType,
 		ResourceNamesSubscribe: names[rsrc.EndpointType],
-	}, stream.NewStreamState(false, make(map[string]string)), watchCh)
+	}, stream.NewStreamState(false, map[string]string{names[rsrc.EndpointType][0]: ""}), watchCh)
 
 	// The first time we set the snapshot without consuming from the blocking channel, so this should time out.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
@@ -238,10 +238,9 @@ func TestSnapshotDeltaCacheWatchTimeout(t *testing.T) {
 
 	// The channel should get closed due to the watch trigger.
 	select {
-	case response, ok := <-watchTriggeredCh:
+	case response := <-watchTriggeredCh:
 		// Verify that we pass the context through.
 		assert.Equal(t, response.GetContext().Value(testKey{}), "bar")
-		assert.False(t, ok)
 	case <-time.After(time.Second):
 		t.Fatalf("timed out")
 	}

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -14,7 +16,6 @@ import (
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSnapshotCacheDeltaWatch(t *testing.T) {

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -143,7 +143,7 @@ func NewSnapshotCacheWithHeartbeating(ctx context.Context, ads bool, hash NodeHa
 				cache.mu.Lock()
 				for node := range cache.status {
 					// TODO(snowp): Omit heartbeats if a real response has been sent recently.
-					cache.sendHeartbeats(node)
+					cache.sendHeartbeats(ctx, node)
 				}
 				cache.mu.Unlock()
 			case <-ctx.Done():
@@ -154,7 +154,7 @@ func NewSnapshotCacheWithHeartbeating(ctx context.Context, ads bool, hash NodeHa
 	return cache
 }
 
-func (cache *snapshotCache) sendHeartbeats(node string) {
+func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 	snapshot := cache.snapshots[node]
 	if info, ok := cache.status[node]; ok {
 		info.mu.Lock()
@@ -178,7 +178,7 @@ func (cache *snapshotCache) sendHeartbeats(node string) {
 				cache.log.Debugf("respond open watch %d%v with heartbeat for version %q", id, watch.Request.ResourceNames, version)
 			}
 
-			cache.respond(context.Background(), watch.Request, watch.Response, resourcesWithTtl, version, true)
+			cache.respond(ctx, watch.Request, watch.Response, resourcesWithTtl, version, true)
 
 			// The watch must be deleted and we must rely on the client to ack this response to create a new watch.
 			delete(info.watches, id)

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
+	"github.com/stretchr/testify/assert"
 )
 
 type group struct{}
@@ -101,7 +102,7 @@ func TestSnapshotCacheWithTtl(t *testing.T) {
 		t.Errorf("unexpected snapshot found for key %q", key)
 	}
 
-	if err := c.SetSnapshot(key, snapshotWithTtl); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, snapshotWithTtl); err != nil {
 		t.Fatal(err)
 	}
 
@@ -189,7 +190,7 @@ func TestSnapshotCache(t *testing.T) {
 		t.Errorf("unexpected snapshot found for key %q", key)
 	}
 
-	if err := c.SetSnapshot(key, snapshot); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, snapshot); err != nil {
 		t.Fatal(err)
 	}
 
@@ -232,7 +233,7 @@ func TestSnapshotCache(t *testing.T) {
 
 func TestSnapshotCacheFetch(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
-	if err := c.SetSnapshot(key, snapshot); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, snapshot); err != nil {
 		t.Fatal(err)
 	}
 
@@ -268,7 +269,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 		watches[typ] = make(chan cache.Response, 1)
 		c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}, watches[typ])
 	}
-	if err := c.SetSnapshot(key, snapshot); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, snapshot); err != nil {
 		t.Fatal(err)
 	}
 	for _, typ := range testTypes {
@@ -299,7 +300,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	// set partially-versioned snapshot
 	snapshot2 := snapshot
 	snapshot2.Resources[types.Endpoint] = cache.NewResources(version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
-	if err := c.SetSnapshot(key, snapshot2); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, snapshot2); err != nil {
 		t.Fatal(err)
 	}
 	if count := c.GetStatusInfo(key).GetNumWatches(); count != len(testTypes)-1 {
@@ -332,7 +333,7 @@ func TestConcurrentSetWatch(t *testing.T) {
 				if i < 25 {
 					snap := cache.Snapshot{}
 					snap.Resources[types.Endpoint] = cache.NewResources(fmt.Sprintf("v%d", i), []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
-					c.SetSnapshot(id, snap)
+					c.SetSnapshot(context.Background(), key, snap)
 				} else {
 					if cancel != nil {
 						cancel()
@@ -370,9 +371,46 @@ func TestSnapshotCacheWatchCancel(t *testing.T) {
 	}
 }
 
+func TestSnapshotCacheWatchTimeout(t *testing.T) {
+	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+
+	// Create a non-buffered channel that will block sends.
+	watchCh := make(chan cache.Response)
+	c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: names[rsrc.EndpointType]}, watchCh)
+
+	// The first time we set the snapshot without consuming from the blocking channel, so this should time out.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	err := c.SetSnapshot(ctx, key, snapshot)
+	assert.EqualError(t, err, context.Canceled.Error())
+
+	// Now reset the snapshot with a consuming channel. This verifies that if setting the snapshot fails,
+	// we can retry by setting the same snapshot. In other words, we keep the watch open even if we failed
+	// to respond to it within the deadline.
+	watchTriggeredCh := make(chan cache.Response)
+	go func() {
+		response := <-watchCh
+		watchTriggeredCh <- response
+		close(watchTriggeredCh)
+	}()
+
+	err = c.SetSnapshot(context.WithValue(context.Background(), testKey{}, "bar"), key, snapshot)
+	assert.NoError(t, err)
+
+	// The channel should get closed due to the watch trigger.
+	select {
+	case response := <-watchTriggeredCh:
+		// Verify that we pass the context through.
+		assert.Equal(t, response.GetContext().Value(testKey{}), "bar")
+	case <-time.After(time.Second):
+		t.Fatalf("timed out")
+	}
+}
+
 func TestSnapshotClear(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
-	if err := c.SetSnapshot(key, snapshot); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, snapshot); err != nil {
 		t.Fatal(err)
 	}
 	c.ClearSnapshot(key)

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -22,13 +22,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
-	"github.com/stretchr/testify/assert"
 )
 
 type group struct{}

--- a/pkg/integration/ttl_integration_test.go
+++ b/pkg/integration/ttl_integration_test.go
@@ -67,7 +67,7 @@ func TestTtlResponse(t *testing.T) {
 
 	oneSecond := time.Second
 	cla := &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "resource"}
-	err = snapshotCache.SetSnapshot("test", cache.NewSnapshotWithTtls("1", []types.ResourceWithTtl{{
+	err = snapshotCache.SetSnapshot(context.Background(), "test", cache.NewSnapshotWithTtls("1", []types.ResourceWithTtl{{
 		Resource: cla,
 		Ttl:      &oneSecond,
 	}}, nil, nil, nil, nil, nil))

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -45,7 +45,7 @@ type Callbacks interface {
 	// Returning an error will end processing and close the stream. OnStreamClosed will still be called.
 	OnStreamRequest(int64, *discovery.DiscoveryRequest) error
 	// OnStreamResponse is called immediately prior to sending a response on a stream.
-	OnStreamResponse(int64, *discovery.DiscoveryRequest, *discovery.DiscoveryResponse)
+	OnStreamResponse(context.Context, int64, *discovery.DiscoveryRequest, *discovery.DiscoveryResponse)
 }
 
 // NewServer creates handlers from a config watcher and callbacks.
@@ -177,7 +177,7 @@ func (s *server) process(stream Stream, reqCh <-chan *discovery.DiscoveryRequest
 		streamNonce = streamNonce + 1
 		out.Nonce = strconv.FormatInt(streamNonce, 10)
 		if s.callbacks != nil {
-			s.callbacks.OnStreamResponse(streamID, resp.GetRequest(), out)
+			s.callbacks.OnStreamResponse(resp.GetContext(), streamID, resp.GetRequest(), out)
 		}
 		return out.Nonce, stream.Send(out)
 	}

--- a/pkg/server/v3/server.go
+++ b/pkg/server/v3/server.go
@@ -70,7 +70,7 @@ type CallbackFuncs struct {
 	DeltaStreamOpenFunc     func(context.Context, int64, string) error
 	DeltaStreamClosedFunc   func(int64)
 	StreamRequestFunc       func(int64, *discovery.DiscoveryRequest) error
-	StreamResponseFunc      func(int64, *discovery.DiscoveryRequest, *discovery.DiscoveryResponse)
+	StreamResponseFunc      func(context.Context, int64, *discovery.DiscoveryRequest, *discovery.DiscoveryResponse)
 	StreamDeltaRequestFunc  func(int64, *discovery.DeltaDiscoveryRequest) error
 	StreamDeltaResponseFunc func(int64, *discovery.DeltaDiscoveryRequest, *discovery.DeltaDiscoveryResponse)
 	FetchRequestFunc        func(context.Context, *discovery.DiscoveryRequest) error
@@ -121,9 +121,9 @@ func (c CallbackFuncs) OnStreamRequest(streamID int64, req *discovery.DiscoveryR
 }
 
 // OnStreamResponse invokes StreamResponseFunc.
-func (c CallbackFuncs) OnStreamResponse(streamID int64, req *discovery.DiscoveryRequest, resp *discovery.DiscoveryResponse) {
+func (c CallbackFuncs) OnStreamResponse(ctx context.Context, streamID int64, req *discovery.DiscoveryRequest, resp *discovery.DiscoveryResponse) {
 	if c.StreamResponseFunc != nil {
-		c.StreamResponseFunc(streamID, req, resp)
+		c.StreamResponseFunc(ctx, streamID, req, resp)
 	}
 }
 

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -225,7 +225,7 @@ func main() {
 			log.Printf("snapshot inconsistency: %+v\n", snapshot)
 		}
 
-		err := config.SetSnapshot(nodeID, snapshot)
+		err := config.SetSnapshot(context.Background(), nodeID, snapshot)
 		if err != nil {
 			log.Printf("snapshot error %q for %+v\n", err, snapshot)
 			os.Exit(1)

--- a/pkg/test/v3/callbacks.go
+++ b/pkg/test/v3/callbacks.go
@@ -55,7 +55,7 @@ func (cb *Callbacks) OnStreamRequest(int64, *discovery.DiscoveryRequest) error {
 	}
 	return nil
 }
-func (cb *Callbacks) OnStreamResponse(int64, *discovery.DiscoveryRequest, *discovery.DiscoveryResponse) {
+func (cb *Callbacks) OnStreamResponse(context.Context, int64, *discovery.DiscoveryRequest, *discovery.DiscoveryResponse) {
 }
 func (cb *Callbacks) OnStreamDeltaResponse(id int64, req *discovery.DeltaDiscoveryRequest, res *discovery.DeltaDiscoveryResponse) {
 	cb.mu.Lock()


### PR DESCRIPTION
This allows for setting a timeout on responding to watches, and allows us to pass additional information to OnStreamResponse, allowing for additional information about the response to be passed to the server callbacks.