### PR TITLE
test: Update http listener connection-manager configuration to use fully qualified config as required in envoy now.

### DIFF
--- a/pkg/test/resource/v3/resource.go
+++ b/pkg/test/resource/v3/resource.go
@@ -30,6 +30,7 @@ import (
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	als "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
+	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
@@ -262,11 +263,13 @@ func buildHTTPConnectionManager() *hcm.HttpConnectionManager {
 	}
 
 	// HTTP filter configuration.
+	routerConfig, _ := anypb.New(&router.Router{})
 	manager := &hcm.HttpConnectionManager{
 		CodecType:  hcm.HttpConnectionManager_AUTO,
 		StatPrefix: "http",
 		HttpFilters: []*hcm.HttpFilter{{
-			Name: wellknown.Router,
+			Name:       wellknown.Router,
+			ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: routerConfig},
 		}},
 		AccessLog: []*alf.AccessLog{{
 			Name: wellknown.HTTPGRPCAccessLog,
@@ -492,6 +495,7 @@ func MakeExtensionConfig(mode string, extensionConfigName string, route string) 
 	rdsSource := configSource(mode)
 
 	// HTTP filter configuration
+	routerConfig, _ := anypb.New(&router.Router{})
 	manager := &hcm.HttpConnectionManager{
 		CodecType:  hcm.HttpConnectionManager_AUTO,
 		StatPrefix: "http",
@@ -502,7 +506,8 @@ func MakeExtensionConfig(mode string, extensionConfigName string, route string) 
 			},
 		},
 		HttpFilters: []*hcm.HttpFilter{{
-			Name: wellknown.Router,
+			Name:       wellknown.Router,
+			ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: routerConfig},
 		}},
 	}
 	pbst, err := anypb.New(manager)


### PR DESCRIPTION
Since the update of envoy in https://github.com/envoyproxy/envoy/pull/20397, the integration tests are failing as envoy is rejecting the listeners defined with a router filter not also using a fully qualified configuration
While this PR should fix it, this seems like a bad compatibility break on envoy side without much notice on the pull request