### PR TITLE
Fix example: use fully qualified config for http router filter

### DIFF
--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -24,6 +24,7 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -104,6 +105,7 @@ func makeRoute(routeName string, clusterName string) *route.RouteConfiguration {
 }
 
 func makeHTTPListener(listenerName string, route string) *listener.Listener {
+	routerConfig, _ := anypb.New(&router.Router{})
 	// HTTP filter configuration
 	manager := &hcm.HttpConnectionManager{
 		CodecType:  hcm.HttpConnectionManager_AUTO,
@@ -115,7 +117,8 @@ func makeHTTPListener(listenerName string, route string) *listener.Listener {
 			},
 		},
 		HttpFilters: []*hcm.HttpFilter{{
-			Name: wellknown.Router,
+			Name:       wellknown.Router,
+			ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: routerConfig},
 		}},
 	}
 	pbst, err := anypb.New(manager)


### PR DESCRIPTION
`make example` fails because envoy keeps rejecting listener because of missing `ConfigType` for the http router filter supplied by control plane. This PR is fixing the same.
