### PR TITLE
Update the Go version to 1.16.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ feedback, we might decided to revisit this aspect at a later point in time.
 
 ## Requirements
 
-1. Go 1.11+
+1. Go 1.16+
 
 ## Quick start
 

--- a/examples/dyplomat/Dockerfile
+++ b/examples/dyplomat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 WORKDIR /go/src/dyplomat
 COPY . /go/src/dyplomat

--- a/examples/dyplomat/go.mod
+++ b/examples/dyplomat/go.mod
@@ -1,6 +1,6 @@
-module kubecon-demo/dyplomat
+module github.com/envoyproxy/go-control-plane/examples/dyplomat
 
-go 1.14
+go 1.16
 
 require (
 	github.com/envoyproxy/go-control-plane v0.9.6

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/go-control-plane
 
-go 1.11
+go 1.16
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1


### PR DESCRIPTION
Update the Go version directive to 1.16 since that is currently the
oldest supported go release.

This fixes #532.

Signed-off-by: James Peach <jpeach@apache.org>
