### PR TITLE
Linear cache: Add new UpdateResources method to update multiple resources at once without doing a stow update and limit unneeded allocations when processing delta watches

### DIFF
--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -30,25 +30,39 @@ type resourceContainer struct {
 
 func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.StreamState, resources resourceContainer) *RawDeltaResponse {
 	// variables to build our response with
-	nextVersionMap := make(map[string]string)
-	filtered := make([]types.Resource, 0, len(resources.resourceMap))
-	toRemove := make([]string, 0)
+	var nextVersionMap map[string]string
+	var filtered []types.Resource
+	var toRemove []string
 
 	// If we are handling a wildcard request, we want to respond with all resources
 	switch {
 	case state.IsWildcard():
+		if len(state.GetResourceVersions()) == 0 {
+			filtered = make([]types.Resource, 0, len(resources.resourceMap))
+		}
+		nextVersionMap = make(map[string]string, len(resources.resourceMap))
 		for name, r := range resources.resourceMap {
 			// Since we've already precomputed the version hashes of the new snapshot,
 			// we can just set it here to be used for comparison later
 			version := resources.versionMap[name]
 			nextVersionMap[name] = version
 			prevVersion, found := state.GetResourceVersions()[name]
-			if !found || (prevVersion != nextVersionMap[name]) {
+			if !found || (prevVersion != version) {
 				filtered = append(filtered, r)
+			}
+		}
+
+		// Compute resources for removal
+		for name, prevVersion := range state.GetResourceVersions() {
+			// The prevVersion != "" check is in place to make sure we are only sending an update to the client once right after it is removed.
+			// If the client decides to keep the subscription we skip the add for every subsequent response.
+			if _, ok := resources.resourceMap[name]; !ok && prevVersion != "" {
+				toRemove = append(toRemove, name)
 			}
 		}
 	default:
 		// Reply only with the requested resources
+		nextVersionMap = make(map[string]string, len(state.GetResourceVersions()))
 		for name, prevVersion := range state.GetResourceVersions() {
 			if r, ok := resources.resourceMap[name]; ok {
 				nextVersion := resources.versionMap[name]
@@ -59,16 +73,10 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.St
 			} else {
 				// We track non-existent resources for non-wildcard streams until the client explicitly unsubscribes from them.
 				nextVersionMap[name] = ""
+				if prevVersion != "" {
+					toRemove = append(toRemove, name)
+				}
 			}
-		}
-	}
-
-	// Compute resources for removal regardless of the request type
-	for name, prevVersion := range state.GetResourceVersions() {
-		// The prevVersion != "" check is in place to make sure we are only sending an update to the client once right after it is removed.
-		// If the client decides to keep the subscription we skip the add for every subsequent response.
-		if _, ok := resources.resourceMap[name]; !ok && prevVersion != "" {
-			toRemove = append(toRemove, name)
 		}
 	}
 

--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -53,10 +53,8 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.St
 		}
 
 		// Compute resources for removal
-		for name, prevVersion := range state.GetResourceVersions() {
-			// The prevVersion != "" check is in place to make sure we are only sending an update to the client once right after it is removed.
-			// If the client decides to keep the subscription we skip the add for every subsequent response.
-			if _, ok := resources.resourceMap[name]; !ok && prevVersion != "" {
+		for name := range state.GetResourceVersions() {
+			if _, ok := resources.resourceMap[name]; !ok {
 				toRemove = append(toRemove, name)
 			}
 		}
@@ -73,6 +71,8 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.St
 			} else {
 				// We track non-existent resources for non-wildcard streams until the client explicitly unsubscribes from them.
 				nextVersionMap[name] = ""
+				// The version check is to make sure we are only sending an update once right after removal.
+				// If the client keeps the subscription, we skip the add for every subsequent response.
 				if prevVersion != "" {
 					toRemove = append(toRemove, name)
 				}

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -218,6 +218,32 @@ func (cache *LinearCache) DeleteResource(name string) error {
 	return nil
 }
 
+// UpdateResources updates/deletes a list of resources in the cache.
+// Calling UpdateResources instead of iterating on UpdateResource and DeleteResource
+// is significantly more efficient when using delta or wildcard watches.
+func (cache *LinearCache) UpdateResources(toUpdate map[string]types.Resource, toDelete []string) error {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	cache.version++
+
+	modified := make(map[string]struct{}, len(toUpdate)+len(toDelete))
+	for name, resource := range toUpdate {
+		cache.versionVector[name] = cache.version
+		cache.resources[name] = resource
+		modified[name] = struct{}{}
+	}
+	for _, name := range toDelete {
+		delete(cache.versionVector, name)
+		delete(cache.resources, name)
+		modified[name] = struct{}{}
+	}
+
+	cache.notifyAll(modified)
+
+	return nil
+}
+
 // SetResources replaces current resources with a new set of resources.
 // This function is useful for wildcard xDS subscriptions.
 // This way watches that are subscribed to all resources are triggered only once regardless of how many resources are changed.


### PR DESCRIPTION
In use cases where linear cache is used with eds and delta watches, the user can currently only update the cache in two ways:
* full stow set (SetResources): this requires the user to build the entire list to then pass it to the cache, which then hashes everything to figure out what changed. This is very resource intensive (in our case ~1s of CPU). After that it will only check once for delta watches and return all changed endpoints at once
* provide detailed updates one by one (through UpdateResource and DeleteResource): this does not require the user to keep a full view of the data, and does not consume much cpu in hashing (only hashing the resources actually updated), but it will check all delta watches for each call, and will forward endpoints changed a key at a time (more traffic with clients)

In our case the main issue switching to the second part is the cpu usage (and time spent) on updates when updating multiple resources (though with still num_updates << total_keys, e.g. 50 vs 5000) while multiple delta watches exist (~20)
We then end up spending more than 120ms of CPU (for ~50 updates/deletes) with profiles like (this is aggregated for updates between 0 and 50):
![image](https://user-images.githubusercontent.com/75266282/158439018-e3970835-9f1b-4c0e-b7b0-4a024c8c0305.png)

In order to improve this, two changes are in this PR:
* Do not pre-allocate the slice of filtered resources in most cases
  * When the delta watch is non-wildcard, this is irrelevant to pre-allocate for the total list of resources, and most checks will return no change at all
  * When the delta watch is wildcard, pre-allocate when there is no version passed, but not in other cases when most resources have not been updated
* Provide a method to update/delete multiple resources at once. This allows only one iteration across watches, improving resource usage and limiting traffic between the control-plane and the clients

After the fix, runtime of the update (only includes iterating through calls to UpdateResource/DeleteResource before and on call to UpdateResources after) is greatly improved and stable (blue line below)
![image](https://user-images.githubusercontent.com/75266282/158462319-0d444a50-0058-4d83-a441-e37c8da8629c.png)
