### PR TITLE
Initial implementation of VHDS, refactor resource generation for the test package, to make adding new listeners easier

### DIFF
--- a/pkg/cache/types/types.go
+++ b/pkg/cache/types/types.go
@@ -37,6 +37,7 @@ const (
 	Cluster
 	Route
 	ScopedRoute
+	VirtualHost
 	Listener
 	Secret
 	Runtime

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -44,6 +44,8 @@ func GetResponseType(typeURL resource.Type) types.ResponseType {
 		return types.Route
 	case resource.ScopedRouteType:
 		return types.ScopedRoute
+	case resource.VirtualHostType:
+		return types.VirtualHost
 	case resource.ListenerType:
 		return types.Listener
 	case resource.SecretType:
@@ -67,6 +69,8 @@ func GetResponseTypeURL(responseType types.ResponseType) (string, error) {
 		return resource.RouteType, nil
 	case types.ScopedRoute:
 		return resource.ScopedRouteType, nil
+	case types.VirtualHost:
+		return resource.VirtualHostType, nil
 	case types.Listener:
 		return resource.ListenerType, nil
 	case types.Secret:
@@ -77,7 +81,7 @@ func GetResponseTypeURL(responseType types.ResponseType) (string, error) {
 		return resource.ExtensionConfigType, nil
 	}
 
-	return "", fmt.Errorf("couldn't map response type to known resource type")
+	return "", fmt.Errorf("couldn't map response type (%v) to known resource type", responseType)
 }
 
 // GetResourceName returns the resource name for a valid xDS response type.
@@ -90,6 +94,8 @@ func GetResourceName(res types.Resource) string {
 	case *route.RouteConfiguration:
 		return v.GetName()
 	case *route.ScopedRouteConfiguration:
+		return v.GetName()
+	case *route.VirtualHost:
 		return v.GetName()
 	case *listener.Listener:
 		return v.GetName()

--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -31,9 +31,11 @@ import (
 const (
 	clusterName         = "cluster0"
 	routeName           = "route0"
+	embeddedRouteName   = "embeddedRoute0"
 	scopedRouteName     = "scopedRoute0"
 	listenerName        = "listener0"
 	scopedListenerName  = "scopedListener0"
+	virtualHostName     = "virtualHost0"
 	runtimeName         = "runtime0"
 	tlsName             = "secret0"
 	rootName            = "root0"
@@ -43,10 +45,12 @@ const (
 var (
 	testEndpoint        = resource.MakeEndpoint(clusterName, 8080)
 	testCluster         = resource.MakeCluster(resource.Ads, clusterName)
-	testRoute           = resource.MakeRoute(routeName, clusterName)
-	testScopedRoute     = resource.MakeScopedRoute(scopedRouteName, routeName, []string{"1.2.3.4"})
+	testRoute           = resource.MakeRouteConfig(routeName, clusterName)
+	testEmbeddedRoute   = resource.MakeRouteConfig(embeddedRouteName, clusterName)
+	testScopedRoute     = resource.MakeScopedRouteConfig(scopedRouteName, routeName, []string{"1.2.3.4"})
+	testVirtualHost     = resource.MakeVirtualHost(virtualHostName, clusterName)
 	testListener        = resource.MakeRouteHTTPListener(resource.Ads, listenerName, 80, routeName)
-	testScopedListener  = resource.MakeScopedRouteHTTPListenerForRoute(resource.Ads, scopedListenerName, 80, scopedRouteName)
+	testScopedListener  = resource.MakeScopedRouteHTTPListenerForRoute(resource.Ads, scopedListenerName, 80, embeddedRouteName)
 	testRuntime         = resource.MakeRuntime(runtimeName)
 	testSecret          = resource.MakeSecrets(tlsName, rootName)
 	testExtensionConfig = resource.MakeExtensionConfig(resource.Ads, extensionConfigName, routeName)
@@ -57,6 +61,7 @@ func TestValidate(t *testing.T) {
 	assert.NoError(t, testCluster.Validate())
 	assert.NoError(t, testRoute.Validate())
 	assert.NoError(t, testScopedRoute.Validate())
+	assert.NoError(t, testVirtualHost.Validate())
 	assert.NoError(t, testListener.Validate())
 	assert.NoError(t, testScopedListener.Validate())
 	assert.NoError(t, testRuntime.Validate())
@@ -90,6 +95,9 @@ func TestGetResourceName(t *testing.T) {
 	}
 	if name := cache.GetResourceName(testScopedRoute); name != scopedRouteName {
 		t.Errorf("GetResourceName(%v) => got %q, want %q", testScopedRoute, name, scopedRouteName)
+	}
+	if name := cache.GetResourceName(testVirtualHost); name != virtualHostName {
+		t.Errorf("GetResourceName(%v) => got %q, want %q", testVirtualHost, name, virtualHostName)
 	}
 	if name := cache.GetResourceName(testListener); name != listenerName {
 		t.Errorf("GetResourceName(%v) => got %q, want %q", testListener, name, listenerName)
@@ -141,8 +149,16 @@ func TestGetResourceReferences(t *testing.T) {
 			out: map[rsrc.Type]map[string]bool{},
 		},
 		{
+			in:  resource.MakeVHDSRouteConfig(resource.Ads, routeName),
+			out: map[rsrc.Type]map[string]bool{},
+		},
+		{
 			in:  testScopedRoute,
 			out: map[rsrc.Type]map[string]bool{rsrc.RouteType: {routeName: true}},
+		},
+		{
+			in:  testVirtualHost,
+			out: map[rsrc.Type]map[string]bool{},
 		},
 		{
 			in:  testEndpoint,
@@ -160,10 +176,9 @@ func TestGetResourceReferences(t *testing.T) {
 		}
 	}
 }
-
 func TestGetAllResourceReferencesReturnsExpectedRefs(t *testing.T) {
 	expected := map[rsrc.Type]map[string]bool{
-		rsrc.RouteType:    {routeName: true, scopedRouteName: true},
+		rsrc.RouteType:    {routeName: true, embeddedRouteName: true},
 		rsrc.EndpointType: {clusterName: true},
 	}
 

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -53,8 +53,10 @@ var (
 	snapshot, _ = cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType:        {testEndpoint},
 		rsrc.ClusterType:         {testCluster},
-		rsrc.RouteType:           {testRoute},
-		rsrc.ListenerType:        {testListener},
+		rsrc.RouteType:           {testRoute, testEmbeddedRoute},
+		rsrc.ScopedRouteType:     {testScopedRoute},
+		rsrc.VirtualHostType:     {testVirtualHost},
+		rsrc.ListenerType:        {testScopedListener, testListener},
 		rsrc.RuntimeType:         {testRuntime},
 		rsrc.SecretType:          {testSecret[0]},
 		rsrc.ExtensionConfigType: {testExtensionConfig},
@@ -64,25 +66,31 @@ var (
 	snapshotWithTTL, _ = cache.NewSnapshotWithTTLs(version, map[rsrc.Type][]types.ResourceWithTTL{
 		rsrc.EndpointType:        {{Resource: testEndpoint, TTL: &ttl}},
 		rsrc.ClusterType:         {{Resource: testCluster}},
-		rsrc.RouteType:           {{Resource: testRoute}},
-		rsrc.ListenerType:        {{Resource: testListener}},
+		rsrc.RouteType:           {{Resource: testRoute}, {Resource: testEmbeddedRoute}},
+		rsrc.ScopedRouteType:     {{Resource: testScopedRoute}},
+		rsrc.VirtualHostType:     {{Resource: testVirtualHost}},
+		rsrc.ListenerType:        {{Resource: testScopedListener}, {Resource: testListener}},
 		rsrc.RuntimeType:         {{Resource: testRuntime}},
 		rsrc.SecretType:          {{Resource: testSecret[0]}},
 		rsrc.ExtensionConfigType: {{Resource: testExtensionConfig}},
 	})
 
 	names = map[string][]string{
-		rsrc.EndpointType: {clusterName},
-		rsrc.ClusterType:  nil,
-		rsrc.RouteType:    {routeName},
-		rsrc.ListenerType: nil,
-		rsrc.RuntimeType:  nil,
+		rsrc.EndpointType:    {clusterName},
+		rsrc.ClusterType:     nil,
+		rsrc.RouteType:       {routeName, embeddedRouteName},
+		rsrc.ScopedRouteType: nil,
+		rsrc.VirtualHostType: nil,
+		rsrc.ListenerType:    nil,
+		rsrc.RuntimeType:     nil,
 	}
 
 	testTypes = []string{
 		rsrc.EndpointType,
 		rsrc.ClusterType,
 		rsrc.RouteType,
+		rsrc.ScopedRouteType,
+		rsrc.VirtualHostType,
 		rsrc.ListenerType,
 		rsrc.RuntimeType,
 	}
@@ -436,8 +444,8 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 	snapshot2, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType:        {testEndpoint, resource.MakeEndpoint(clusterName2, 8080)},
 		rsrc.ClusterType:         {testCluster, resource.MakeCluster(resource.Ads, clusterName2)},
-		rsrc.RouteType:           {testRoute, resource.MakeRoute(routeName2, clusterName2)},
-		rsrc.ListenerType:        {testListener, resource.MakeRouteHTTPListener(resource.Ads, listenerName2, 80, routeName2)},
+		rsrc.RouteType:           {testRoute, resource.MakeRouteConfig(routeName2, clusterName2)},
+		rsrc.ListenerType:        {testScopedListener, resource.MakeRouteHTTPListener(resource.Ads, listenerName2, 80, routeName2)},
 		rsrc.RuntimeType:         {},
 		rsrc.SecretType:          {},
 		rsrc.ExtensionConfigType: {},

--- a/pkg/cache/v3/snapshot_test.go
+++ b/pkg/cache/v3/snapshot_test.go
@@ -60,7 +60,7 @@ func TestListenerWithMissingRoutesIsInconsistent(t *testing.T) {
 
 func TestListenerWithUnidentifiedRouteIsInconsistent(t *testing.T) {
 	if snap, _ := cache.NewSnapshot(version, map[rsrc.Type][]types.Resource{
-		rsrc.RouteType:    {resource.MakeRoute("test", clusterName)},
+		rsrc.RouteType:    {resource.MakeRouteConfig("test", clusterName)},
 		rsrc.ListenerType: {testListener},
 	}); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
@@ -73,7 +73,7 @@ func TestRouteListenerWithRouteIsConsistent(t *testing.T) {
 			resource.MakeRouteHTTPListener(resource.Xds, "listener1", 80, "testRoute0"),
 		},
 		rsrc.RouteType: {
-			resource.MakeRoute("testRoute0", clusterName),
+			resource.MakeRouteConfig("testRoute0", clusterName),
 		},
 	})
 
@@ -88,7 +88,7 @@ func TestScopedRouteListenerWithScopedRouteOnlyIsInconsistent(t *testing.T) {
 			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80),
 		},
 		rsrc.ScopedRouteType: {
-			resource.MakeScopedRoute("scopedRoute0", "testRoute0", []string{"1.2.3.4"}),
+			resource.MakeScopedRouteConfig("scopedRoute0", "testRoute0", []string{"1.2.3.4"}),
 		},
 	}); snap.Consistent() == nil {
 		t.Errorf("got consistent snapshot %#v", snap)
@@ -101,10 +101,10 @@ func TestScopedRouteListenerWithScopedRouteAndRouteIsConsistent(t *testing.T) {
 			resource.MakeScopedRouteHTTPListener(resource.Xds, "listener0", 80),
 		},
 		rsrc.ScopedRouteType: {
-			resource.MakeScopedRoute("scopedRoute0", "testRoute0", []string{"1.2.3.4"}),
+			resource.MakeScopedRouteConfig("scopedRoute0", "testRoute0", []string{"1.2.3.4"}),
 		},
 		rsrc.RouteType: {
-			resource.MakeRoute("testRoute0", clusterName),
+			resource.MakeRouteConfig("testRoute0", clusterName),
 		},
 	})
 
@@ -117,7 +117,7 @@ func TestScopedRouteListenerWithInlineScopedRouteAndRouteIsConsistent(t *testing
 			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "testRoute0"),
 		},
 		rsrc.RouteType: {
-			resource.MakeRoute("testRoute0", clusterName),
+			resource.MakeRouteConfig("testRoute0", clusterName),
 		},
 	})
 
@@ -131,7 +131,7 @@ func TestScopedRouteListenerWithInlineScopedRouteAndNoRouteIsInconsistent(t *tes
 			resource.MakeScopedRouteHTTPListenerForRoute(resource.Xds, "listener0", 80, "testRoute0"),
 		},
 		rsrc.RouteType: {
-			resource.MakeRoute("testRoute1", clusterName),
+			resource.MakeRouteConfig("testRoute1", clusterName),
 		},
 	})
 
@@ -146,11 +146,11 @@ func TestMultipleListenersWithScopedRouteAndRouteIsConsistent(t *testing.T) {
 			resource.MakeRouteHTTPListener(resource.Xds, "listener1", 80, "testRoute1"),
 		},
 		rsrc.ScopedRouteType: {
-			resource.MakeScopedRoute("scopedRoute0", "testRoute0", []string{"1.2.3.4"}),
+			resource.MakeScopedRouteConfig("scopedRoute0", "testRoute0", []string{"1.2.3.4"}),
 		},
 		rsrc.RouteType: {
-			resource.MakeRoute("testRoute0", clusterName),
-			resource.MakeRoute("testRoute1", clusterName),
+			resource.MakeRouteConfig("testRoute0", clusterName),
+			resource.MakeRouteConfig("testRoute1", clusterName),
 		},
 	})
 

