### PR TITLE
Introduce ResourceSnapshot interface.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/golang/protobuf v1.5.0
-	github.com/google/go-cmp v0.5.5
+	github.com/google/go-cmp v0.5.6
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/proto/otlp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,9 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -165,7 +165,7 @@ func makeConfigSource() *core.ConfigSource {
 	return source
 }
 
-func GenerateSnapshot() cache.Snapshot {
+func GenerateSnapshot() *cache.Snapshot {
 	snap, _ := cache.NewSnapshot("1",
 		map[resource.Type][]types.Resource{
 			resource.ClusterType:  {makeCluster(ClusterName)},

--- a/pkg/cache/v3/fixtures_test.go
+++ b/pkg/cache/v3/fixtures_test.go
@@ -1,0 +1,38 @@
+package cache_test
+
+import (
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+)
+
+var fixture = &fixtureGenerator{
+	version:  "x",
+	version2: "y",
+}
+
+type fixtureGenerator struct {
+	version  string
+	version2 string
+}
+
+func (f *fixtureGenerator) snapshot() *cache.Snapshot {
+	snapshot, err := cache.NewSnapshot(
+		f.version,
+		map[rsrc.Type][]types.Resource{
+			rsrc.EndpointType:        {testEndpoint},
+			rsrc.ClusterType:         {testCluster},
+			rsrc.RouteType:           {testRoute},
+			rsrc.ListenerType:        {testListener},
+			rsrc.RuntimeType:         {testRuntime},
+			rsrc.SecretType:          {testSecret[0]},
+			rsrc.ExtensionConfigType: {testExtensionConfig},
+		},
+	)
+
+	if err != nil {
+		panic(err.Error())
+	}
+
+	return snapshot
+}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -26,6 +26,35 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 )
 
+// ResourceSnapshot is an abstract snapshot of a collection of resources that
+// can be stored in a SnapshotCache. This enables applications to use the
+// SnapshotCache watch machinery with their own resource types. Most
+// applications will use Snapshot.
+type ResourceSnapshot interface {
+	// GetVersion should return the current version of the resource indicated
+	// by typeURL. The version string that is returned is opaque and should
+	// only be compared for equality.
+	GetVersion(typeURL string) string
+
+	// GetResourcesAndTTL returns all resources of the type indicted by
+	// typeURL, together with their TTL.
+	GetResourcesAndTTL(typeURL string) map[string]types.ResourceWithTTL
+
+	// GetResources returns all resources of the type indicted by
+	// typeURL. This is identical to GetResourcesAndTTL, except that
+	// the TTL is omitted.
+	GetResources(typeURL string) map[string]types.Resource
+
+	// ConstructVersionMap is a hint that a delta watch will soon make a
+	// call to GetVersionMap. The snapshot should construct an internal
+	// opaque version string for each collection of resource types.
+	ConstructVersionMap() error
+
+	// GetVersionMap returns a map of resource name to resource version for
+	// all the resources of type indicated by typeURL.
+	GetVersionMap(typeURL string) map[string]string
+}
+
 // SnapshotCache is a snapshot-based cache that maintains a single versioned
 // snapshot of responses per node. SnapshotCache consistently replies with the
 // latest snapshot. For the protocol to work correctly in ADS mode, EDS/RDS
@@ -46,10 +75,10 @@ type SnapshotCache interface {
 	//
 	// This method will cause the server to respond to all open watches, for which
 	// the version differs from the snapshot version.
-	SetSnapshot(ctx context.Context, node string, snapshot Snapshot) error
+	SetSnapshot(ctx context.Context, node string, snapshot ResourceSnapshot) error
 
 	// GetSnapshots gets the snapshot for a node.
-	GetSnapshot(node string) (Snapshot, error)
+	GetSnapshot(node string) (ResourceSnapshot, error)
 
 	// ClearSnapshot removes all status and snapshot information associated with a node.
 	ClearSnapshot(node string)
@@ -75,7 +104,7 @@ type snapshotCache struct {
 	ads bool
 
 	// snapshots are cached resources indexed by node IDs
-	snapshots map[string]Snapshot
+	snapshots map[string]ResourceSnapshot
 
 	// status information for all nodes indexed by node IDs
 	status map[string]*statusInfo
@@ -109,7 +138,7 @@ func newSnapshotCache(ads bool, hash NodeHash, logger log.Logger) *snapshotCache
 	cache := &snapshotCache{
 		log:       logger,
 		ads:       ads,
-		snapshots: make(map[string]Snapshot),
+		snapshots: make(map[string]ResourceSnapshot),
 		status:    make(map[string]*statusInfo),
 		hash:      hash,
 	}
@@ -188,7 +217,7 @@ func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
 }
 
 // SetSnapshotCacheContext updates a snapshot for a node.
-func (cache *snapshotCache) SetSnapshot(ctx context.Context, node string, snapshot Snapshot) error {
+func (cache *snapshotCache) SetSnapshot(ctx context.Context, node string, snapshot ResourceSnapshot) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
@@ -229,7 +258,7 @@ func (cache *snapshotCache) SetSnapshot(ctx context.Context, node string, snapsh
 		for id, watch := range info.deltaWatches {
 			res, err := cache.respondDelta(
 				ctx,
-				&snapshot,
+				snapshot,
 				watch.Request,
 				watch.Response,
 				watch.StreamState,
@@ -249,13 +278,13 @@ func (cache *snapshotCache) SetSnapshot(ctx context.Context, node string, snapsh
 }
 
 // GetSnapshots gets the snapshot for a node, and returns an error if not found.
-func (cache *snapshotCache) GetSnapshot(node string) (Snapshot, error) {
+func (cache *snapshotCache) GetSnapshot(node string) (ResourceSnapshot, error) {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
 
 	snap, ok := cache.snapshots[node]
 	if !ok {
-		return Snapshot{}, fmt.Errorf("no snapshot found for node %s", node)
+		return nil, fmt.Errorf("no snapshot found for node %s", node)
 	}
 	return snap, nil
 }
@@ -306,8 +335,12 @@ func (cache *snapshotCache) CreateWatch(request *Request, streamState stream.Str
 	info.lastWatchRequestTime = time.Now()
 	info.mu.Unlock()
 
+	var version string
+
 	snapshot, exists := cache.snapshots[nodeID]
-	version := snapshot.GetVersion(request.TypeUrl)
+	if exists {
+		version = snapshot.GetVersion(request.TypeUrl)
+	}
 
 	if exists {
 		knownResourceNames := streamState.GetKnownResourceNames(request.TypeUrl)
@@ -339,7 +372,6 @@ func (cache *snapshotCache) CreateWatch(request *Request, streamState stream.Str
 	if !exists || request.VersionInfo == version {
 		watchID := cache.nextWatchID()
 		cache.log.Debugf("open watch %d for %s%v from nodeID %q, version %q", watchID, request.TypeUrl, request.ResourceNames, nodeID, request.VersionInfo)
-
 		info.mu.Lock()
 		info.watches[watchID] = ResponseWatch{Request: request, Response: value}
 		info.mu.Unlock()
@@ -452,11 +484,11 @@ func (cache *snapshotCache) CreateDeltaWatch(request *DeltaRequest, state stream
 	if exists {
 		err := snapshot.ConstructVersionMap()
 		if err != nil {
-			cache.log.Errorf("failed to compute version for snapshot resources inline, waiting for next snapshot update")
+			cache.log.Errorf("failed to compute version for snapshot resources inline: %s", err)
 		}
-		response, err := cache.respondDelta(context.Background(), &snapshot, request, value, state)
+		response, err := cache.respondDelta(context.Background(), snapshot, request, value, state)
 		if err != nil {
-			cache.log.Errorf("failed to respond with delta response, waiting for next snapshot update: %s", err)
+			cache.log.Errorf("failed to respond with delta response: %s", err)
 		}
 
 		delayedResponse = response == nil
@@ -464,9 +496,14 @@ func (cache *snapshotCache) CreateDeltaWatch(request *DeltaRequest, state stream
 
 	if delayedResponse {
 		watchID := cache.nextDeltaWatchID()
-		cache.log.Infof("open delta watch ID:%d for %s Resources:%v from nodeID: %q, system version %q", watchID, t, state.GetResourceVersions(), nodeID, snapshot.GetVersion(t))
-		info.setDeltaResponseWatch(watchID, DeltaResponseWatch{Request: request, Response: value, StreamState: state})
 
+		if exists {
+			cache.log.Infof("open delta watch ID:%d for %s Resources:%v from nodeID: %q,  version %q", watchID, t, state.GetResourceVersions(), nodeID, snapshot.GetVersion(t))
+		} else {
+			cache.log.Infof("open delta watch ID:%d for %s Resources:%v from nodeID: %q", watchID, t, state.GetResourceVersions(), nodeID)
+		}
+
+		info.setDeltaResponseWatch(watchID, DeltaResponseWatch{Request: request, Response: value, StreamState: state})
 		return cache.cancelDeltaWatch(nodeID, watchID)
 	}
 
@@ -474,7 +511,7 @@ func (cache *snapshotCache) CreateDeltaWatch(request *DeltaRequest, state stream
 }
 
 // Respond to a delta watch with the provided snapshot value. If the response is nil, there has been no state change.
-func (cache *snapshotCache) respondDelta(ctx context.Context, snapshot *Snapshot, request *DeltaRequest, value chan DeltaResponse, state stream.StreamState) (*RawDeltaResponse, error) {
+func (cache *snapshotCache) respondDelta(ctx context.Context, snapshot ResourceSnapshot, request *DeltaRequest, value chan DeltaResponse, state stream.StreamState) (*RawDeltaResponse, error) {
 	resp := createDeltaResponse(ctx, request, state, resourceContainer{
 		resourceMap:   snapshot.GetResources(request.TypeUrl),
 		versionMap:    snapshot.GetVersionMap(request.TypeUrl),

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -22,7 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -47,21 +53,8 @@ func (group) ID(node *core.Node) string {
 }
 
 var (
-	version  = "x"
-	version2 = "y"
-
-	snapshot, _ = cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
-		rsrc.EndpointType:        {testEndpoint},
-		rsrc.ClusterType:         {testCluster},
-		rsrc.RouteType:           {testRoute},
-		rsrc.ListenerType:        {testListener},
-		rsrc.RuntimeType:         {testRuntime},
-		rsrc.SecretType:          {testSecret[0]},
-		rsrc.ExtensionConfigType: {testExtensionConfig},
-	})
-
 	ttl                = 2 * time.Second
-	snapshotWithTTL, _ = cache.NewSnapshotWithTTLs(version, map[rsrc.Type][]types.ResourceWithTTL{
+	snapshotWithTTL, _ = cache.NewSnapshotWithTTLs(fixture.version, map[rsrc.Type][]types.ResourceWithTTL{
 		rsrc.EndpointType:        {{Resource: testEndpoint, TTL: &ttl}},
 		rsrc.ClusterType:         {{Resource: testCluster}},
 		rsrc.RouteType:           {{Resource: testRoute}},
@@ -129,8 +122,8 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 			c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}, streamState, value)
 			select {
 			case out := <-value:
-				if gotVersion, _ := out.GetVersion(); gotVersion != version {
-					t.Errorf("got version %q, want %q", gotVersion, version)
+				if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
+					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
 				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResourcesAndTTL(typ))
@@ -155,13 +148,13 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 			end := time.After(5 * time.Second)
 			for {
 				value := make(chan cache.Response, 1)
-				cancel := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: version},
+				cancel := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: fixture.version},
 					streamState, value)
 
 				select {
 				case out := <-value:
-					if gotVersion, _ := out.GetVersion(); gotVersion != version {
-						t.Errorf("got version %q, want %q", gotVersion, version)
+					if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
+						t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 					}
 					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
@@ -200,7 +193,7 @@ func TestSnapshotCache(t *testing.T) {
 		t.Errorf("unexpected snapshot found for key %q", key)
 	}
 
-	if err := c.SetSnapshot(context.Background(), key, snapshot); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, fixture.snapshot()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -208,8 +201,8 @@ func TestSnapshotCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(snap, snapshot) {
-		t.Errorf("expect snapshot: %v, got: %v", snapshot, snap)
+	if !reflect.DeepEqual(snap, fixture.snapshot()) {
+		t.Errorf("expect snapshot: %v, got: %v", fixture.snapshot(), snap)
 	}
 
 	// try to get endpoints with incorrect list of names
@@ -232,8 +225,9 @@ func TestSnapshotCache(t *testing.T) {
 				streamState, value)
 			select {
 			case out := <-value:
-				if gotVersion, _ := out.GetVersion(); gotVersion != version {
-					t.Errorf("got version %q, want %q", gotVersion, version)
+				snapshot := fixture.snapshot()
+				if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
+					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
 				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
 					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
@@ -247,7 +241,7 @@ func TestSnapshotCache(t *testing.T) {
 
 func TestSnapshotCacheFetch(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
-	if err := c.SetSnapshot(context.Background(), key, snapshot); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, fixture.snapshot()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -257,8 +251,8 @@ func TestSnapshotCacheFetch(t *testing.T) {
 			if err != nil || resp == nil {
 				t.Fatal("unexpected error or null response")
 			}
-			if gotVersion, _ := resp.GetVersion(); gotVersion != version {
-				t.Errorf("got version %q, want %q", gotVersion, version)
+			if gotVersion, _ := resp.GetVersion(); gotVersion != fixture.version {
+				t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 			}
 		})
 	}
@@ -271,7 +265,7 @@ func TestSnapshotCacheFetch(t *testing.T) {
 
 	// no response for latest version
 	if resp, err := c.Fetch(context.Background(),
-		&discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, VersionInfo: version}); resp != nil || err == nil {
+		&discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType, VersionInfo: fixture.version}); resp != nil || err == nil {
 		t.Errorf("latest version: response is not nil %v", resp)
 	}
 }
@@ -284,16 +278,17 @@ func TestSnapshotCacheWatch(t *testing.T) {
 		watches[typ] = make(chan cache.Response, 1)
 		c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}, streamState, watches[typ])
 	}
-	if err := c.SetSnapshot(context.Background(), key, snapshot); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, fixture.snapshot()); err != nil {
 		t.Fatal(err)
 	}
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
-				if gotVersion, _ := out.GetVersion(); gotVersion != version {
-					t.Errorf("got version %q, want %q", gotVersion, version)
+				if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
+					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
+				snapshot := fixture.snapshot()
 				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
 					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
 				}
@@ -307,7 +302,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	// open new watches with the latest version
 	for _, typ := range testTypes {
 		watches[typ] = make(chan cache.Response, 1)
-		c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: version},
+		c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ], VersionInfo: fixture.version},
 			streamState, watches[typ])
 	}
 	if count := c.GetStatusInfo(key).GetNumWatches(); count != len(testTypes) {
@@ -315,8 +310,8 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	}
 
 	// set partially-versioned snapshot
-	snapshot2 := snapshot
-	snapshot2.Resources[types.Endpoint] = cache.NewResources(version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
+	snapshot2 := fixture.snapshot()
+	snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
 	if err := c.SetSnapshot(context.Background(), key, snapshot2); err != nil {
 		t.Fatal(err)
 	}
@@ -327,8 +322,8 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	// validate response for endpoints
 	select {
 	case out := <-watches[rsrc.EndpointType]:
-		if gotVersion, _ := out.GetVersion(); gotVersion != version2 {
-			t.Errorf("got version %q, want %q", gotVersion, version2)
+		if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version2 {
+			t.Errorf("got version %q, want %q", gotVersion, fixture.version2)
 		}
 		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
 			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
@@ -348,7 +343,7 @@ func TestConcurrentSetWatch(t *testing.T) {
 			if i < 25 {
 				snap := cache.Snapshot{}
 				snap.Resources[types.Endpoint] = cache.NewResources(fmt.Sprintf("v%d", i), []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
-				if err := c.SetSnapshot(context.Background(), id, snap); err != nil {
+				if err := c.SetSnapshot(context.Background(), id, &snap); err != nil {
 					t.Fatalf("failed to set snapshot %q: %s", id, err)
 				}
 			} else {
@@ -401,7 +396,7 @@ func TestSnapshotCacheWatchTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
-	err := c.SetSnapshot(ctx, key, snapshot)
+	err := c.SetSnapshot(ctx, key, fixture.snapshot())
 	assert.EqualError(t, err, context.Canceled.Error())
 
 	// Now reset the snapshot with a consuming channel. This verifies that if setting the snapshot fails,
@@ -414,7 +409,7 @@ func TestSnapshotCacheWatchTimeout(t *testing.T) {
 		close(watchTriggeredCh)
 	}()
 
-	err = c.SetSnapshot(context.WithValue(context.Background(), testKey{}, "bar"), key, snapshot)
+	err = c.SetSnapshot(context.WithValue(context.Background(), testKey{}, "bar"), key, fixture.snapshot())
 	assert.NoError(t, err)
 
 	// The channel should get closed due to the watch trigger.
@@ -433,7 +428,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 	listenerName2 := "listenerName2"
 	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
 
-	snapshot2, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	snapshot2, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType:        {testEndpoint, resource.MakeEndpoint(clusterName2, 8080)},
 		rsrc.ClusterType:         {testCluster, resource.MakeCluster(resource.Ads, clusterName2)},
 		rsrc.RouteType:           {testRoute, resource.MakeRoute(routeName2, clusterName2)},
@@ -455,8 +450,8 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 
 	select {
 	case out := <-watch:
-		if gotVersion, _ := out.GetVersion(); gotVersion != version {
-			t.Errorf("got version %q, want %q", gotVersion, version)
+		if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
+			t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 		}
 		want := map[string]types.ResourceWithTTL{clusterName: snapshot2.Resources[types.Endpoint].Items[clusterName]}
 		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), want) {
@@ -470,14 +465,14 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 	go func() {
 		state := stream.NewStreamState(false, map[string]string{})
 		state.SetKnownResourceNames(rsrc.EndpointType, map[string]struct{}{clusterName: {}})
-		c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, VersionInfo: version,
+		c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, VersionInfo: fixture.version,
 			ResourceNames: []string{clusterName, clusterName2}}, state, watch)
 	}()
 
 	select {
 	case out := <-watch:
-		if gotVersion, _ := out.GetVersion(); gotVersion != version {
-			t.Errorf("got version %q, want %q", gotVersion, version)
+		if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
+			t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 		}
 		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
 			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
@@ -489,7 +484,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 	// Repeat request for with same version and make sure a watch is created
 	state := stream.NewStreamState(false, map[string]string{})
 	state.SetKnownResourceNames(rsrc.EndpointType, map[string]struct{}{clusterName: {}, clusterName2: {}})
-	if cancel := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, VersionInfo: version,
+	if cancel := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, VersionInfo: fixture.version,
 		ResourceNames: []string{clusterName, clusterName2}}, state, watch); cancel == nil {
 		t.Fatal("Should create a watch")
 	} else {
@@ -499,7 +494,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 
 func TestSnapshotClear(t *testing.T) {
 	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
-	if err := c.SetSnapshot(context.Background(), key, snapshot); err != nil {
+	if err := c.SetSnapshot(context.Background(), key, fixture.snapshot()); err != nil {
 		t.Fatal(err)
 	}
 	c.ClearSnapshot(key)
@@ -509,4 +504,97 @@ func TestSnapshotClear(t *testing.T) {
 	if keys := c.GetStatusKeys(); len(keys) != 0 {
 		t.Errorf("keys should be empty")
 	}
+}
+
+type singleResourceSnapshot struct {
+	version  string
+	typeurl  string
+	name     string
+	resource types.Resource
+}
+
+func (s *singleResourceSnapshot) GetVersion(typeURL string) string {
+	return s.version
+}
+
+func (s *singleResourceSnapshot) GetResourcesAndTTL(typeURL string) map[string]types.ResourceWithTTL {
+	if typeURL != s.typeurl {
+		return nil
+	}
+
+	ttl := time.Second
+	return map[string]types.ResourceWithTTL{
+		s.name: {Resource: s.resource, TTL: &ttl},
+	}
+}
+
+func (s *singleResourceSnapshot) GetResources(typeURL string) map[string]types.Resource {
+	if typeURL != s.typeurl {
+		return nil
+	}
+	return map[string]types.Resource{
+		s.name: s.resource,
+	}
+}
+
+func (s *singleResourceSnapshot) ConstructVersionMap() error {
+	return nil
+}
+
+func (s *singleResourceSnapshot) GetVersionMap(typeURL string) map[string]string {
+	if typeURL != s.typeurl {
+		return nil
+	}
+	return map[string]string{
+		s.name: s.version,
+	}
+}
+
+// TestSnapshotSingleResourceFetch is a basic test to verify that simple
+// cache functions work with a type that is not `Snapshot`.
+func TestSnapshotSingleResourceFetch(t *testing.T) {
+	durationTypeURL := "type.googleapis.com/" + string(proto.MessageName(&durationpb.Duration{}))
+
+	anyDuration := func(d time.Duration) *anypb.Any {
+		bytes, err := cache.MarshalResource(durationpb.New(d))
+		require.NoError(t, err)
+		return &anypb.Any{
+			TypeUrl: durationTypeURL,
+			Value:   bytes,
+		}
+	}
+
+	unwrapResource := func(src *anypb.Any) *discovery.Resource {
+		dst := &discovery.Resource{}
+		require.NoError(t, anypb.UnmarshalTo(src, dst, proto.UnmarshalOptions{}))
+		return dst
+	}
+
+	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	require.NoError(t, c.SetSnapshot(context.Background(), key, &singleResourceSnapshot{
+		version:  "version-one",
+		typeurl:  durationTypeURL,
+		name:     "one-second",
+		resource: durationpb.New(time.Second),
+	}))
+
+	resp, err := c.Fetch(context.Background(), &discovery.DiscoveryRequest{
+		TypeUrl:       durationTypeURL,
+		ResourceNames: []string{"one-second"}},
+	)
+	require.NoError(t, err)
+
+	vers, err := resp.GetVersion()
+	require.NoError(t, err)
+	assert.Equal(t, "version-one", vers)
+
+	discoveryResponse, err := resp.GetDiscoveryResponse()
+	require.NoError(t, err)
+	assert.Equal(t, durationTypeURL, discoveryResponse.GetTypeUrl())
+	require.Equal(t, 1, len(discoveryResponse.GetResources()))
+	assert.Equal(t, "", cmp.Diff(
+		unwrapResource(discoveryResponse.GetResources()[0]).GetResource(),
+		anyDuration(time.Second),
+		protocmp.Transform()),
+	)
 }

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -35,38 +35,40 @@ type Snapshot struct {
 	VersionMap map[string]map[string]string
 }
 
+var _ ResourceSnapshot = &Snapshot{}
+
 // NewSnapshot creates a snapshot from response types and a version.
 // The resources map is keyed off the type URL of a resource, followed by the slice of resource objects.
-func NewSnapshot(version string, resources map[resource.Type][]types.Resource) (Snapshot, error) {
+func NewSnapshot(version string, resources map[resource.Type][]types.Resource) (*Snapshot, error) {
 	out := Snapshot{}
 
 	for typ, resource := range resources {
 		index := GetResponseType(typ)
 		if index == types.UnknownType {
-			return out, errors.New("unknown resource type: " + typ)
+			return nil, errors.New("unknown resource type: " + typ)
 		}
 
 		out.Resources[index] = NewResources(version, resource)
 	}
 
-	return out, nil
+	return &out, nil
 }
 
 // NewSnapshotWithTTLs creates a snapshot of ResourceWithTTLs.
 // The resources map is keyed off the type URL of a resource, followed by the slice of resource objects.
-func NewSnapshotWithTTLs(version string, resources map[resource.Type][]types.ResourceWithTTL) (Snapshot, error) {
+func NewSnapshotWithTTLs(version string, resources map[resource.Type][]types.ResourceWithTTL) (*Snapshot, error) {
 	out := Snapshot{}
 
 	for typ, resource := range resources {
 		index := GetResponseType(typ)
 		if index == types.UnknownType {
-			return out, errors.New("unknown resource type: " + typ)
+			return nil, errors.New("unknown resource type: " + typ)
 		}
 
 		out.Resources[index] = NewResourcesWithTTL(version, resource)
 	}
 
-	return out, nil
+	return &out, nil
 }
 
 // Consistent check verifies that the dependent resources are exactly listed in the

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -28,13 +28,15 @@ import (
 
 // Tests the snapshot defined in simple_test.go to ensure it is consistent.
 func TestTestSnapshotIsConsistent(t *testing.T) {
+	snapshot := fixture.snapshot()
+
 	if err := snapshot.Consistent(); err != nil {
 		t.Errorf("got inconsistent snapshot for %#v\nerr=%s", snapshot, err.Error())
 	}
 }
 
 func TestSnapshotWithOnlyEndpointIsInconsistent(t *testing.T) {
-	if snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	if snap, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType: {testEndpoint},
 	}); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
@@ -42,7 +44,7 @@ func TestSnapshotWithOnlyEndpointIsInconsistent(t *testing.T) {
 }
 
 func TestClusterWithMissingEndpointIsInconsistent(t *testing.T) {
-	if snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	if snap, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType: {resource.MakeEndpoint("missing", 8080)},
 		rsrc.ClusterType:  {testCluster},
 	}); snap.Consistent() == nil {
@@ -51,7 +53,7 @@ func TestClusterWithMissingEndpointIsInconsistent(t *testing.T) {
 }
 
 func TestListenerWithMissingRoutesIsInconsistent(t *testing.T) {
-	if snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	if snap, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {testListener}},
 	); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
@@ -59,7 +61,7 @@ func TestListenerWithMissingRoutesIsInconsistent(t *testing.T) {
 }
 
 func TestListenerWithUnidentifiedRouteIsInconsistent(t *testing.T) {
-	if snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	if snap, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.RouteType:    {resource.MakeRoute("test", clusterName)},
 		rsrc.ListenerType: {testListener},
 	}); snap.Consistent() == nil {
@@ -68,7 +70,7 @@ func TestListenerWithUnidentifiedRouteIsInconsistent(t *testing.T) {
 }
 
 func TestRouteListenerWithRouteIsConsistent(t *testing.T) {
-	snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	snap, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
 			resource.MakeRouteHTTPListener(resource.Xds, "listener1", 80, "testRoute0"),
 		},
@@ -83,7 +85,7 @@ func TestRouteListenerWithRouteIsConsistent(t *testing.T) {
 }
 
 func TestScopedRouteListenerWithScopedRouteOnlyIsInconsistent(t *testing.T) {
-	if snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	if snap, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
 			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80),
 		},
@@ -96,7 +98,7 @@ func TestScopedRouteListenerWithScopedRouteOnlyIsInconsistent(t *testing.T) {
 }
 
 func TestScopedRouteListenerWithScopedRouteAndRouteIsConsistent(t *testing.T) {
-	snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	snap, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
 			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80),
 		},
@@ -112,7 +114,7 @@ func TestScopedRouteListenerWithScopedRouteAndRouteIsConsistent(t *testing.T) {
 }
 
 func TestScopedRouteListenerWithInlineScopedRouteAndRouteIsConsistent(t *testing.T) {
-	snap, err := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	snap, err := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
 			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "testRoute0"),
 		},
@@ -126,7 +128,7 @@ func TestScopedRouteListenerWithInlineScopedRouteAndRouteIsConsistent(t *testing
 }
 
 func TestScopedRouteListenerWithInlineScopedRouteAndNoRouteIsInconsistent(t *testing.T) {
-	snap, err := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	snap, err := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
 			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "testRoute0"),
 		},
@@ -140,7 +142,7 @@ func TestScopedRouteListenerWithInlineScopedRouteAndNoRouteIsInconsistent(t *tes
 }
 
 func TestMultipleListenersWithScopedRouteAndRouteIsConsistent(t *testing.T) {
-	snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	snap, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
 			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80),
 			resource.MakeRouteHTTPListener(resource.Xds, "listener1", 80, "testRoute1"),
@@ -170,6 +172,8 @@ func TestSnapshotGetters(t *testing.T) {
 	if out := nilsnap.GetVersion(rsrc.EndpointType); out != "" {
 		t.Errorf("got non-empty version for nil snapshot: %#v", out)
 	}
+
+	snapshot := fixture.snapshot()
 	if out := snapshot.GetResources("not a type"); out != nil {
 		t.Errorf("got non-empty resources for unknown type: %#v", out)
 	}
@@ -179,11 +183,11 @@ func TestSnapshotGetters(t *testing.T) {
 }
 
 func TestNewSnapshotBadType(t *testing.T) {
-	snap, err := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	snap, err := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		"random.type": nil,
 	})
 
 	// Should receive an error from an unknown type
 	assert.Error(t, err)
-	assert.Equal(t, cache.Snapshot{}, snap)
+	assert.Nil(t, snap)
 }

--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -512,7 +512,7 @@ type TestSnapshot struct {
 }
 
 // Generate produces a snapshot from the parameters.
-func (ts TestSnapshot) Generate() cache.Snapshot {
+func (ts TestSnapshot) Generate() *cache.Snapshot {
 	clusters := make([]types.Resource, ts.NumClusters)
 	endpoints := make([]types.Resource, ts.NumClusters)
 	for i := 0; i < ts.NumClusters; i++ {


### PR DESCRIPTION
Introduce a ResourceSnaphot interface to abstract the type of the snapshot
stored in a SnapshotCache. This allows applications to use SnapshotCache
without also having to use Snapshot. The usefulness of that is that it
is possible to use SnapshotCache with non-Envoy xDS applications.

This fixes #489.

Signed-off-by: James Peach <jpeach@apache.org>