### PR TITLE
Update lint to use the bugs preset.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,9 @@ run:
   timeout: 10m
 
 linters:
+  presets:
+  - bugs
+
   enable:
   - bodyclose
   - gofmt
@@ -12,6 +15,9 @@ linters:
   - unconvert
   - unparam
 
+  disable:
+  - scopelint # deprecated but still enabled in the bugs preset
+
 linters-settings:
   misspell:
     locale: US
@@ -21,6 +27,8 @@ linters-settings:
     check-exported: false
   goimports:
     local-prefixes: github.com/envoyproxy/go-control-plane
+  exhaustive:
+    default-signifies-exhaustive: true
 
 issues:
   fix: true

--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,12 @@ examples:
 
 .PHONY: lint
 lint:
-	docker run \
+	@docker run \
 		--rm \
 		--volume $$(pwd):/src \
 		--workdir /src \
-		golangci/golangci-lint:v1.41.1 \
-	golangci-lint run
+		golangci/golangci-lint:v1.43.0 \
+	golangci-lint -v run
 
 #-----------------
 #-- integration

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -75,9 +75,10 @@ func GetResponseTypeURL(responseType types.ResponseType) (string, error) {
 		return resource.RuntimeType, nil
 	case types.ExtensionConfig:
 		return resource.ExtensionConfigType, nil
+	default:
+		return "", fmt.Errorf("couldn't map response type %v to known resource type", responseType)
 	}
 
-	return "", fmt.Errorf("couldn't map response type to known resource type")
 }
 
 // GetResourceName returns the resource name for a valid xDS response type.

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -194,7 +194,7 @@ func (s *Snapshot) ConstructVersionMap() error {
 			}
 			v := HashResource(marshaledResource)
 			if v == "" {
-				return fmt.Errorf("failed to build resource version: %v", err)
+				return fmt.Errorf("failed to build resource version: %w", err)
 			}
 
 			s.VersionMap[typeURL][GetResourceName(r.Resource)] = v

--- a/pkg/server/v3/gateway.go
+++ b/pkg/server/v3/gateway.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -81,7 +82,8 @@ func (h *HTTPGateway) ServeHTTP(req *http.Request) ([]byte, int, error) {
 	if err != nil {
 		// SkipFetchErrors will return a 304 which will signify to the envoy client that
 		// it is already at the latest version; all other errors will 500 with a message.
-		if _, ok := err.(*types.SkipFetchError); ok {
+		var skip *types.SkipFetchError
+		if ok := errors.As(err, &skip); ok {
 			return nil, http.StatusNotModified, nil
 		}
 		return nil, http.StatusInternalServerError, fmt.Errorf("fetch error: " + err.Error())

--- a/pkg/server/v3/gateway_test.go
+++ b/pkg/server/v3/gateway_test.go
@@ -87,7 +87,7 @@ func TestGateway(t *testing.T) {
 		},
 	}
 	for _, cs := range failCases {
-		req, err := http.NewRequest(http.MethodPost, cs.path, cs.body)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, cs.path, cs.body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -104,7 +104,7 @@ func TestGateway(t *testing.T) {
 	}
 
 	for _, path := range []string{resource.FetchClusters, resource.FetchRoutes, resource.FetchListeners} {
-		req, err := http.NewRequest(http.MethodPost, path, strings.NewReader("{\"node\": {\"id\": \"test\"}}"))
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, path, strings.NewReader("{\"node\": {\"id\": \"test\"}}"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -302,31 +302,46 @@ func callEcho() (int, int) {
 	ok, failed := 0, 0
 	ch := make(chan error, total)
 
+	client := http.Client{
+		Timeout: 100 * time.Millisecond,
+		Transport: &http.Transport{
+			TLSClientConfig: &cryptotls.Config{InsecureSkipVerify: true}, // nolint:gosec
+		},
+	}
+
+	get := func(count int) (*http.Response, error) {
+		proto := "http"
+		if tls {
+			proto = "https"
+		}
+
+		req, err := http.NewRequestWithContext(
+			context.Background(),
+			http.MethodGet,
+			fmt.Sprintf("%s://127.0.0.1:%d", proto, basePort+uint(count)),
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return client.Do(req)
+	}
+
 	// spawn requests
 	for i := 0; i < total; i++ {
 		go func(i int) {
-			client := http.Client{
-				Timeout: 100 * time.Millisecond,
-				Transport: &http.Transport{
-					TLSClientConfig: &cryptotls.Config{InsecureSkipVerify: true}, // nolint:gosec
-				},
-			}
-			proto := "http"
-			if tls {
-				proto = "https"
-			}
-			req, err := client.Get(fmt.Sprintf("%s://127.0.0.1:%d", proto, basePort+uint(i)))
+			resp, err := get(i)
 			if err != nil {
 				ch <- err
 				return
 			}
-			body, err := ioutil.ReadAll(req.Body)
+			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				req.Body.Close()
+				resp.Body.Close()
 				ch <- err
 				return
 			}
-			if err := req.Body.Close(); err != nil {
+			if err := resp.Body.Close(); err != nil {
 				ch <- err
 				return
 			}

--- a/pkg/test/v3/accesslog.go
+++ b/pkg/test/v3/accesslog.go
@@ -1,7 +1,9 @@
 package test
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -36,8 +38,11 @@ func (svc *AccessLogService) StreamAccessLogs(stream accessloggrpc.AccessLogServ
 	var logName string
 	for {
 		msg, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
 		if err != nil {
-			return nil
+			return err
 		}
 		if msg.Identifier != nil {
 			logName = msg.Identifier.LogName
@@ -76,4 +81,6 @@ func (svc *AccessLogService) StreamAccessLogs(stream accessloggrpc.AccessLogServ
 			}
 		}
 	}
+
+	return nil
 }


### PR DESCRIPTION
Update golangci-lint to the latest version and enable the bugs preset
to run the collection of linters that are intended to catch code bugs.

Signed-off-by: James Peach <jpeach@apache.org>