--- a/pkg/resource/v3/resource.go
+++ b/pkg/resource/v3/resource.go
@@ -19,6 +19,7 @@ const (
 	ClusterType         = apiTypePrefix + "envoy.config.cluster.v3.Cluster"
 	RouteType           = apiTypePrefix + "envoy.config.route.v3.RouteConfiguration"
 	ScopedRouteType     = apiTypePrefix + "envoy.config.route.v3.ScopedRouteConfiguration"
+	VirtualHostType     = apiTypePrefix + "envoy.config.route.v3.VirtualHost"
 	ListenerType        = apiTypePrefix + "envoy.config.listener.v3.Listener"
 	SecretType          = apiTypePrefix + "envoy.extensions.transport_sockets.tls.v3.Secret"
 	ExtensionConfigType = apiTypePrefix + "envoy.config.core.v3.TypedExtensionConfig"

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -159,30 +159,37 @@ func makeDeltaResponses() map[string][]cache.DeltaResponse {
 				SystemVersionInfo: "4",
 			},
 		},
+		rsrc.VirtualHostType: {
+			&cache.RawDeltaResponse{
+				Resources:         []types.Resource{virtualHost},
+				DeltaRequest:      &discovery.DeltaDiscoveryRequest{TypeUrl: rsrc.VirtualHostType},
+				SystemVersionInfo: "5",
+			},
+		},
 		rsrc.ListenerType: {
 			&cache.RawDeltaResponse{
 				Resources:         []types.Resource{httpListener, httpScopedListener},
 				DeltaRequest:      &discovery.DeltaDiscoveryRequest{TypeUrl: rsrc.ListenerType},
-				SystemVersionInfo: "5",
+				SystemVersionInfo: "6",
 			},
 		},
 		rsrc.SecretType: {
 			&cache.RawDeltaResponse{
-				SystemVersionInfo: "6",
+				SystemVersionInfo: "7",
 				Resources:         []types.Resource{secret},
 				DeltaRequest:      &discovery.DeltaDiscoveryRequest{TypeUrl: rsrc.SecretType},
 			},
 		},
 		rsrc.RuntimeType: {
 			&cache.RawDeltaResponse{
-				SystemVersionInfo: "7",
+				SystemVersionInfo: "8",
 				Resources:         []types.Resource{runtime},
 				DeltaRequest:      &discovery.DeltaDiscoveryRequest{TypeUrl: rsrc.RuntimeType},
 			},
 		},
 		rsrc.ExtensionConfigType: {
 			&cache.RawDeltaResponse{
-				SystemVersionInfo: "8",
+				SystemVersionInfo: "9",
 				Resources:         []types.Resource{extensionConfig},
 				DeltaRequest:      &discovery.DeltaDiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
 			},
@@ -190,7 +197,7 @@ func makeDeltaResponses() map[string][]cache.DeltaResponse {
 		// Pass-through type (types without explicit handling)
 		opaqueType: {
 			&cache.RawDeltaResponse{
-				SystemVersionInfo: "9",
+				SystemVersionInfo: "10",
 				Resources:         []types.Resource{opaque},
 				DeltaRequest:      &discovery.DeltaDiscoveryRequest{TypeUrl: opaqueType},
 			},
@@ -209,6 +216,8 @@ func process(typ string, resp *mockDeltaStream, s server.Server) error {
 		err = s.DeltaRoutes(resp)
 	case rsrc.ScopedRouteType:
 		err = s.DeltaScopedRoutes(resp)
+	case rsrc.VirtualHostType:
+		err = s.DeltaVirtualHosts(resp)
 	case rsrc.ListenerType:
 		err = s.DeltaListeners(resp)
 	case rsrc.SecretType:
@@ -339,6 +348,10 @@ func TestDeltaAggregatedHandlers(t *testing.T) {
 			ResourceNamesSubscribe: []string{scopedRouteName},
 		},
 		{
+			TypeUrl:                rsrc.VirtualHostType,
+			ResourceNamesSubscribe: []string{virtualHostName},
+		},
+		{
 			TypeUrl:                rsrc.SecretType,
 			ResourceNamesSubscribe: []string{secretName},
 		},
@@ -368,6 +381,7 @@ func TestDeltaAggregatedHandlers(t *testing.T) {
 						rsrc.ClusterType:     1,
 						rsrc.RouteType:       1,
 						rsrc.ScopedRouteType: 1,
+						rsrc.VirtualHostType: 1,
 						rsrc.ListenerType:    1,
 						rsrc.SecretType:      1},
 					config.deltaCounts,

--- a/pkg/server/v3/server.go
+++ b/pkg/server/v3/server.go
@@ -45,6 +45,7 @@ type Server interface {
 	clusterservice.ClusterDiscoveryServiceServer
 	routeservice.RouteDiscoveryServiceServer
 	routeservice.ScopedRoutesDiscoveryServiceServer
+	routeservice.VirtualHostDiscoveryServiceServer
 	listenerservice.ListenerDiscoveryServiceServer
 	discoverygrpc.AggregatedDiscoveryServiceServer
 	secretservice.SecretDiscoveryServiceServer
@@ -218,6 +219,8 @@ func (s *server) StreamExtensionConfigs(stream extensionconfigservice.ExtensionC
 	return s.StreamHandler(stream, resource.ExtensionConfigType)
 }
 
+// VHDS doesn't support SOTW requests, so no handler for it exists.
+
 // Fetch is the universal fetch method.
 func (s *server) Fetch(ctx context.Context, req *discovery.DiscoveryRequest) (*discovery.DiscoveryResponse, error) {
 	return s.rest.Fetch(ctx, req)
@@ -287,6 +290,8 @@ func (s *server) FetchExtensionConfigs(ctx context.Context, req *discovery.Disco
 	return s.Fetch(ctx, req)
 }
 
+// VHDS doesn't support REST requests, so no handler exists for this.
+
 func (s *server) DeltaStreamHandler(stream stream.DeltaStream, typeURL string) error {
 	return s.delta.DeltaStreamHandler(stream, typeURL)
 }
@@ -325,4 +330,8 @@ func (s *server) DeltaRuntime(stream runtimeservice.RuntimeDiscoveryService_Delt
 
 func (s *server) DeltaExtensionConfigs(stream extensionconfigservice.ExtensionConfigDiscoveryService_DeltaExtensionConfigsServer) error {
 	return s.DeltaStreamHandler(stream, resource.ExtensionConfigType)
+}
+
+func (s *server) DeltaVirtualHosts(stream routeservice.VirtualHostDiscoveryService_DeltaVirtualHostsServer) error {
+	return s.DeltaStreamHandler(stream, resource.VirtualHostType)
 }

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -144,6 +144,7 @@ const (
 	clusterName         = "cluster0"
 	routeName           = "route0"
 	scopedRouteName     = "scopedRoute0"
+	virtualHostName     = "virtualHost0"
 	listenerName        = "listener0"
 	scopedListenerName  = "scopedListener0"
 	secretName          = "secret0"
@@ -158,8 +159,9 @@ var (
 	}
 	endpoint           = resource.MakeEndpoint(clusterName, 8080)
 	cluster            = resource.MakeCluster(resource.Ads, clusterName)
-	route              = resource.MakeRoute(routeName, clusterName)
-	scopedRoute        = resource.MakeScopedRoute(scopedRouteName, routeName, []string{"127.0.0.1"})
+	route              = resource.MakeRouteConfig(routeName, clusterName)
+	scopedRoute        = resource.MakeScopedRouteConfig(scopedRouteName, routeName, []string{"127.0.0.1"})
+	virtualHost        = resource.MakeVirtualHost(virtualHostName, clusterName)
 	httpListener       = resource.MakeRouteHTTPListener(resource.Ads, listenerName, 80, routeName)
 	httpScopedListener = resource.MakeScopedRouteHTTPListener(resource.Ads, scopedListenerName, 80)
 	secret             = resource.MakeSecrets(secretName, "test")[0]
@@ -210,30 +212,37 @@ func makeResponses() map[string][]cache.Response {
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ScopedRouteType},
 			},
 		},
-		rsrc.ListenerType: {
+		rsrc.VirtualHostType: {
 			&cache.RawResponse{
 				Version:   "5",
+				Resources: []types.ResourceWithTTL{{Resource: virtualHost}},
+				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.VirtualHostType},
+			},
+		},
+		rsrc.ListenerType: {
+			&cache.RawResponse{
+				Version:   "6",
 				Resources: []types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
 			},
 		},
 		rsrc.SecretType: {
 			&cache.RawResponse{
-				Version:   "6",
+				Version:   "7",
 				Resources: []types.ResourceWithTTL{{Resource: secret}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
 			},
 		},
 		rsrc.RuntimeType: {
 			&cache.RawResponse{
-				Version:   "7",
+				Version:   "8",
 				Resources: []types.ResourceWithTTL{{Resource: runtime}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
 			},
 		},
 		rsrc.ExtensionConfigType: {
 			&cache.RawResponse{
-				Version:   "8",
+				Version:   "9",
 				Resources: []types.ResourceWithTTL{{Resource: extensionConfig}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
 			},
@@ -241,7 +250,7 @@ func makeResponses() map[string][]cache.Response {
 		// Pass-through type (xDS does not exist for this type)
 		opaqueType: {
 			&cache.RawResponse{
-				Version:   "9",
+				Version:   "10",
 				Resources: []types.ResourceWithTTL{{Resource: opaque}},
 				Request:   &discovery.DiscoveryRequest{TypeUrl: opaqueType},
 			},
@@ -579,6 +588,10 @@ func TestAggregatedHandlers(t *testing.T) {
 		TypeUrl:       rsrc.ScopedRouteType,
 		ResourceNames: []string{scopedRouteName},
 	}
+	resp.recv <- &discovery.DiscoveryRequest{
+		TypeUrl:       rsrc.VirtualHostType,
+		ResourceNames: []string{virtualHostName},
+	}
 
 	s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
 	go func() {
@@ -588,17 +601,19 @@ func TestAggregatedHandlers(t *testing.T) {
 	}()
 
 	count := 0
+	expectedCount := 6
 	for {
 		select {
 		case <-resp.sent:
 			count++
-			if count >= 5 {
+			if count >= expectedCount {
 				close(resp.recv)
 				if want := map[string]int{
 					rsrc.EndpointType:    1,
 					rsrc.ClusterType:     1,
 					rsrc.RouteType:       1,
 					rsrc.ScopedRouteType: 1,
+					rsrc.VirtualHostType: 1,
 					rsrc.ListenerType:    1,
 				}; !reflect.DeepEqual(want, config.counts) {
 					t.Errorf("watch counts => got %v, want %v", config.counts, want)
@@ -608,7 +623,7 @@ func TestAggregatedHandlers(t *testing.T) {
 				return
 			}
 		case <-time.After(1 * time.Second):
-			t.Fatalf("got %d messages on the stream, not 4", count)
+			t.Fatalf("got %d messages on the stream, not %d", count, expectedCount)
 		}
 	}
 }

--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -111,8 +111,17 @@ func MakeCluster(mode string, clusterName string) *cluster.Cluster {
 	}
 }
 
-// MakeRoute creates an HTTP route that routes to a given cluster.
-func MakeRoute(routeName, clusterName string) *route.RouteConfiguration {
+func MakeVHDSRouteConfig(mode string, routeName string) *route.RouteConfiguration {
+	return &route.RouteConfiguration{
+		Name: routeName,
+		Vhds: &route.Vhds{
+			ConfigSource: configSource(mode),
+		},
+	}
+}
+
+// MakeRouteConfig creates an HTTP route config that routes to a given cluster.
+func MakeRouteConfig(routeName string, clusterName string) *route.RouteConfiguration {
 	return &route.RouteConfiguration{
 		Name: routeName,
 		VirtualHosts: []*route.VirtualHost{{
@@ -136,8 +145,8 @@ func MakeRoute(routeName, clusterName string) *route.RouteConfiguration {
 	}
 }
 
-// MakeScopedRoute creates an HTTP scoped route that routes to a given cluster.
-func MakeScopedRoute(scopedRouteName string, routeConfigurationName string, keyFragments []string) *route.ScopedRouteConfiguration {
+// MakeScopedRouteConfig creates an HTTP scoped route that routes to a given cluster.
+func MakeScopedRouteConfig(scopedRouteName string, routeConfigurationName string, keyFragments []string) *route.ScopedRouteConfiguration {
 	k := &route.ScopedRouteConfiguration_Key{}
 
 	for _, key := range keyFragments {
@@ -155,6 +164,29 @@ func MakeScopedRoute(scopedRouteName string, routeConfigurationName string, keyF
 		RouteConfigurationName: routeConfigurationName,
 		Key:                    k,
 	}
+}
+
+func MakeVirtualHost(virtualHostName string, clusterName string) *route.VirtualHost {
+	ret := &route.VirtualHost{
+		Name:    virtualHostName,
+		Domains: []string{"*"},
+		Routes: []*route.Route{{
+			Match: &route.RouteMatch{
+				PathSpecifier: &route.RouteMatch_Prefix{
+					Prefix: "/",
+				},
+			},
+			Action: &route.Route_Route{
+				Route: &route.RouteAction{
+					ClusterSpecifier: &route.RouteAction_Cluster{
+						Cluster: clusterName,
+					},
+				},
+			},
+		}},
+	}
+
+	return ret
 }
 
 // data source configuration
@@ -500,6 +532,8 @@ type TestSnapshot struct {
 	NumHTTPListeners int
 	// NumScopedHTTPListeners is the total number of scoped route HTTP listeners to generate.
 	NumScopedHTTPListeners int
+	// NumScopedHTTPListeners is the total number of HTTP listeners to generate where the routes are resolved via VHDS.
+	NumVHDSHTTPListeners int
 	// NumTCPListeners is the total number of TCP listeners to generate.
 	// Listeners are assigned clusters in a round-robin fashion.
 	NumTCPListeners int
@@ -509,10 +543,146 @@ type TestSnapshot struct {
 	TLS bool
 	// NumExtension is the total number of Extension Config
 	NumExtension int
+
+	currentPort uint32
+}
+
+func (ts *TestSnapshot) generateHTTPListeners(numListeners int, clusters []types.Resource) ([]types.Resource, []types.Resource) {
+	listeners := []types.Resource{}
+	routeConfigs := []types.Resource{}
+
+	if len(clusters) <= 0 {
+		return nil, nil
+	}
+
+	for i := 0; i < numListeners; i++ {
+		listenerName := fmt.Sprintf("listener-%d", ts.currentPort-ts.BasePort)
+		routeName := fmt.Sprintf("route-%s-%d", ts.Version, ts.currentPort)
+
+		// Evenly distribute routes amongst current number of clusters.
+		routeConfigs = append(routeConfigs, MakeRouteConfig(routeName, cache.GetResourceName(clusters[i%len(clusters)])))
+		listener := MakeRouteHTTPListener(ts.Xds, listenerName, ts.currentPort, routeName)
+		ts.addTLS(listener)
+		listeners = append(listeners, listener)
+
+		ts.currentPort += 1
+	}
+
+	return listeners, routeConfigs
+}
+
+func (ts *TestSnapshot) generateScopedHTTPListeners(numListeners int, clusters []types.Resource) ([]types.Resource, []types.Resource, []types.Resource) {
+	listeners := []types.Resource{}
+	scopedRouteConfigs := []types.Resource{}
+	routeConfigs := []types.Resource{}
+
+	if len(clusters) <= 0 {
+		return nil, nil, nil
+	}
+
+	for i := 0; i < numListeners; i++ {
+		listenerName := fmt.Sprintf("listener-%d", ts.currentPort-ts.BasePort)
+		scopedRouteName := fmt.Sprintf("scopedroute-%d", i)
+		routeName := fmt.Sprintf("route-%s-%d", ts.Version, ts.currentPort)
+
+		// Evenly distribute routes amongst current number of clusters.
+		routeConfigs = append(routeConfigs, MakeRouteConfig(routeName, cache.GetResourceName(clusters[i%len(clusters)])))
+		scopedRouteConfigs = append(scopedRouteConfigs, MakeScopedRouteConfig(scopedRouteName, routeName, []string{ts.getPath()}))
+		listener := MakeScopedRouteHTTPListener(ts.Xds, listenerName, ts.currentPort)
+		ts.addTLS(listener)
+		listeners = append(listeners, listener)
+
+		ts.currentPort += 1
+	}
+
+	return listeners, scopedRouteConfigs, routeConfigs
+}
+
+func (ts *TestSnapshot) generateVHDSHTTPListeners(numListeners int, clusters []types.Resource) ([]types.Resource, []types.Resource, []types.Resource) {
+	listeners := []types.Resource{}
+	routeConfigs := []types.Resource{}
+	virtualHosts := []types.Resource{}
+
+	if len(clusters) <= 0 {
+		return nil, nil, nil
+	}
+
+	for i := 0; i < numListeners; i++ {
+		listenerName := fmt.Sprintf("listener-%d", ts.currentPort-ts.BasePort)
+		routeName := fmt.Sprintf("route-%s-%d", ts.Version, ts.currentPort)
+		virtualHostName := fmt.Sprintf("%s/%s", routeName, ts.getPath())
+
+		// Evenly distribute routes amongst current number of clusters.
+		virtualHosts = append(virtualHosts, MakeVirtualHost(virtualHostName, cache.GetResourceName(clusters[i%len(clusters)])))
+		routeConfigs = append(routeConfigs, MakeVHDSRouteConfig(ts.Xds, routeName))
+		listener := MakeRouteHTTPListener(ts.Xds, listenerName, ts.currentPort, routeName)
+		ts.addTLS(listener)
+		listeners = append(listeners, listener)
+
+		ts.currentPort += 1
+	}
+
+	return listeners, routeConfigs, virtualHosts
+}
+
+func (ts *TestSnapshot) generateTCPListeners(numListeners int, clusters []types.Resource) []types.Resource {
+	listeners := []types.Resource{}
+
+	if len(clusters) <= 0 {
+		return nil
+	}
+
+	for i := 0; i < numListeners; i++ {
+		listenerName := fmt.Sprintf("listener-%d", ts.currentPort-ts.BasePort)
+
+		// Evenly distribute routes amongst current number of clusters.
+		listener := MakeTCPListener(listenerName, ts.currentPort, cache.GetResourceName(clusters[i%ts.NumClusters]))
+		ts.addTLS(listener)
+		listeners = append(listeners, listener)
+
+		ts.currentPort += 1
+	}
+
+	return listeners
+}
+
+func (ts *TestSnapshot) addTLS(l *listener.Listener) {
+	if ts.TLS {
+		for i, chain := range l.FilterChains {
+			tlsc := &auth.DownstreamTlsContext{
+				CommonTlsContext: &auth.CommonTlsContext{
+					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
+						Name:      tlsName,
+						SdsConfig: configSource(ts.Xds),
+					}},
+					ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
+						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+							Name:      rootName,
+							SdsConfig: configSource(ts.Xds),
+						},
+					},
+				},
+			}
+			mt, _ := anypb.New(tlsc)
+			chain.TransportSocket = &core.TransportSocket{
+				Name: "envoy.transport_sockets.tls",
+				ConfigType: &core.TransportSocket_TypedConfig{
+					TypedConfig: mt,
+				},
+			}
+			l.FilterChains[i] = chain
+		}
+	}
+}
+
+func (ts *TestSnapshot) getPath() string {
+	return fmt.Sprintf("%s:%d", localhost, ts.currentPort)
 }
 
 // Generate produces a snapshot from the parameters.
-func (ts TestSnapshot) Generate() cache.Snapshot {
+func (ts *TestSnapshot) Generate() cache.Snapshot {
+	ts.currentPort = ts.BasePort
+
 	clusters := make([]types.Resource, ts.NumClusters)
 	endpoints := make([]types.Resource, ts.NumClusters)
 	for i := 0; i < ts.NumClusters; i++ {
@@ -521,75 +691,18 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 		endpoints[i] = MakeEndpoint(name, ts.UpstreamPort)
 	}
 
-	totalHTTPListeners := ts.NumHTTPListeners + ts.NumScopedHTTPListeners
-	routes := make([]types.Resource, totalHTTPListeners)
-	scopedRoutes := make([]types.Resource, ts.NumScopedHTTPListeners)
+	l1, r1 := ts.generateHTTPListeners(ts.NumHTTPListeners, clusters)
+	l2, sr1, r2 := ts.generateScopedHTTPListeners(ts.NumScopedHTTPListeners, clusters)
+	l3 := ts.generateTCPListeners(ts.NumTCPListeners, clusters)
+	l4, r3, vh1 := ts.generateVHDSHTTPListeners(ts.NumVHDSHTTPListeners, clusters)
 
-	for i := 0; i < totalHTTPListeners; i++ {
-		suffix := fmt.Sprintf("%s-%d", ts.Version, i)
-		routeName := fmt.Sprintf("route-%s", suffix)
-		routes[i] = MakeRoute(routeName, cache.GetResourceName(clusters[i%ts.NumClusters]))
-
-		// Scoped Routes.
-		if i >= ts.NumHTTPListeners {
-			scopedRouteName := fmt.Sprintf("scopedroute-%s", suffix)
-			port := ts.BasePort + uint32(i)
-			scopedRoutes[i-ts.NumHTTPListeners] = MakeScopedRoute(scopedRouteName, routeName, []string{fmt.Sprintf("127.0.0.1:%d", port)})
-		}
-	}
-
-	numHTTPListeners := ts.NumHTTPListeners
-	numScopedHTTPListeners := ts.NumScopedHTTPListeners
-	numTCPListeners := ts.NumTCPListeners
-	total := numHTTPListeners + numScopedHTTPListeners + numTCPListeners
-
-	listeners := make([]types.Resource, total)
-	for i := 0; i < total; i++ {
-		port := ts.BasePort + uint32(i)
-		// listener name must be same since ports are shared and previous listener is drained
-		name := fmt.Sprintf("listener-%d", port)
-		var listener *listener.Listener
-
-		if numHTTPListeners > 0 {
-			listener = MakeRouteHTTPListener(ts.Xds, name, port, cache.GetResourceName(routes[i]))
-			numHTTPListeners--
-		} else if numScopedHTTPListeners > 0 {
-			listener = MakeScopedRouteHTTPListener(ts.Xds, name, port)
-			numScopedHTTPListeners--
-		} else if numTCPListeners > 0 {
-			listener = MakeTCPListener(name, port, cache.GetResourceName(clusters[i%ts.NumClusters]))
-			numTCPListeners--
-		}
-
-		if ts.TLS {
-			for i, chain := range listener.FilterChains {
-				tlsc := &auth.DownstreamTlsContext{
-					CommonTlsContext: &auth.CommonTlsContext{
-						TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-							Name:      tlsName,
-							SdsConfig: configSource(ts.Xds),
-						}},
-						ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
-							ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-								Name:      rootName,
-								SdsConfig: configSource(ts.Xds),
-							},
-						},
-					},
-				}
-				mt, _ := anypb.New(tlsc)
-				chain.TransportSocket = &core.TransportSocket{
-					Name: "envoy.transport_sockets.tls",
-					ConfigType: &core.TransportSocket_TypedConfig{
-						TypedConfig: mt,
-					},
-				}
-				listener.FilterChains[i] = chain
-			}
-		}
-
-		listeners[i] = listener
-	}
+	listeners := append(l1, l2...)
+	listeners = append(listeners, l3...)
+	listeners = append(listeners, l4...)
+	scopedRoutes := append(sr1)
+	routes := append(r1, r2...)
+	routes = append(routes, r3...)
+	virtualHosts := vh1
 
 	runtimes := make([]types.Resource, ts.NumRuntimes)
 	for i := 0; i < ts.NumRuntimes; i++ {
@@ -616,6 +729,7 @@ func (ts TestSnapshot) Generate() cache.Snapshot {
 		resource.ClusterType:         clusters,
 		resource.RouteType:           routes,
 		resource.ScopedRouteType:     scopedRoutes,
+		resource.VirtualHostType:     virtualHosts,
 		resource.ListenerType:        listeners,
 		resource.RuntimeType:         runtimes,
 		resource.SecretType:          secrets,

--- a/pkg/test/v3/register.go
+++ b/pkg/test/v3/register.go
@@ -42,6 +42,7 @@ func RegisterServer(grpcServer *grpc.Server, server server.Server) {
 	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, server)
 	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, server)
 	routeservice.RegisterScopedRoutesDiscoveryServiceServer(grpcServer, server)
+	routeservice.RegisterVirtualHostDiscoveryServiceServer(grpcServer, server)
 	listenerservice.RegisterListenerDiscoveryServiceServer(grpcServer, server)
 	secretservice.RegisterSecretDiscoveryServiceServer(grpcServer, server)
 	runtimeservice.RegisterRuntimeDiscoveryServiceServer(grpcServer, server)


### PR DESCRIPTION
These changes allow for VHDS to be used in the management server. This is an initial PR and I would appreciate feedback on anything I may not have considered yet (API usage, missing test cases, etc.)

Currently, if the ConfigSource under the VHDS portion is set to anything other than "DELTA_GRPC", Envoy will complain about it not being a supported protocol type. For more information, please refer to https://github.com/envoyproxy/go-control-plane/issues/525

Signed-off-by: mtagstyle <anthony.tran@live.ca>