### PR TITLE
cache: fix empty context in response of linear cache

### DIFF
--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -134,6 +134,7 @@ func (cache *LinearCache) respond(value chan Response, staleResources []string) 
 		Request:   &Request{TypeUrl: cache.typeURL},
 		Resources: resources,
 		Version:   cache.getVersion(),
+		Ctx:       context.Background(),
 	}
 }
 

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -44,6 +44,9 @@ func verifyResponse(t *testing.T, ch <-chan Response, version string, num int) {
 	if r.GetRequest().TypeUrl != testType {
 		t.Errorf("unexpected empty request type URL: %q", r.GetRequest().TypeUrl)
 	}
+	if r.GetContext() == nil {
+		t.Errorf("unexpected empty response context")
+	}
 	out, err := r.GetDiscoveryResponse()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Signed-off-by: Bing Han <h.bing612@gmail.com>

A small fix. Without this, `Ctx` in response of linear cache will be nil, which may be used in callbacks and cause problems.

Besides this, maybe we can support passing Context in some methods of `LinearCache` like what we do in `SnapshotCache`? This can be done in another PR(or another issue to discuss).