### PR TITLE
Update the godoc link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # control-plane
 
-![example workflow](https://github.com/envoyproxy/go-control-plane/actions/workflows/ci.yaml/badge.svg)
+![CI Status](https://github.com/envoyproxy/go-control-plane/actions/workflows/ci.yaml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/envoyproxy/go-control-plane)](https://goreportcard.com/report/github.com/envoyproxy/go-control-plane)
-[![GoDoc](https://godoc.org/github.com/envoyproxy/go-control-plane?status.svg)](https://godoc.org/github.com/envoyproxy/go-control-plane)
+[![GoDoc](https://pkg.go.dev/badge/github.com/envoyproxy/go-control-plane.svg)](https://pkg.go.dev/github.com/envoyproxy/go-control-plane)
 
 This repository contains a Go-based implementation of an API server that
 implements the discovery service APIs defined in


### PR DESCRIPTION
Update the godoc link and badge to point to pkg.go.dev, which is now
the preferred documentation site.
