### PR TITLE
Adding -sleep flag

### DIFF
--- a/build/integration.sh
+++ b/build/integration.sh
@@ -16,6 +16,8 @@ XDS=${XDS:-ads}
 # pprof profiler mode
 MODE=${MODE:-0}
 
+SLEEP=${SLEEP:-0}
+
 # Number of RTDS layers.
 if [ "$XDS" = "ads" ]; then
   RUNTIMES=2
@@ -43,4 +45,4 @@ function cleanup() {
 trap cleanup EXIT
 
 # run the test suite (which also contains the control plane)
-bin/test --xds=${XDS} --runtimes=${RUNTIMES} --pprofMode=${MODE} -debug -message="$MESSAGE" "$@"
+bin/test --xds=${XDS} --runtimes=${RUNTIMES} --pprofMode=${MODE} -sleep=${SLEEP} -debug -message="$MESSAGE" "$@"

--- a/pkg/test/main/README.md
+++ b/pkg/test/main/README.md
@@ -37,3 +37,21 @@ eventually converges to use the latest pushed configuration) for each run.
 
 You can run ```bin/test -help``` to get a list of the cli flags that
 the test program accepts.  There are also comments in ```main.go```.
+
+## Running servers without running test scenarios
+
+For purposes such as running load testing or throughput benchmarking, there is
+a flag to just run the servers instead of running test scenarios. This allows a
+user to use all the configurations the test driver accepts which is described in
+the previous section and generate customized requests against it to conduct
+experiments. This can be done via an environment variable to `build/integration.sh`
+or `-sleep` flag to `bin/test`.
+
+e.g.
+```
+SLEEP=30m build/integration.sh
+```
+
+```
+SLEEP=2h make benchmark
+```


### PR DESCRIPTION
Added `-sleep` flag to test driver which will not run integration tests but wait for a given duration so that a user can send custom requests.

## How to test changes:

Build test binary
```
make bin/test
```
Run test driver for 5 minutes:
```
SLEEP=5m make benchmark
```

The log should show something like:
```
sleeping for 5m0s
...
sleep period is complete
```
