### PR TITLE
cache: rework snapshot api

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed h1:OZmjad4L3H8ncOIR8rnb5MREYqG8ixi5+WbeUsquF0c=
-github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158 h1:CevA8fI91PAnP8vpnXuB8ZYAZ5wqY86nAbxfgK8tWO4=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -165,14 +165,11 @@ func makeConfigSource() *core.ConfigSource {
 }
 
 func GenerateSnapshot() cache.Snapshot {
-	return cache.NewSnapshot(
-		"1",
-		[]types.Resource{}, // endpoints
-		[]types.Resource{makeCluster(ClusterName)},
-		[]types.Resource{makeRoute(RouteName, ClusterName)},
-		[]types.Resource{makeHTTPListener(ListenerName, RouteName)},
-		[]types.Resource{}, // runtimes
-		[]types.Resource{}, // secrets
-		[]types.Resource{}, // extension configs
+	return cache.NewSnapshot("1",
+		map[string][]types.Resource{
+			resource.ClusterType:  {makeCluster(ClusterName)},
+			resource.RouteType:    {makeRoute(RouteName, ClusterName)},
+			resource.ListenerType: {makeHTTPListener(ListenerName, RouteName)},
+		},
 	)
 }

--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -166,7 +166,7 @@ func makeConfigSource() *core.ConfigSource {
 
 func GenerateSnapshot() cache.Snapshot {
 	return cache.NewSnapshot("1",
-		map[string][]types.Resource{
+		map[resource.Type][]types.Resource{
 			resource.ClusterType:  {makeCluster(ClusterName)},
 			resource.RouteType:    {makeRoute(RouteName, ClusterName)},
 			resource.ListenerType: {makeHTTPListener(ListenerName, RouteName)},

--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -165,11 +165,12 @@ func makeConfigSource() *core.ConfigSource {
 }
 
 func GenerateSnapshot() cache.Snapshot {
-	return cache.NewSnapshot("1",
+	snap, _ := cache.NewSnapshot("1",
 		map[resource.Type][]types.Resource{
 			resource.ClusterType:  {makeCluster(ClusterName)},
 			resource.RouteType:    {makeRoute(RouteName, ClusterName)},
 			resource.ListenerType: {makeHTTPListener(ListenerName, RouteName)},
 		},
 	)
+	return snap
 }

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -182,7 +182,7 @@ func TestConcurrentSetDeltaWatch(t *testing.T) {
 				id := fmt.Sprintf("%d", i%2)
 				responses := make(chan cache.DeltaResponse, 1)
 				if i < 25 {
-					snap := cache.Snapshot{}
+					snap := cache.NewSnapshot("", map[string][]types.Resource{})
 					snap.Resources[types.Endpoint] = cache.NewResources(version, []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
 					if err := c.SetSnapshot(context.Background(), key, snap); err != nil {
 						t.Fatalf("snapshot failed: %s", err)

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -182,7 +182,7 @@ func TestConcurrentSetDeltaWatch(t *testing.T) {
 				id := fmt.Sprintf("%d", i%2)
 				responses := make(chan cache.DeltaResponse, 1)
 				if i < 25 {
-					snap := cache.NewSnapshot("", map[string][]types.Resource{})
+					snap := cache.NewSnapshot("", map[rsrc.Type][]types.Resource{})
 					snap.Resources[types.Endpoint] = cache.NewResources(version, []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
 					if err := c.SetSnapshot(context.Background(), key, snap); err != nil {
 						t.Fatalf("snapshot failed: %s", err)

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -182,7 +182,10 @@ func TestConcurrentSetDeltaWatch(t *testing.T) {
 				id := fmt.Sprintf("%d", i%2)
 				responses := make(chan cache.DeltaResponse, 1)
 				if i < 25 {
-					snap := cache.NewSnapshot("", map[rsrc.Type][]types.Resource{})
+					snap, err := cache.NewSnapshot("", map[rsrc.Type][]types.Resource{})
+					if err != nil {
+						t.Fatal(err)
+					}
 					snap.Resources[types.Endpoint] = cache.NewResources(version, []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
 					if err := c.SetSnapshot(context.Background(), key, snap); err != nil {
 						t.Fatalf("snapshot failed: %s", err)

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -35,7 +35,7 @@ import (
 )
 
 // GetResponseType returns the enumeration for a valid xDS type URL
-func GetResponseType(typeURL string) types.ResponseType {
+func GetResponseType(typeURL resource.Type) types.ResponseType {
 	switch typeURL {
 	case resource.EndpointType:
 		return types.Endpoint

--- a/pkg/cache/v3/resources.go
+++ b/pkg/cache/v3/resources.go
@@ -38,8 +38,8 @@ func NewResources(version string, items []types.Resource) Resources {
 	return NewResourcesWithTTL(version, itemsWithTTL)
 }
 
-// NewResources creates a new resource group.
-func NewResourcesWithTTL(version string, items []types.ResourceWithTTL) Resources { // nolint:golint,revive
+// NewResourcesWithTTL creates a new resource group.
+func NewResourcesWithTTL(version string, items []types.ResourceWithTTL) Resources {
 	return Resources{
 		Version: version,
 		Items:   IndexResourcesByName(items),

--- a/pkg/cache/v3/resources.go
+++ b/pkg/cache/v3/resources.go
@@ -1,0 +1,47 @@
+package cache
+
+import "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+
+// Resources is a versioned group of resources.
+type Resources struct {
+	// Version information.
+	Version string
+
+	// Items in the group indexed by name.
+	Items map[string]types.ResourceWithTTL
+}
+
+// IndexResourcesByName creates a map from the resource name to the resource.
+func IndexResourcesByName(items []types.ResourceWithTTL) map[string]types.ResourceWithTTL {
+	indexed := make(map[string]types.ResourceWithTTL)
+	for _, item := range items {
+		indexed[GetResourceName(item.Resource)] = item
+	}
+	return indexed
+}
+
+// IndexRawResourcesByName creates a map from the resource name to the resource.
+func IndexRawResourcesByName(items []types.Resource) map[string]types.Resource {
+	indexed := make(map[string]types.Resource)
+	for _, item := range items {
+		indexed[GetResourceName(item)] = item
+	}
+	return indexed
+}
+
+// NewResources creates a new resource group.
+func NewResources(version string, items []types.Resource) Resources {
+	itemsWithTTL := []types.ResourceWithTTL{}
+	for _, item := range items {
+		itemsWithTTL = append(itemsWithTTL, types.ResourceWithTTL{Resource: item})
+	}
+	return NewResourcesWithTTL(version, itemsWithTTL)
+}
+
+// NewResources creates a new resource group.
+func NewResourcesWithTTL(version string, items []types.ResourceWithTTL) Resources { // nolint:golint,revive
+	return Resources{
+		Version: version,
+		Items:   IndexResourcesByName(items),
+	}
+}

--- a/pkg/cache/v3/resources_test.go
+++ b/pkg/cache/v3/resources_test.go
@@ -1,0 +1,84 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+)
+
+func TestIndexResourcesByName(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []types.ResourceWithTTL
+		want      map[string]types.ResourceWithTTL
+	}{
+		{
+			name:      "empty",
+			resources: nil,
+			want:      map[string]types.ResourceWithTTL{},
+		},
+		{
+			name: "more than one",
+			resources: []types.ResourceWithTTL{
+				{Resource: testEndpoint, TTL: &ttl},
+				{Resource: testRoute, TTL: &ttl},
+			},
+			want: map[string]types.ResourceWithTTL{
+				"cluster0": {Resource: testEndpoint, TTL: &ttl},
+				"route0":   {Resource: testRoute, TTL: &ttl},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cache.IndexResourcesByName(tt.resources)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIndexRawResourceByName(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []types.Resource
+		want      map[string]types.Resource
+	}{
+		{
+			name:      "empty",
+			resources: nil,
+			want:      map[string]types.Resource{},
+		},
+		{
+			name: "more than one",
+			resources: []types.Resource{
+				testEndpoint,
+				testRoute,
+			},
+			want: map[string]types.Resource{
+				"cluster0": testEndpoint,
+				"route0":   testRoute,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cache.IndexRawResourcesByName(tt.resources)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNewResources(t *testing.T) {
+	resources := cache.NewResources("x", []types.Resource{
+		testEndpoint,
+		testRoute,
+	})
+
+	assert.NotNil(t, resources.Items)
+	assert.Equal(t, "x", resources.Version)
+}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -157,7 +157,7 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 		for id, watch := range info.watches {
 			// Respond with the current version regardless of whether the version has changed.
 			version := snapshot.GetVersion(watch.Request.TypeUrl)
-			resources := snapshot.GetResourcesAndTtl(watch.Request.TypeUrl)
+			resources := snapshot.GetResourcesAndTTL(watch.Request.TypeUrl)
 
 			// TODO(snowp): Construct this once per type instead of once per watch.
 			resourcesWithTTL := map[string]types.ResourceWithTTL{}
@@ -201,7 +201,7 @@ func (cache *snapshotCache) SetSnapshot(ctx context.Context, node string, snapsh
 				if cache.log != nil {
 					cache.log.Debugf("respond open watch %d%v with new version %q", id, watch.Request.ResourceNames, version)
 				}
-				resources := snapshot.GetResourcesAndTtl(watch.Request.TypeUrl)
+				resources := snapshot.GetResourcesAndTTL(watch.Request.TypeUrl)
 				err := cache.respond(ctx, watch.Request, watch.Response, resources, version, false)
 				if err != nil {
 					return err
@@ -321,7 +321,7 @@ func (cache *snapshotCache) CreateWatch(request *Request, value chan Response) f
 	}
 
 	// otherwise, the watch may be responded immediately
-	resources := snapshot.GetResourcesAndTtl(request.TypeUrl)
+	resources := snapshot.GetResourcesAndTTL(request.TypeUrl)
 	_ = cache.respond(context.Background(), request, value, resources, version, false)
 
 	return nil
@@ -492,7 +492,7 @@ func (cache *snapshotCache) Fetch(ctx context.Context, request *Request) (Respon
 			return nil, &types.SkipFetchError{}
 		}
 
-		resources := snapshot.GetResourcesAndTtl(request.TypeUrl)
+		resources := snapshot.GetResourcesAndTTL(request.TypeUrl)
 		out := createResponse(ctx, request, resources, version, false)
 		return out, nil
 	}

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -49,7 +49,7 @@ var (
 	version  = "x"
 	version2 = "y"
 
-	snapshot = cache.NewSnapshot(version, map[string][]types.Resource{
+	snapshot = cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType:        {testEndpoint},
 		rsrc.ClusterType:         {testCluster},
 		rsrc.RouteType:           {testRoute},
@@ -60,7 +60,7 @@ var (
 	})
 
 	ttl             = 2 * time.Second
-	snapshotWithTTL = cache.NewSnapshotWithTTLs(version, map[string][]types.ResourceWithTTL{
+	snapshotWithTTL = cache.NewSnapshotWithTTLs(version, map[rsrc.Type][]types.ResourceWithTTL{
 		rsrc.EndpointType:        {{Resource: testEndpoint, TTL: &ttl}},
 		rsrc.ClusterType:         {{Resource: testCluster}},
 		rsrc.RouteType:           {{Resource: testRoute}},

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -49,7 +49,7 @@ var (
 	version  = "x"
 	version2 = "y"
 
-	snapshot = cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	snapshot, _ = cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType:        {testEndpoint},
 		rsrc.ClusterType:         {testCluster},
 		rsrc.RouteType:           {testRoute},
@@ -59,8 +59,8 @@ var (
 		rsrc.ExtensionConfigType: {testExtensionConfig},
 	})
 
-	ttl             = 2 * time.Second
-	snapshotWithTTL = cache.NewSnapshotWithTTLs(version, map[rsrc.Type][]types.ResourceWithTTL{
+	ttl                = 2 * time.Second
+	snapshotWithTTL, _ = cache.NewSnapshotWithTTLs(version, map[rsrc.Type][]types.ResourceWithTTL{
 		rsrc.EndpointType:        {{Resource: testEndpoint, TTL: &ttl}},
 		rsrc.ClusterType:         {{Resource: testCluster}},
 		rsrc.RouteType:           {{Resource: testRoute}},

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -49,24 +49,26 @@ var (
 	version  = "x"
 	version2 = "y"
 
-	snapshot = cache.NewSnapshot(version,
-		[]types.Resource{testEndpoint},
-		[]types.Resource{testCluster},
-		[]types.Resource{testRoute},
-		[]types.Resource{testListener},
-		[]types.Resource{testRuntime},
-		[]types.Resource{testSecret[0]},
-		[]types.Resource{testExtensionConfig})
+	snapshot = cache.NewSnapshot(version, map[string][]types.Resource{
+		rsrc.EndpointType:        {testEndpoint},
+		rsrc.ClusterType:         {testCluster},
+		rsrc.RouteType:           {testRoute},
+		rsrc.ListenerType:        {testListener},
+		rsrc.RuntimeType:         {testRuntime},
+		rsrc.SecretType:          {testSecret[0]},
+		rsrc.ExtensionConfigType: {testExtensionConfig},
+	})
 
-	ttl = 2 * time.Second
-
-	snapshotWithTTL = cache.NewSnapshotWithTtls(version,
-		[]types.ResourceWithTTL{{Resource: testEndpoint, TTL: &ttl}},
-		[]types.ResourceWithTTL{{Resource: testCluster}},
-		[]types.ResourceWithTTL{{Resource: testRoute}},
-		[]types.ResourceWithTTL{{Resource: testListener}},
-		[]types.ResourceWithTTL{{Resource: testRuntime}},
-		[]types.ResourceWithTTL{{Resource: testSecret[0]}})
+	ttl             = 2 * time.Second
+	snapshotWithTTL = cache.NewSnapshotWithTTLs(version, map[string][]types.ResourceWithTTL{
+		rsrc.EndpointType:        {{Resource: testEndpoint, TTL: &ttl}},
+		rsrc.ClusterType:         {{Resource: testCluster}},
+		rsrc.RouteType:           {{Resource: testRoute}},
+		rsrc.ListenerType:        {{Resource: testListener}},
+		rsrc.RuntimeType:         {{Resource: testRuntime}},
+		rsrc.SecretType:          {{Resource: testSecret[0]}},
+		rsrc.ExtensionConfigType: {{Resource: testExtensionConfig}},
+	})
 
 	names = map[string][]string{
 		rsrc.EndpointType: {clusterName},
@@ -94,7 +96,7 @@ func (log logger) Infof(format string, args ...interface{})  { log.t.Logf(format
 func (log logger) Warnf(format string, args ...interface{})  { log.t.Logf(format, args...) }
 func (log logger) Errorf(format string, args ...interface{}) { log.t.Logf(format, args...) }
 
-func TestSnapshotCacheWithTtl(t *testing.T) {
+func TestSnapshotCacheWithTTL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	c := cache.NewSnapshotCacheWithHeartbeating(ctx, true, group{}, logger{t: t}, time.Second)
@@ -128,8 +130,8 @@ func TestSnapshotCacheWithTtl(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != version {
 					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTtl(typ)) {
-					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResourcesAndTtl(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResourcesAndTTL(typ))
 				}
 			case <-time.After(2 * time.Second):
 				t.Errorf("failed to receive snapshot response")
@@ -156,11 +158,11 @@ func TestSnapshotCacheWithTtl(t *testing.T) {
 					if gotVersion, _ := out.GetVersion(); gotVersion != version {
 						t.Errorf("got version %q, want %q", gotVersion, version)
 					}
-					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTtl(typ)) {
+					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
 					}
 
-					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTtl(typ)) {
+					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
 					}
 
@@ -222,8 +224,8 @@ func TestSnapshotCache(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != version {
 					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTtl(typ)) {
-					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTtl(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -280,8 +282,8 @@ func TestSnapshotCacheWatch(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != version {
 					t.Errorf("got version %q, want %q", gotVersion, version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTtl(typ)) {
-					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTtl(typ))
+				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
+					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
 				}
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -315,7 +317,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 			t.Errorf("got version %q, want %q", gotVersion, version2)
 		}
 		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
-			t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
+			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 )
 
 // Snapshot is an internally consistent snapshot of xDS resources.
@@ -36,7 +37,7 @@ type Snapshot struct {
 
 // NewSnapshot creates a snapshot from response types and a version.
 // The resources map is keyed off the type URL of a resource, followed by the slice of resource objects.
-func NewSnapshot(version string, resources map[string][]types.Resource) Snapshot {
+func NewSnapshot(version string, resources map[resource.Type][]types.Resource) Snapshot {
 	out := Snapshot{}
 
 	for typ, resource := range resources {
@@ -51,7 +52,7 @@ func NewSnapshot(version string, resources map[string][]types.Resource) Snapshot
 
 // NewSnapshotWithTTLs creates a snapshot with time to live per resource.
 // The resources map is keyed off the type URL of a resource, followed by the slice of resource objects.
-func NewSnapshotWithTTLs(version string, resources map[string][]types.ResourceWithTTL) Snapshot {
+func NewSnapshotWithTTLs(version string, resources map[resource.Type][]types.ResourceWithTTL) Snapshot {
 	out := Snapshot{}
 
 	for typ, resource := range resources {
@@ -92,7 +93,7 @@ func (s *Snapshot) Consistent() error {
 }
 
 // GetResources selects snapshot resources by type, returning the map of resources.
-func (s *Snapshot) GetResources(typeURL string) map[string]types.Resource {
+func (s *Snapshot) GetResources(typeURL resource.Type) map[string]types.Resource {
 	resources := s.GetResourcesAndTTL(typeURL)
 	if resources == nil {
 		return nil
@@ -107,8 +108,8 @@ func (s *Snapshot) GetResources(typeURL string) map[string]types.Resource {
 	return withoutTTL
 }
 
-// GetResourcesAndTtl selects snapshot resources by type, returning the map of resources and the associated TTL.
-func (s *Snapshot) GetResourcesAndTTL(typeURL string) map[string]types.ResourceWithTTL { // nolint:golint,revive
+// GetResourcesAndTTL selects snapshot resources by type, returning the map of resources and the associated TTL.
+func (s *Snapshot) GetResourcesAndTTL(typeURL resource.Type) map[string]types.ResourceWithTTL {
 	if s == nil {
 		return nil
 	}
@@ -120,7 +121,7 @@ func (s *Snapshot) GetResourcesAndTTL(typeURL string) map[string]types.ResourceW
 }
 
 // GetVersion returns the version for a resource type.
-func (s *Snapshot) GetVersion(typeURL string) string {
+func (s *Snapshot) GetVersion(typeURL resource.Type) string {
 	if s == nil {
 		return ""
 	}

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -37,32 +37,36 @@ type Snapshot struct {
 
 // NewSnapshot creates a snapshot from response types and a version.
 // The resources map is keyed off the type URL of a resource, followed by the slice of resource objects.
-func NewSnapshot(version string, resources map[resource.Type][]types.Resource) Snapshot {
+func NewSnapshot(version string, resources map[resource.Type][]types.Resource) (Snapshot, error) {
 	out := Snapshot{}
 
 	for typ, resource := range resources {
 		index := GetResponseType(typ)
-		if index != types.UnknownType {
-			out.Resources[index] = NewResources(version, resource)
+		if index == types.UnknownType {
+			return out, errors.New("unknown resource type: " + typ)
 		}
+
+		out.Resources[index] = NewResources(version, resource)
 	}
 
-	return out
+	return out, nil
 }
 
-// NewSnapshotWithTTLs creates a snapshot with time to live per resource.
+// NewSnapshotWithTTLs creates a snapshot of ResourceWithTTLs.
 // The resources map is keyed off the type URL of a resource, followed by the slice of resource objects.
-func NewSnapshotWithTTLs(version string, resources map[resource.Type][]types.ResourceWithTTL) Snapshot {
+func NewSnapshotWithTTLs(version string, resources map[resource.Type][]types.ResourceWithTTL) (Snapshot, error) {
 	out := Snapshot{}
 
 	for typ, resource := range resources {
 		index := GetResponseType(typ)
-		if index != types.UnknownType {
-			out.Resources[index] = NewResourcesWithTTL(version, resource)
+		if index == types.UnknownType {
+			return out, errors.New("unknown resource type: " + typ)
 		}
+
+		out.Resources[index] = NewResourcesWithTTL(version, resource)
 	}
 
-	return out
+	return out, nil
 }
 
 // Consistent check verifies that the dependent resources are exactly listed in the

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -27,18 +27,30 @@ func TestSnapshotConsistent(t *testing.T) {
 	if err := snapshot.Consistent(); err != nil {
 		t.Errorf("got inconsistent snapshot for %#v", snapshot)
 	}
-	if snap := cache.NewSnapshot(version, []types.Resource{testEndpoint}, nil, nil, nil, nil, nil, nil); snap.Consistent() == nil {
+
+	if snap := cache.NewSnapshot(version, map[string][]types.Resource{
+		rsrc.EndpointType: {testEndpoint},
+	}); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
-	if snap := cache.NewSnapshot(version, []types.Resource{resource.MakeEndpoint("missing", 8080)},
-		[]types.Resource{testCluster}, nil, nil, nil, nil, nil); snap.Consistent() == nil {
+
+	if snap := cache.NewSnapshot(version, map[string][]types.Resource{
+		rsrc.EndpointType: {resource.MakeEndpoint("missing", 8080)},
+		rsrc.ClusterType:  {testCluster},
+	}); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
-	if snap := cache.NewSnapshot(version, nil, nil, nil, []types.Resource{testListener}, nil, nil, nil); snap.Consistent() == nil {
+
+	if snap := cache.NewSnapshot(version, map[string][]types.Resource{
+		rsrc.ListenerType: {testListener}},
+	); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
-	if snap := cache.NewSnapshot(version, nil, nil,
-		[]types.Resource{resource.MakeRoute("test", clusterName)}, []types.Resource{testListener}, nil, nil, nil); snap.Consistent() == nil {
+
+	if snap := cache.NewSnapshot(version, map[string][]types.Resource{
+		rsrc.RouteType:    {resource.MakeRoute("test", clusterName)},
+		rsrc.ListenerType: {testListener},
+	}); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 }

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -28,26 +28,26 @@ func TestSnapshotConsistent(t *testing.T) {
 		t.Errorf("got inconsistent snapshot for %#v", snapshot)
 	}
 
-	if snap := cache.NewSnapshot(version, map[string][]types.Resource{
+	if snap := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType: {testEndpoint},
 	}); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 
-	if snap := cache.NewSnapshot(version, map[string][]types.Resource{
+	if snap := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType: {resource.MakeEndpoint("missing", 8080)},
 		rsrc.ClusterType:  {testCluster},
 	}); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 
-	if snap := cache.NewSnapshot(version, map[string][]types.Resource{
+	if snap := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {testListener}},
 	); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
 	}
 
-	if snap := cache.NewSnapshot(version, map[string][]types.Resource{
+	if snap := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.RouteType:    {resource.MakeRoute("test", clusterName)},
 		rsrc.ListenerType: {testListener},
 	}); snap.Consistent() == nil {

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -17,11 +17,12 @@ package cache_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSnapshotConsistent(t *testing.T) {

--- a/pkg/integration/ttl_integration_test.go
+++ b/pkg/integration/ttl_integration_test.go
@@ -67,10 +67,12 @@ func TestTTLResponse(t *testing.T) {
 
 	oneSecond := time.Second
 	cla := &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "resource"}
-	err = snapshotCache.SetSnapshot(context.Background(), "test", cache.NewSnapshotWithTtls("1", []types.ResourceWithTTL{{
-		Resource: cla,
-		TTL:      &oneSecond,
-	}}, nil, nil, nil, nil, nil))
+	err = snapshotCache.SetSnapshot(context.Background(), "test", cache.NewSnapshotWithTTLs("1", map[string][]types.ResourceWithTTL{
+		resource.EndpointType: {{
+			Resource: cla,
+			TTL:      &oneSecond,
+		}},
+	}))
 	assert.NoError(t, err)
 
 	timeout := time.NewTimer(5 * time.Second)

--- a/pkg/integration/ttl_integration_test.go
+++ b/pkg/integration/ttl_integration_test.go
@@ -67,7 +67,7 @@ func TestTTLResponse(t *testing.T) {
 
 	oneSecond := time.Second
 	cla := &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "resource"}
-	err = snapshotCache.SetSnapshot(context.Background(), "test", cache.NewSnapshotWithTTLs("1", map[string][]types.ResourceWithTTL{
+	err = snapshotCache.SetSnapshot(context.Background(), "test", cache.NewSnapshotWithTTLs("1", map[resource.Type][]types.ResourceWithTTL{
 		resource.EndpointType: {{
 			Resource: cla,
 			TTL:      &oneSecond,

--- a/pkg/integration/ttl_integration_test.go
+++ b/pkg/integration/ttl_integration_test.go
@@ -67,12 +67,13 @@ func TestTTLResponse(t *testing.T) {
 
 	oneSecond := time.Second
 	cla := &envoy_config_endpoint_v3.ClusterLoadAssignment{ClusterName: "resource"}
-	err = snapshotCache.SetSnapshot(context.Background(), "test", cache.NewSnapshotWithTTLs("1", map[resource.Type][]types.ResourceWithTTL{
+	snap, _ := cache.NewSnapshotWithTTLs("1", map[resource.Type][]types.ResourceWithTTL{
 		resource.EndpointType: {{
 			Resource: cla,
 			TTL:      &oneSecond,
 		}},
-	}))
+	})
+	err = snapshotCache.SetSnapshot(context.Background(), "test", snap)
 	assert.NoError(t, err)
 
 	timeout := time.NewTimer(5 * time.Second)

--- a/pkg/resource/v3/resource.go
+++ b/pkg/resource/v3/resource.go
@@ -8,6 +8,9 @@ import (
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 )
 
+// Type is an alias to string which we expose to users of the snapshot API which accepts `resource.Type` resource URLs.
+type Type = string
+
 // Resource types in xDS v3.
 const (
 	apiTypePrefix       = "type.googleapis.com/"

--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -444,16 +444,15 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 		extensions[i] = MakeExtensionConfig(Ads, extensionConfigName, routeName)
 	}
 
-	out := cache.NewSnapshot(
-		ts.Version,
-		endpoints,
-		clusters,
-		routes,
-		listeners,
-		runtimes,
-		secrets,
-		extensions,
-	)
+	out := cache.NewSnapshot(ts.Version, map[string][]types.Resource{
+		resource.EndpointType:        endpoints,
+		resource.ClusterType:         clusters,
+		resource.RouteType:           routes,
+		resource.ListenerType:        listeners,
+		resource.RuntimeType:         runtimes,
+		resource.SecretType:          secrets,
+		resource.ExtensionConfigType: extensions,
+	})
 
 	return out
 }

--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -444,7 +444,7 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 		extensions[i] = MakeExtensionConfig(Ads, extensionConfigName, routeName)
 	}
 
-	out := cache.NewSnapshot(ts.Version, map[resource.Type][]types.Resource{
+	out, _ := cache.NewSnapshot(ts.Version, map[resource.Type][]types.Resource{
 		resource.EndpointType:        endpoints,
 		resource.ClusterType:         clusters,
 		resource.RouteType:           routes,

--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -444,7 +444,7 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 		extensions[i] = MakeExtensionConfig(Ads, extensionConfigName, routeName)
 	}
 
-	out := cache.NewSnapshot(ts.Version, map[string][]types.Resource{
+	out := cache.NewSnapshot(ts.Version, map[resource.Type][]types.Resource{
 		resource.EndpointType:        endpoints,
 		resource.ClusterType:         clusters,
 		resource.RouteType:           routes,


### PR DESCRIPTION
reworks cache api so we no longer need to change function signatures when adding support for new xDS services