### PR TITLE
snapshot cache: fix heartbeat panic

### DIFF
--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -184,7 +184,11 @@ func NewSnapshotCacheWithHeartbeating(ctx context.Context, ads bool, hash NodeHa
 }
 
 func (cache *snapshotCache) sendHeartbeats(ctx context.Context, node string) {
-	snapshot := cache.snapshots[node]
+	snapshot, ok := cache.snapshots[node]
+	if !ok {
+		return
+	}
+
 	if info, ok := cache.status[node]; ok {
 		info.mu.Lock()
 		for id, watch := range info.watches {

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -604,3 +604,34 @@ func TestSnapshotSingleResourceFetch(t *testing.T) {
 		protocmp.Transform()),
 	)
 }
+
+func TestAvertPanicForWatchOnNonExistentSnapshot(t *testing.T) {
+	ctx := context.Background()
+	c := cache.NewSnapshotCacheWithHeartbeating(ctx, false, cache.IDHash{}, nil, time.Millisecond)
+
+	// Create watch.
+	req := &cache.Request{
+		Node:          &core.Node{Id: "test"},
+		ResourceNames: []string{"rtds"},
+		TypeUrl:       rsrc.RuntimeType,
+	}
+	ss := stream.NewStreamState(false, map[string]string{"cluster": "abcdef"})
+	responder := make(chan cache.Response)
+	c.CreateWatch(req, ss, responder)
+
+	go func() {
+		// Wait for at least one heartbeat to occur, then set snapshot.
+		time.Sleep(time.Millisecond * 5)
+		srs := &singleResourceSnapshot{
+			version:  "version-one",
+			typeurl:  rsrc.RuntimeType,
+			name:     "one-second",
+			resource: durationpb.New(time.Second),
+		}
+		if err := c.SetSnapshot(ctx, "test", srs); err != nil {
+			panic(err)
+		}
+	}()
+
+	<-responder
+}

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -629,7 +629,7 @@ func TestAvertPanicForWatchOnNonExistentSnapshot(t *testing.T) {
 			resource: durationpb.New(time.Second),
 		}
 		if err := c.SetSnapshot(ctx, "test", srs); err != nil {
-			panic(err)
+			t.Errorf("unexpected error setting snapshot %v", err)
 		}
 	}()
 


### PR DESCRIPTION
Encountering a panic where the snapshot has not been set yet but the cache is heartbeating and a watch comes in. Add a check on the snapshot existence for the node to avoid the panic.

Added a test to verify.

```
2022-08-02T15:18:27.520Z       DEBUG   v3/simple.go:391        open watch 1 for type.googleapis.com/envoy.service.runtime.v3.Runtime[rtds] from nodeID "test-cluster", version ""
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xb3a163]

goroutine 7 [running]:
github.com/envoyproxy/go-control-plane/pkg/cache/v3.(*snapshotCache).sendHeartbeats(0xc0003a2180, {0xf26d10, 0xc000040030}, {0xc000496754, 0xc})
       /go/src/github.com/envoyproxy/go-control-plane/pkg/cache/v3/simple.go:193 +0x163
github.com/envoyproxy/go-control-plane/pkg/cache/v3.NewSnapshotCacheWithHeartbeating.func1()
       /go/src/github.com/envoyproxy/go-control-plane/pkg/cache/v3/simple.go:176 +0x154
created by github.com/envoyproxy/go-control-plane/pkg/cache/v3.NewSnapshotCacheWithHeartbeating
       /go/src/github.com/envoyproxy/go-control-plane/pkg/cache/v3/simple.go:167 +0x1a9
```