### PR TITLE
Fix scoped route consistency check.

### DIFF
--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -112,6 +112,30 @@ func TestScopedRouteListenerWithScopedRouteAndRouteIsConsistent(t *testing.T) {
 	}
 }
 
+func TestScopedRouteListenerWithInlineScopedRouteAndRouteIsConsistent(t *testing.T) {
+	snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+		rsrc.ListenerType: {
+			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "scopedRoute0", "testRoute0"),
+		},
+		rsrc.RouteType: {
+			resource.MakeRoute("testRoute0", clusterName),
+		},
+	})
+
+	assert.NoError(t, snap.Consistent())
+
+	snap, _ = cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+		rsrc.ListenerType: {
+			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "scopedRoute0", "testRoute0"),
+		},
+		rsrc.RouteType: {
+			resource.MakeRoute("testRoute1", clusterName),
+		},
+	})
+
+	assert.Error(t, snap.Consistent())
+}
+
 func TestMultipleListenersWithScopedRouteAndRouteIsConsistent(t *testing.T) {
 	snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -113,7 +114,7 @@ func TestScopedRouteListenerWithScopedRouteAndRouteIsConsistent(t *testing.T) {
 }
 
 func TestScopedRouteListenerWithInlineScopedRouteAndRouteIsConsistent(t *testing.T) {
-	snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+	snap, err := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
 			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "scopedRoute0", "testRoute0"),
 		},
@@ -122,9 +123,12 @@ func TestScopedRouteListenerWithInlineScopedRouteAndRouteIsConsistent(t *testing
 		},
 	})
 
+	require.NoError(t, err)
 	assert.NoError(t, snap.Consistent())
+}
 
-	snap, _ = cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
+func TestScopedRouteListenerWithInlineScopedRouteAndNoRouteIsInconsistent(t *testing.T) {
+	snap, err := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
 			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "scopedRoute0", "testRoute0"),
 		},
@@ -133,6 +137,7 @@ func TestScopedRouteListenerWithInlineScopedRouteAndRouteIsConsistent(t *testing
 		},
 	})
 
+	require.NoError(t, err)
 	assert.Error(t, snap.Consistent())
 }
 


### PR DESCRIPTION
Scoped routes can be specified with a SRDS resource, or they can be
inlined, in which case a RDS resource is needed. The snapshot consistency
checker was always assuming the former case.

This fixes #514.

Signed-off-by: James Peach <jpeach@apache.org>
