### PR TITLE
Fix scoped route references.

### DIFF
--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -125,6 +125,10 @@ func TestGetResourceReferences(t *testing.T) {
 			out: map[rsrc.Type]map[string]bool{},
 		},
 		{
+			in:  resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, listenerName, 80, routeName),
+			out: map[rsrc.Type]map[string]bool{rsrc.RouteType: {routeName: true}},
+		},
+		{
 			in:  resource.MakeRouteHTTPListener(resource.Ads, listenerName, 80, routeName),
 			out: map[rsrc.Type]map[string]bool{rsrc.RouteType: {routeName: true}},
 		},

--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -18,6 +18,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -44,31 +46,21 @@ var (
 	testRoute           = resource.MakeRoute(routeName, clusterName)
 	testScopedRoute     = resource.MakeScopedRoute(scopedRouteName, routeName, []string{"1.2.3.4"})
 	testListener        = resource.MakeRouteHTTPListener(resource.Ads, listenerName, 80, routeName)
-	testScopedListener  = resource.MakeScopedRouteHTTPListener(resource.Ads, scopedListenerName, 80, scopedRouteName)
+	testScopedListener  = resource.MakeScopedRouteHTTPListenerForRoute(resource.Ads, scopedListenerName, 80, scopedRouteName)
 	testRuntime         = resource.MakeRuntime(runtimeName)
 	testSecret          = resource.MakeSecrets(tlsName, rootName)
 	testExtensionConfig = resource.MakeExtensionConfig(resource.Ads, extensionConfigName, routeName)
 )
 
 func TestValidate(t *testing.T) {
-	if err := testEndpoint.Validate(); err != nil {
-		t.Error(err)
-	}
-	if err := testCluster.Validate(); err != nil {
-		t.Error(err)
-	}
-	if err := testRoute.Validate(); err != nil {
-		t.Error(err)
-	}
-	if err := testScopedRoute.Validate(); err != nil {
-		t.Error(err)
-	}
-	if err := testListener.Validate(); err != nil {
-		t.Error(err)
-	}
-	if err := testRuntime.Validate(); err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, testEndpoint.Validate())
+	assert.NoError(t, testCluster.Validate())
+	assert.NoError(t, testRoute.Validate())
+	assert.NoError(t, testScopedRoute.Validate())
+	assert.NoError(t, testListener.Validate())
+	assert.NoError(t, testScopedListener.Validate())
+	assert.NoError(t, testRuntime.Validate())
+	assert.NoError(t, testExtensionConfig.Validate())
 
 	invalidRoute := &route.RouteConfiguration{
 		Name: "test",
@@ -129,8 +121,8 @@ func TestGetResourceReferences(t *testing.T) {
 			out: map[rsrc.Type]map[string]bool{rsrc.EndpointType: {"test": true}},
 		},
 		{
-			in:  resource.MakeScopedRouteHTTPListener(resource.Xds, listenerName, 80, scopedRouteName),
-			out: map[rsrc.Type]map[string]bool{rsrc.ScopedRouteType: {scopedRouteName: true}},
+			in:  resource.MakeScopedRouteHTTPListener(resource.Xds, listenerName, 80),
+			out: map[rsrc.Type]map[string]bool{},
 		},
 		{
 			in:  resource.MakeRouteHTTPListener(resource.Ads, listenerName, 80, routeName),
@@ -167,9 +159,8 @@ func TestGetResourceReferences(t *testing.T) {
 
 func TestGetAllResourceReferencesReturnsExpectedRefs(t *testing.T) {
 	expected := map[rsrc.Type]map[string]bool{
-		rsrc.RouteType:       {routeName: true},
-		rsrc.ScopedRouteType: {scopedRouteName: true},
-		rsrc.EndpointType:    {clusterName: true},
+		rsrc.RouteType:    {routeName: true, scopedRouteName: true},
+		rsrc.EndpointType: {clusterName: true},
 	}
 
 	resources := [types.UnknownType]cache.Resources{}

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -87,9 +87,8 @@ func (s *Snapshot) Consistent() error {
 
 	// Loop through each referenced resource.
 	referencedResponseTypes := map[types.ResponseType]struct{}{
-		types.Endpoint:    {},
-		types.ScopedRoute: {},
-		types.Route:       {},
+		types.Endpoint: {},
+		types.Route:    {},
 	}
 
 	for idx, items := range s.Resources {
@@ -106,12 +105,13 @@ func (s *Snapshot) Consistent() error {
 			referenceSet := referencedResources[typeURL]
 
 			if len(referenceSet) != len(items.Items) {
-				return fmt.Errorf("mismatched reference and resource lengths: len(%v) != %d", referenceSet, len(items.Items))
+				return fmt.Errorf("mismatched %q reference and resource lengths: len(%v) != %d",
+					typeURL, referenceSet, len(items.Items))
 			}
 
 			// Check superset.
 			if err := superset(referenceSet, items.Items); err != nil {
-				return err
+				return fmt.Errorf("inconsistent %q reference: %w", typeURL, err)
 			}
 		}
 	}

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -85,7 +85,7 @@ func TestRouteListenerWithRouteIsConsistent(t *testing.T) {
 func TestScopedRouteListenerWithScopedRouteOnlyIsInconsistent(t *testing.T) {
 	if snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
-			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80, "scopedRoute0"),
+			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80),
 		},
 		rsrc.ScopedRouteType: {
 			resource.MakeScopedRoute("scopedRoute0", "testRoute0", []string{"1.2.3.4"}),
@@ -98,7 +98,7 @@ func TestScopedRouteListenerWithScopedRouteOnlyIsInconsistent(t *testing.T) {
 func TestScopedRouteListenerWithScopedRouteAndRouteIsConsistent(t *testing.T) {
 	snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
-			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80, "scopedRoute0"),
+			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80),
 		},
 		rsrc.ScopedRouteType: {
 			resource.MakeScopedRoute("scopedRoute0", "testRoute0", []string{"1.2.3.4"}),
@@ -108,15 +108,13 @@ func TestScopedRouteListenerWithScopedRouteAndRouteIsConsistent(t *testing.T) {
 		},
 	})
 
-	if err := snap.Consistent(); err != nil {
-		t.Errorf("got inconsistent snapshot %s, %#v", err.Error(), snap)
-	}
+	assert.NoError(t, snap.Consistent(), "got inconsistent snapshot %#v", snap)
 }
 
 func TestScopedRouteListenerWithInlineScopedRouteAndRouteIsConsistent(t *testing.T) {
 	snap, err := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
-			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "scopedRoute0", "testRoute0"),
+			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "testRoute0"),
 		},
 		rsrc.RouteType: {
 			resource.MakeRoute("testRoute0", clusterName),
@@ -130,7 +128,7 @@ func TestScopedRouteListenerWithInlineScopedRouteAndRouteIsConsistent(t *testing
 func TestScopedRouteListenerWithInlineScopedRouteAndNoRouteIsInconsistent(t *testing.T) {
 	snap, err := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
-			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "scopedRoute0", "testRoute0"),
+			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "testRoute0"),
 		},
 		rsrc.RouteType: {
 			resource.MakeRoute("testRoute1", clusterName),
@@ -144,7 +142,7 @@ func TestScopedRouteListenerWithInlineScopedRouteAndNoRouteIsInconsistent(t *tes
 func TestMultipleListenersWithScopedRouteAndRouteIsConsistent(t *testing.T) {
 	snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.ListenerType: {
-			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80, "scopedRoute0"),
+			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80),
 			resource.MakeRouteHTTPListener(resource.Xds, "listener1", 80, "testRoute1"),
 		},
 		rsrc.ScopedRouteType: {

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -159,7 +159,7 @@ var (
 	route              = resource.MakeRoute(routeName, clusterName)
 	scopedRoute        = resource.MakeScopedRoute(scopedRouteName, routeName, []string{"127.0.0.1"})
 	httpListener       = resource.MakeRouteHTTPListener(resource.Ads, listenerName, 80, routeName)
-	httpScopedListener = resource.MakeScopedRouteHTTPListener(resource.Ads, scopedListenerName, 80, scopedRouteName)
+	httpScopedListener = resource.MakeScopedRouteHTTPListener(resource.Ads, scopedListenerName, 80)
 	secret             = resource.MakeSecrets(secretName, "test")[0]
 	runtime            = resource.MakeRuntime(runtimeName)
 	extensionConfig    = resource.MakeExtensionConfig(resource.Ads, extensionConfigName, routeName)

--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -299,11 +299,11 @@ func MakeRouteHTTPListener(mode string, listenerName string, port uint32, route 
 }
 
 // Creates a HTTP listener using Scoped Routes, which extracts the "Host" header field as the key.
-func MakeScopedRouteHTTPListener(mode string, listenerName string, port uint32, scopedRouteConfigName string) *listener.Listener {
+func MakeScopedRouteHTTPListener(mode string, listenerName string, port uint32) *listener.Listener {
 	source := configSource(mode)
 	routeSpecifier := &hcm.HttpConnectionManager_ScopedRoutes{
 		ScopedRoutes: &hcm.ScopedRoutes{
-			Name: scopedRouteConfigName,
+			Name: "scoped-route-config", // This name is not bound to a xDS resource.
 			ScopeKeyBuilder: &hcm.ScopedRoutes_ScopeKeyBuilder{
 				Fragments: []*hcm.ScopedRoutes_ScopeKeyBuilder_FragmentBuilder{
 					{
@@ -354,11 +354,11 @@ func MakeScopedRouteHTTPListener(mode string, listenerName string, port uint32, 
 // MakeScopedRouteHTTPListenerForRoute is the same as
 // MakeScopedRouteHTTPListener, except it inlines a reference to the
 // routeConfigName, and so doesn't require a ScopedRouteConfiguration resource.
-func MakeScopedRouteHTTPListenerForRoute(mode string, listenerName string, port uint32, scopedRouteConfigName string, routeConfigName string) *listener.Listener {
+func MakeScopedRouteHTTPListenerForRoute(mode string, listenerName string, port uint32, routeConfigName string) *listener.Listener {
 	source := configSource(mode)
 	routeSpecifier := &hcm.HttpConnectionManager_ScopedRoutes{
 		ScopedRoutes: &hcm.ScopedRoutes{
-			Name: scopedRouteConfigName,
+			Name: "scoped-route-config", // This name is not bound to a xDS resource.
 			ScopeKeyBuilder: &hcm.ScopedRoutes_ScopeKeyBuilder{
 				Fragments: []*hcm.ScopedRoutes_ScopeKeyBuilder_FragmentBuilder{
 					{
@@ -554,7 +554,7 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 			listener = MakeRouteHTTPListener(ts.Xds, name, port, cache.GetResourceName(routes[i]))
 			numHTTPListeners--
 		} else if numScopedHTTPListeners > 0 {
-			listener = MakeScopedRouteHTTPListener(ts.Xds, name, port, cache.GetResourceName(scopedRoutes[numScopedHTTPListeners-1]))
+			listener = MakeScopedRouteHTTPListener(ts.Xds, name, port)
 			numScopedHTTPListeners--
 		} else if numTCPListeners > 0 {
 			listener = MakeTCPListener(name, port, cache.GetResourceName(clusters[i%ts.NumClusters]))


### PR DESCRIPTION
When setting the `ScopedRoutes` field in a `HttpConnectionManager`
resouce, the name provided in the `ScopedRoutes` field is not the
name of a `ScopedRouteConfiguration` xDS resource, it's just a name.
When scoped routing is being used, the control plane may provide any
number of `ScopedRouteConfiguration` resouces, which are not linked to
any specific `HttpConnectionManager`.

This fixes #517.

Signed-off-by: James Peach <jpeach@apache.org>
