### PR TITLE
Fix linear cache data race

### DIFF
--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -250,7 +250,14 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 func (cache *LinearCache) GetResources() map[string]types.Resource {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
-	return cache.resources
+
+	// create a copy of our internal storage to avoid data races
+	// involving mutations of our backing map
+	resources := make(map[string]types.Resource, len(cache.resources))
+	for k, v := range cache.resources {
+		resources[k] = v
+	}
+	return resources
 }
 
 func (cache *LinearCache) CreateWatch(request *Request, value chan Response) func() {


### PR DESCRIPTION
I'm currently leveraging this library to implement an SDS server. As part of that work I expose resources stored in a linear cache as metrics -- this involves handling updating and removing cache entries in one goroutine and reading doing map length calculations periodically in another.

While running go's race detector I was getting warnings with this pattern that can be recreated with [this gist](https://gist.github.com/andrewstucki/aae130f78bdc291877ed8675fa8c7f05#file-main-go). They look like:

```
➜  control-plane-demo go run -race main.go
==================
WARNING: DATA RACE
Write at 0x00c000263c50 by goroutine 8:
  runtime.mapdelete_faststr()
      /usr/local/Cellar/go/1.17.1/libexec/src/runtime/map_faststr.go:300 +0x0
  github.com/envoyproxy/go-control-plane/pkg/cache/v3.(*LinearCache).DeleteResource()
      /Users/me/Code/go/pkg/mod/github.com/envoyproxy/go-control-plane@v0.9.10-0.20211015202125-ac6f816cacb0/pkg/cache/v3/linear.go:211 +0x176
  main.main.func2()
      /Users/me/control-plane-demo/main.go:60 +0x144

Previous read at 0x00c000263c50 by goroutine 9:
  main.main.func3()
      /Users/me/control-plane-demo/main.go:72 +0x108

Goroutine 8 (running) created at:
  main.main()
      /Users/me/control-plane-demo/main.go:52 +0x776

Goroutine 9 (running) created at:
  main.main()
      /Users/me/control-plane-demo/main.go:65 +0x8a4
==================
Cache has 0 resources
Cache has 0 resources
Cache has 0 resources
Cache has 0 resources
Found 1 data race(s)
exit status 66
```

From a quick perusal of the code, despite locking around the underlying resources map, the `GetResources` function returns the map directly and subsequent reads/modifications of this return value are no longer guarded by the cache's mutex. This PR modifies `GetResources` to return a copy of the underlying map rather than the map itself. The data race goes away:

```
➜  control-plane-demo go run -race main.go
Cache has 0 resources
Cache has 0 resources
Cache has 0 resources
Cache has 0 resources
```