### PR TITLE
cache: remove watch ID methods from the StatusInfo interface

### DIFF
--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -410,7 +410,7 @@ func (cache *snapshotCache) CreateDeltaWatch(request *DeltaRequest, state stream
 	}
 
 	// update last watch request time
-	info.SetLastDeltaWatchRequestTime(time.Now())
+	info.setLastDeltaWatchRequestTime(time.Now())
 
 	// find the current cache snapshot for the provided node
 	snapshot, exists := cache.snapshots[nodeID]
@@ -436,7 +436,7 @@ func (cache *snapshotCache) CreateDeltaWatch(request *DeltaRequest, state stream
 	if delayedResponse {
 		watchID := cache.nextDeltaWatchID()
 		cache.log.Infof("open delta watch ID:%d for %s Resources:%v from nodeID: %q, system version %q", watchID, t, state.GetResourceVersions(), nodeID, snapshot.GetVersion(t))
-		info.SetDeltaResponseWatch(watchID, DeltaResponseWatch{Request: request, Response: value, StreamState: state})
+		info.setDeltaResponseWatch(watchID, DeltaResponseWatch{Request: request, Response: value, StreamState: state})
 
 		return cache.cancelDeltaWatch(nodeID, watchID)
 	}

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -41,8 +41,7 @@ func (IDHash) ID(node *core.Node) string {
 
 var _ NodeHash = IDHash{}
 
-// StatusInfo tracks the server state for the remote Envoy node.
-// Not all fields are used by all cache implementations.
+// StatusInfo publishes information about nodes that are watching the xDS cache.
 type StatusInfo interface {
 	// GetNode returns the node metadata.
 	GetNode() *core.Node
@@ -58,14 +57,9 @@ type StatusInfo interface {
 
 	// GetLastDeltaWatchRequestTime returns the timestamp of the last delta discovery watch request.
 	GetLastDeltaWatchRequestTime() time.Time
-
-	// SetLastDeltaWatchRequestTime will set the current time of the last delta discovery watch request
-	SetLastDeltaWatchRequestTime(time.Time)
-
-	// SetDeltaResponseWatch will set the provided delta response watch to the associate watch ID
-	SetDeltaResponseWatch(int64, DeltaResponseWatch)
 }
 
+// statusInfo tracks the server state for the remote Envoy node.
 type statusInfo struct {
 	// node is the constant Envoy node metadata.
 	node *core.Node
@@ -148,20 +142,15 @@ func (info *statusInfo) GetLastDeltaWatchRequestTime() time.Time {
 	return info.lastDeltaWatchRequestTime
 }
 
-// GetDeltaStreamState will pull the stream state with the version map out of a specific watch
-func (info *statusInfo) GetDeltaStreamState(watchID int64) stream.StreamState {
-	info.mu.RLock()
-	defer info.mu.RUnlock()
-	return info.deltaWatches[watchID].StreamState
-}
-
-func (info *statusInfo) SetLastDeltaWatchRequestTime(t time.Time) {
+// setLastDeltaWatchRequestTime will set the current time of the last delta discovery watch request.
+func (info *statusInfo) setLastDeltaWatchRequestTime(t time.Time) {
 	info.mu.Lock()
 	defer info.mu.Unlock()
 	info.lastDeltaWatchRequestTime = t
 }
 
-func (info *statusInfo) SetDeltaResponseWatch(id int64, drw DeltaResponseWatch) {
+// setDeltaResponseWatch will set the provided delta response watch for the associated watch ID.
+func (info *statusInfo) setDeltaResponseWatch(id int64, drw DeltaResponseWatch) {
 	info.mu.Lock()
 	defer info.mu.Unlock()
 	info.deltaWatches[id] = drw


### PR DESCRIPTION
The concept of a watch ID is an implementation detail of the snapshot
cache and not exposed in the public API. Remove StatusInfo interface
methods that reference watch IDs, because callers won't be able to
use them.

Fixes #504 

Signed-off-by: James Peach <jpeach@apache.org>