### PR TITLE
Hold a read lock while canceling a snapshot watch.

### DIFF
--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -335,8 +335,8 @@ func (cache *snapshotCache) nextWatchID() int64 {
 func (cache *snapshotCache) cancelWatch(nodeID string, watchID int64) func() {
 	return func() {
 		// uses the cache mutex
-		cache.mu.Lock()
-		defer cache.mu.Unlock()
+		cache.mu.RLock()
+		defer cache.mu.RUnlock()
 		if info, ok := cache.status[nodeID]; ok {
 			info.mu.Lock()
 			delete(info.watches, watchID)
@@ -477,8 +477,8 @@ func (cache *snapshotCache) nextDeltaWatchID() int64 {
 // cancellation function for cleaning stale delta watches
 func (cache *snapshotCache) cancelDeltaWatch(nodeID string, watchID int64) func() {
 	return func() {
-		cache.mu.Lock()
-		defer cache.mu.Unlock()
+		cache.mu.RLock()
+		defer cache.mu.RUnlock()
 		if info, ok := cache.status[nodeID]; ok {
 			info.mu.Lock()
 			delete(info.deltaWatches, watchID)


### PR DESCRIPTION
Since canceling a watch only modified the corresponding statusInfo, we
don't need to hold a write lock on the snapshot cache. Holding a read
lock is sufficient to ensure that the status entry is stable.

This updates #503.

Signed-off-by: James Peach <jpeach@apache.org>