### PR TITLE
[#583][Sotw] Ensure resources are properly sent again if envoy unsubscribes then subscribes again to a resource

### DIFF
--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -105,6 +105,9 @@ type Response interface {
 	// Get the version in the Response.
 	GetVersion() (string, error)
 
+	// Get the list of resources part of the response without having to cast resources
+	GetResourceNames() []string
+
 	// Get the context provided during response creation.
 	GetContext() context.Context
 }
@@ -141,6 +144,9 @@ type RawResponse struct {
 
 	// Resources to be included in the response.
 	Resources []types.ResourceWithTTL
+
+	// Names of the resources included in the response
+	ResourceNames []string
 
 	// Whether this is a heartbeat response. For xDS versions that support TTL, this
 	// will be converted into a response that doesn't contain the actual resource protobuf.
@@ -190,6 +196,9 @@ type PassthroughResponse struct {
 
 	// The discovery response that needs to be sent as is, without any marshaling transformations.
 	DiscoveryResponse *discovery.DiscoveryResponse
+
+	// Names of the resources set in the response
+	ResourceNames []string
 
 	ctx context.Context
 }
@@ -288,6 +297,12 @@ func (r *RawDeltaResponse) GetDeltaDiscoveryResponse() (*discovery.DeltaDiscover
 	return marshaledResponse.(*discovery.DeltaDiscoveryResponse), nil
 }
 
+// GetResourceNames returns the list of resources returned within the response
+// without having to decode the resources
+func (r *RawResponse) GetResourceNames() []string {
+	return r.ResourceNames
+}
+
 // GetRequest returns the original Discovery Request.
 func (r *RawResponse) GetRequest() *discovery.DiscoveryRequest {
 	return r.Request
@@ -348,6 +363,11 @@ func (r *RawResponse) maybeCreateTTLResource(resource types.ResourceWithTTL) (ty
 // GetDiscoveryResponse returns the final passthrough Discovery Response.
 func (r *PassthroughResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	return r.DiscoveryResponse, nil
+}
+
+// GetResourceNames returns the list of resources included within the response
+func (r *PassthroughResponse) GetResourceNames() []string {
+	return r.ResourceNames
 }
 
 // GetDeltaDiscoveryResponse returns the final passthrough Delta Discovery Response.

--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 )
 
 // groups together resource-related arguments for the createDeltaResponse function
@@ -28,7 +27,7 @@ type resourceContainer struct {
 	systemVersion string
 }
 
-func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.StreamState, resources resourceContainer) *RawDeltaResponse {
+func createDeltaResponse(ctx context.Context, req *DeltaRequest, state ClientState, resources resourceContainer) *RawDeltaResponse {
 	// variables to build our response with
 	var nextVersionMap map[string]string
 	var filtered []types.Resource
@@ -37,7 +36,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.St
 	// If we are handling a wildcard request, we want to respond with all resources
 	switch {
 	case state.IsWildcard():
-		if len(state.GetResourceVersions()) == 0 {
+		if len(state.GetKnownResources()) == 0 {
 			filtered = make([]types.Resource, 0, len(resources.resourceMap))
 		}
 		nextVersionMap = make(map[string]string, len(resources.resourceMap))
@@ -46,7 +45,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.St
 			// we can just set it here to be used for comparison later
 			version := resources.versionMap[name]
 			nextVersionMap[name] = version
-			prevVersion, found := state.GetResourceVersions()[name]
+			prevVersion, found := state.GetKnownResources()[name]
 			if !found || (prevVersion != version) {
 				filtered = append(filtered, r)
 			}
@@ -54,17 +53,17 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, state stream.St
 
 		// Compute resources for removal
 		// The resource version can be set to "" here to trigger a removal even if never returned before
-		for name := range state.GetResourceVersions() {
+		for name := range state.GetKnownResources() {
 			if _, ok := resources.resourceMap[name]; !ok {
 				toRemove = append(toRemove, name)
 			}
 		}
 	default:
-		nextVersionMap = make(map[string]string, len(state.GetSubscribedResourceNames()))
+		nextVersionMap = make(map[string]string, len(state.GetSubscribedResources()))
 		// state.GetResourceVersions() may include resources no longer subscribed
 		// In the current code this gets silently cleaned when updating the version map
-		for name := range state.GetSubscribedResourceNames() {
-			prevVersion, found := state.GetResourceVersions()[name]
+		for name := range state.GetSubscribedResources() {
+			prevVersion, found := state.GetKnownResources()[name]
 			if r, ok := resources.resourceMap[name]; ok {
 				nextVersion := resources.versionMap[name]
 				if prevVersion != nextVersion {

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/log"
-	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 )
 
 type watches = map[chan Response]struct{}
@@ -164,11 +163,11 @@ func (cache *LinearCache) notifyAll(modified map[string]struct{}) {
 		}
 
 		for id, watch := range cache.deltaWatches {
-			if !watch.StreamState.WatchesResources(modified) {
+			if !watch.WatchesResources(modified) {
 				continue
 			}
 
-			res := cache.respondDelta(watch.Request, watch.Response, watch.StreamState)
+			res := cache.respondDelta(watch.Request, watch.Response, watch.clientState)
 			if res != nil {
 				delete(cache.deltaWatches, id)
 			}
@@ -176,8 +175,8 @@ func (cache *LinearCache) notifyAll(modified map[string]struct{}) {
 	}
 }
 
-func (cache *LinearCache) respondDelta(request *DeltaRequest, value chan DeltaResponse, state stream.StreamState) *RawDeltaResponse {
-	resp := createDeltaResponse(context.Background(), request, state, resourceContainer{
+func (cache *LinearCache) respondDelta(request *DeltaRequest, value chan DeltaResponse, clientState ClientState) *RawDeltaResponse {
+	resp := createDeltaResponse(context.Background(), request, clientState, resourceContainer{
 		resourceMap:   cache.resources,
 		versionMap:    cache.versionMap,
 		systemVersion: cache.getVersion(),
@@ -187,7 +186,7 @@ func (cache *LinearCache) respondDelta(request *DeltaRequest, value chan DeltaRe
 	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 {
 		if cache.log != nil {
 			cache.log.Debugf("[linear cache] node: %s, sending delta response with resources: %v removed resources %v wildcard: %t",
-				request.GetNode().GetId(), resp.Resources, resp.RemovedResources, state.IsWildcard())
+				request.GetNode().GetId(), resp.Resources, resp.RemovedResources, clientState.IsWildcard())
 		}
 		value <- resp
 		return resp
@@ -298,7 +297,7 @@ func (cache *LinearCache) GetResources() map[string]types.Resource {
 	return resources
 }
 
-func (cache *LinearCache) CreateWatch(request *Request, streamState stream.StreamState, value chan Response) func() {
+func (cache *LinearCache) CreateWatch(request *Request, clientState ClientState, value chan Response) func() {
 	if request.TypeUrl != cache.typeURL {
 		value <- nil
 		return nil
@@ -371,7 +370,7 @@ func (cache *LinearCache) CreateWatch(request *Request, streamState stream.Strea
 	}
 }
 
-func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, state stream.StreamState, value chan DeltaResponse) func() {
+func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, clientState ClientState, value chan DeltaResponse) func() {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
@@ -388,7 +387,7 @@ func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, state stream.S
 			cache.log.Errorf("failed to update version map: %v", err)
 		}
 	}
-	response := cache.respondDelta(request, value, state)
+	response := cache.respondDelta(request, value, clientState)
 
 	// if respondDelta returns nil this means that there is no change in any resource version
 	// create a new watch accordingly
@@ -396,10 +395,10 @@ func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, state stream.S
 		watchID := cache.nextDeltaWatchID()
 		if cache.log != nil {
 			cache.log.Infof("[linear cache] open delta watch ID:%d for %s Resources:%v, system version %q", watchID,
-				cache.typeURL, state.GetSubscribedResourceNames(), cache.getVersion())
+				cache.typeURL, clientState.GetSubscribedResources(), cache.getVersion())
 		}
 
-		cache.deltaWatches[watchID] = DeltaResponseWatch{Request: request, Response: value, StreamState: state}
+		cache.deltaWatches[watchID] = DeltaResponseWatch{Request: request, Response: value, clientState: clientState}
 
 		return cache.cancelDeltaWatch(watchID)
 	}

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -26,7 +26,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/log"
 )
 
-type watches = map[chan Response]struct{}
+type watches = map[ResponseWatch]struct{}
 
 // LinearCache supports collections of opaque resources. This cache has a
 // single collection indexed by resource names and manages resource versions
@@ -112,45 +112,57 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	return out
 }
 
-func (cache *LinearCache) respond(value chan Response, staleResources []string) {
+func (cache *LinearCache) respond(req *Request, value chan Response, staleResources []string) {
 	var resources []types.ResourceWithTTL
+	var resourceNames []string
 	// TODO: optimize the resources slice creations across different clients
 	if len(staleResources) == 0 {
 		resources = make([]types.ResourceWithTTL, 0, len(cache.resources))
-		for _, resource := range cache.resources {
+		resourceNames = make([]string, 0, len(cache.resources))
+		for name, resource := range cache.resources {
 			resources = append(resources, types.ResourceWithTTL{Resource: resource})
+			resourceNames = append(resourceNames, name)
 		}
 	} else {
 		resources = make([]types.ResourceWithTTL, 0, len(staleResources))
+		resourceNames = make([]string, 0, len(staleResources))
 		for _, name := range staleResources {
 			resource := cache.resources[name]
 			if resource != nil {
 				resources = append(resources, types.ResourceWithTTL{Resource: resource})
+				resourceNames = append(resourceNames, name)
 			}
 		}
 	}
 	value <- &RawResponse{
-		Request:   &Request{TypeUrl: cache.typeURL},
-		Resources: resources,
-		Version:   cache.getVersion(),
-		Ctx:       context.Background(),
+		Request:       &Request{TypeUrl: cache.typeURL},
+		Resources:     resources,
+		ResourceNames: resourceNames,
+		Version:       cache.getVersion(),
+		Ctx:           context.Background(),
 	}
 }
 
 func (cache *LinearCache) notifyAll(modified map[string]struct{}) {
 	// de-duplicate watches that need to be responded
-	notifyList := make(map[chan Response][]string)
+	notifyList := make(map[ResponseWatch][]string)
 	for name := range modified {
 		for watch := range cache.watches[name] {
 			notifyList[watch] = append(notifyList[watch], name)
+
+			// Make sure we clean the watch for ALL resources it might be associated with,
+			// as the channel will no longer be listened to
+			for _, resource := range watch.Request.ResourceNames {
+				delete(cache.watches[resource], watch)
+			}
 		}
 		delete(cache.watches, name)
 	}
-	for value, stale := range notifyList {
-		cache.respond(value, stale)
+	for watch, stale := range notifyList {
+		cache.respond(watch.Request, watch.Response, stale)
 	}
-	for value := range cache.watchAll {
-		cache.respond(value, nil)
+	for watch := range cache.watchAll {
+		cache.respond(watch.Request, watch.Response, nil)
 	}
 	cache.watchAll = make(watches)
 
@@ -306,7 +318,7 @@ func (cache *LinearCache) CreateWatch(request *Request, clientState ClientState,
 	// been updated between the last version and the current version. This avoids the problem
 	// of sending empty updates whenever an irrelevant resource changes.
 	stale := false
-	staleResources := []string{} // empty means all
+	var staleResources []string // empty means all
 
 	// strip version prefix if it is present
 	var lastVersion uint64
@@ -323,29 +335,58 @@ func (cache *LinearCache) CreateWatch(request *Request, clientState ClientState,
 	if err != nil {
 		stale = true
 		staleResources = request.ResourceNames
-	} else if len(request.ResourceNames) == 0 {
+		if cache.log != nil {
+			cache.log.Debugf("Watch is stale as version failed to parse %s", err.Error())
+		}
+	} else if clientState.IsWildcard() {
 		stale = lastVersion != cache.version
+		if cache.log != nil {
+			cache.log.Debugf("Watch is stale as version differs for wildcard watch")
+		}
 	} else {
+		// Non wildcard case, we only reply resources that have effectively changed since the version set in the request
+		// This is used for instance in EDS
 		for _, name := range request.ResourceNames {
-			// When a resource is removed, its version defaults 0 and it is not considered stale.
-			if lastVersion < cache.versionVector[name] {
+			// The resource does not exist currently, we won't reply for it
+			if resourceVersion, ok := cache.versionVector[name]; !ok {
+				continue
+			} else if lastVersion < resourceVersion {
+				// The version of the request is older than the last change for the resource, return it
+				stale = true
+				staleResources = append(staleResources, name)
+			} else if _, ok := clientState.GetKnownResources()[name]; !ok {
+				// Resource is not currently known by the client (e.g. a resource is added in the resourceNames)
 				stale = true
 				staleResources = append(staleResources, name)
 			}
 		}
+		if cache.log != nil && stale {
+			cache.log.Debugf("Watch is stale with stale resources %v", staleResources)
+		}
 	}
 	if stale {
-		cache.respond(value, staleResources)
+		cache.respond(request, value, staleResources)
 		return nil
 	}
 	// Create open watches since versions are up to date.
-	if len(request.ResourceNames) == 0 {
-		cache.watchAll[value] = struct{}{}
+	watch := ResponseWatch{request, value}
+	if clientState.IsWildcard() {
+		if cache.log != nil {
+			cache.log.Infof("[linear cache] open watch for %s all resources, system version %q",
+				cache.typeURL, cache.getVersion())
+		}
+		cache.watchAll[watch] = struct{}{}
 		return func() {
 			cache.mu.Lock()
 			defer cache.mu.Unlock()
-			delete(cache.watchAll, value)
+			delete(cache.watchAll, watch)
 		}
+	}
+
+	// Non-wildcard case
+	if cache.log != nil {
+		cache.log.Infof("[linear cache] open watch for %s resources %v, system version %q",
+			cache.typeURL, request.ResourceNames, cache.getVersion())
 	}
 	for _, name := range request.ResourceNames {
 		set, exists := cache.watches[name]
@@ -353,7 +394,7 @@ func (cache *LinearCache) CreateWatch(request *Request, clientState ClientState,
 			set = make(watches)
 			cache.watches[name] = set
 		}
-		set[value] = struct{}{}
+		set[watch] = struct{}{}
 	}
 	return func() {
 		cache.mu.Lock()
@@ -361,7 +402,7 @@ func (cache *LinearCache) CreateWatch(request *Request, clientState ClientState,
 		for _, name := range request.ResourceNames {
 			set, exists := cache.watches[name]
 			if exists {
-				delete(set, value)
+				delete(set, watch)
 			}
 			if len(set) == 0 {
 				delete(cache.watches, name)

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -135,7 +135,7 @@ func (cache *LinearCache) respond(req *Request, value chan Response, staleResour
 		}
 	}
 	value <- &RawResponse{
-		Request:       &Request{TypeUrl: cache.typeURL},
+		Request:       req,
 		Resources:     resources,
 		ResourceNames: resourceNames,
 		Version:       cache.getVersion(),

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -49,7 +49,7 @@ func (l testLogger) log(level string, format string, args ...interface{}) {
 
 func (l testLogger) Debugf(format string, args ...interface{}) {
 	l.t.Helper()
-	l.log("INFO", format, args...)
+	l.log("DEBUG", format, args...)
 }
 
 func (l testLogger) Infof(format string, args ...interface{}) {
@@ -59,12 +59,12 @@ func (l testLogger) Infof(format string, args ...interface{}) {
 
 func (l testLogger) Warnf(format string, args ...interface{}) {
 	l.t.Helper()
-	l.log("INFO", format, args...)
+	l.log("WARN", format, args...)
 }
 
 func (l testLogger) Errorf(format string, args ...interface{}) {
 	l.t.Helper()
-	l.log("INFO", format, args...)
+	l.log("ERROR", format, args...)
 }
 
 func testResource(s string) types.Resource {

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -34,6 +34,39 @@ const (
 	testType = "google.protobuf.StringValue"
 )
 
+type testLogger struct {
+	t *testing.T
+}
+
+func newTestLogger(t *testing.T) testLogger {
+	return testLogger{t}
+}
+
+func (l testLogger) log(level string, format string, args ...interface{}) {
+	l.t.Helper()
+	l.t.Logf("["+level+"] "+format, args...)
+}
+
+func (l testLogger) Debugf(format string, args ...interface{}) {
+	l.t.Helper()
+	l.log("INFO", format, args...)
+}
+
+func (l testLogger) Infof(format string, args ...interface{}) {
+	l.t.Helper()
+	l.log("INFO", format, args...)
+}
+
+func (l testLogger) Warnf(format string, args ...interface{}) {
+	l.t.Helper()
+	l.log("INFO", format, args...)
+}
+
+func (l testLogger) Errorf(format string, args ...interface{}) {
+	l.t.Helper()
+	l.log("INFO", format, args...)
+}
+
 func testResource(s string) types.Resource {
 	return wrapperspb.String(s)
 }
@@ -162,6 +195,7 @@ func checkVersionMapSet(t *testing.T, c *LinearCache) {
 }
 
 func mustBlock(t *testing.T, w <-chan Response) {
+	t.Helper()
 	select {
 	case <-w:
 		t.Error("watch must block")
@@ -170,6 +204,7 @@ func mustBlock(t *testing.T, w <-chan Response) {
 }
 
 func mustBlockDelta(t *testing.T, w <-chan DeltaResponse) {
+	t.Helper()
 	select {
 	case <-w:
 		t.Error("watch must block")
@@ -178,6 +213,7 @@ func mustBlockDelta(t *testing.T, w <-chan DeltaResponse) {
 }
 
 func hashResource(t *testing.T, resource types.Resource) string {
+	t.Helper()
 	marshaledResource, err := MarshalResource(resource)
 	if err != nil {
 		t.Fatal(err)
@@ -229,18 +265,29 @@ func TestLinearCornerCases(t *testing.T) {
 }
 
 func TestLinearBasic(t *testing.T) {
-	streamState := stream.NewStreamState(false, map[string]string{})
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 
 	// Create watches before a resource is ready
+	stream1 := stream.NewStreamState(false, map[string]string{})
 	w1 := make(chan Response, 1)
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &streamState, w1)
+	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: ""}, &stream1, w1)
+	verifyResponse(t, w1, "0", 0)
+	stream1.GetKnownResources()["a"] = "0"
+
+	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &stream1, w1)
 	mustBlock(t, w1)
 	checkVersionMapNotSet(t, c)
 
+	stream := stream.NewStreamState(true, map[string]string{})
 	w := make(chan Response, 1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
+	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: ""}, &stream, w)
+	verifyResponse(t, w, "0", 0)
+
+	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &stream, w)
 	mustBlock(t, w)
+	checkVersionMapNotSet(t, c)
+
 	checkWatchCount(t, c, "a", 2)
 	checkWatchCount(t, c, "b", 1)
 	require.NoError(t, c.UpdateResource("a", testResource("a")))
@@ -248,36 +295,49 @@ func TestLinearBasic(t *testing.T) {
 	checkWatchCount(t, c, "b", 0)
 	verifyResponse(t, w1, "1", 1)
 	verifyResponse(t, w, "1", 1)
+	stream.GetKnownResources()["a"] = "1"
 
 	// Request again, should get same response
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
+	stream.SetWildcard(false)
+	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &stream, w)
 	checkWatchCount(t, c, "a", 0)
 	verifyResponse(t, w, "1", 1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
+
+	// Version is old, so should return it
+	stream.SetWildcard(true)
+	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &stream, w)
 	checkWatchCount(t, c, "a", 0)
 	verifyResponse(t, w, "1", 1)
 
 	// Add another element and update the first, response should be different
 	require.NoError(t, c.UpdateResource("b", testResource("b")))
 	require.NoError(t, c.UpdateResource("a", testResource("aa")))
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
+
+	stream.SetWildcard(false)
+	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"}, &stream, w)
 	verifyResponse(t, w, "3", 1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
+
+	stream.SetWildcard(true)
+	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, &stream, w)
 	verifyResponse(t, w, "3", 2)
 	// Ensure the version map was not created as we only ever used stow watches
 	checkVersionMapNotSet(t, c)
 }
 
 func TestLinearSetResources(t *testing.T) {
-	streamState := stream.NewStreamState(false, map[string]string{})
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 
+	state1 := stream.NewStreamState(false, map[string]string{})
+	state1.GetKnownResources()["a"] = "0"
 	// Create new resources
 	w1 := make(chan Response, 1)
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &streamState, w1)
+	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &state1, w1)
 	mustBlock(t, w1)
+
+	state2 := stream.NewStreamState(true, map[string]string{})
 	w2 := make(chan Response, 1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &streamState, w2)
+	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &state2, w2)
 	mustBlock(t, w2)
 	c.SetResources(map[string]types.Resource{
 		"a": testResource("a"),
@@ -287,9 +347,9 @@ func TestLinearSetResources(t *testing.T) {
 	verifyResponse(t, w2, "1", 2) // the version was only incremented once for all resources
 
 	// Add another element and update the first, response should be different
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"}, &streamState, w1)
+	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"}, &state1, w1)
 	mustBlock(t, w1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, &streamState, w2)
+	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, &state2, w2)
 	mustBlock(t, w2)
 	c.SetResources(map[string]types.Resource{
 		"a": testResource("aa"),
@@ -300,9 +360,9 @@ func TestLinearSetResources(t *testing.T) {
 	verifyResponse(t, w2, "2", 3)
 
 	// Delete resource
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "2"}, &streamState, w1)
+	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "2"}, &state1, w1)
 	mustBlock(t, w1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "2"}, &streamState, w2)
+	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "2"}, &state2, w2)
 	mustBlock(t, w2)
 	c.SetResources(map[string]types.Resource{
 		"b": testResource("b"),
@@ -314,6 +374,7 @@ func TestLinearSetResources(t *testing.T) {
 
 func TestLinearGetResources(t *testing.T) {
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 
 	expectedResources := map[string]types.Resource{
 		"a": testResource("a"),
@@ -332,14 +393,16 @@ func TestLinearGetResources(t *testing.T) {
 func TestLinearVersionPrefix(t *testing.T) {
 	streamState := stream.NewStreamState(false, map[string]string{})
 	c := NewLinearCache(testType, WithVersionPrefix("instance1-"))
+	c.log = newTestLogger(t)
 
 	w := make(chan Response, 1)
 	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
 	verifyResponse(t, w, "instance1-0", 0)
 
 	require.NoError(t, c.UpdateResource("a", testResource("a")))
-	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
+	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "instance1-0"}, &streamState, w)
 	verifyResponse(t, w, "instance1-1", 1)
+	streamState.GetKnownResources()["a"] = "instance1-1"
 
 	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "instance1-1"}, &streamState, w)
 	mustBlock(t, w)
@@ -347,42 +410,73 @@ func TestLinearVersionPrefix(t *testing.T) {
 }
 
 func TestLinearDeletion(t *testing.T) {
-	streamState := stream.NewStreamState(false, map[string]string{})
 	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
+	c.log = newTestLogger(t)
+
+	streamState := stream.NewStreamState(false, map[string]string{})
 	w := make(chan Response, 1)
+	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: ""}, &streamState, w)
+	verifyResponse(t, w, "0", 1)
+	streamState.GetKnownResources()["a"] = "0"
+
 	c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
 	require.NoError(t, c.DeleteResource("a"))
 	verifyResponse(t, w, "1", 0)
 	checkWatchCount(t, c, "a", 0)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
-	verifyResponse(t, w, "1", 1)
-	checkWatchCount(t, c, "b", 0)
-	require.NoError(t, c.DeleteResource("b"))
+	streamState.SetWildcard(true)
 	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, &streamState, w)
+	mustBlock(t, w)
+	checkWatchCount(t, c, "b", 1)
+
+	require.NoError(t, c.DeleteResource("b"))
 	verifyResponse(t, w, "2", 0)
 	checkWatchCount(t, c, "b", 0)
 }
 
 func TestLinearWatchTwo(t *testing.T) {
-	streamState := stream.NewStreamState(false, map[string]string{})
 	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
+	c.log = newTestLogger(t)
+
+	// Default case, stream starts with no version
+	state := stream.NewStreamState(false, map[string]string{})
 	w := make(chan Response, 1)
-	c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"}, &streamState, w)
+	c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: ""}, &state, w)
+	verifyResponse(t, w, "0", 2)
+	state.GetKnownResources()["a"] = "0"
+	state.GetKnownResources()["b"] = "0"
+
+	c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"}, &state, w)
 	mustBlock(t, w)
+
+	// Wildcard should be able to start with a version
+	// It will only return if the version is not up-to-date
+	state1 := stream.NewStreamState(true, map[string]string{})
 	w1 := make(chan Response, 1)
-	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &streamState, w1)
+	c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "0"}, &state1, w1)
 	mustBlock(t, w1)
+
 	require.NoError(t, c.UpdateResource("a", testResource("aa")))
 	// should only get the modified resource
 	verifyResponse(t, w, "1", 1)
+	// Receive an update for all resources
 	verifyResponse(t, w1, "1", 2)
 }
 
-func TestLinearCancel(t *testing.T) {
+func TestLinearResourceSubscription(t *testing.T) {
 	streamState := stream.NewStreamState(false, map[string]string{})
+	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
+	w := make(chan Response, 1)
+
+	c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "1"}, &streamState, w)
+	verifyResponse(t, w, "0", 2)
+}
+
+func TestLinearCancel(t *testing.T) {
+	streamState := stream.NewStreamState(true, map[string]string{})
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 	require.NoError(t, c.UpdateResource("a", testResource("a")))
 
 	// cancel watch-all
@@ -392,8 +486,10 @@ func TestLinearCancel(t *testing.T) {
 	checkWatchCount(t, c, "a", 1)
 	cancel()
 	checkWatchCount(t, c, "a", 0)
+	streamState.GetKnownResources()["a"] = "1"
 
 	// cancel watch for "a"
+	streamState.SetWildcard(false)
 	cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"}, &streamState, w)
 	mustBlock(t, w)
 	checkWatchCount(t, c, "a", 1)
@@ -406,6 +502,7 @@ func TestLinearCancel(t *testing.T) {
 	w4 := make(chan Response, 1)
 	cancel = c.CreateWatch(&Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "1"}, &streamState, w)
 	cancel2 := c.CreateWatch(&Request{ResourceNames: []string{"b"}, TypeUrl: testType, VersionInfo: "1"}, &streamState, w2)
+	streamState.SetWildcard(true)
 	cancel3 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, &streamState, w3)
 	cancel4 := c.CreateWatch(&Request{TypeUrl: testType, VersionInfo: "1"}, &streamState, w4)
 	mustBlock(t, w)
@@ -431,6 +528,7 @@ func TestLinearCancel(t *testing.T) {
 func TestLinearConcurrentSetWatch(t *testing.T) {
 	streamState := stream.NewStreamState(false, map[string]string{})
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 	n := 50
 	for i := 0; i < 2*n; i++ {
 		func(i int) {
@@ -460,6 +558,7 @@ func TestLinearConcurrentSetWatch(t *testing.T) {
 
 func TestLinearDeltaWildcard(t *testing.T) {
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 	state1 := stream.NewStreamState(true, map[string]string{})
 	w1 := make(chan DeltaResponse, 1)
 	c.CreateDeltaWatch(&DeltaRequest{TypeUrl: testType}, &state1, w1)
@@ -481,6 +580,7 @@ func TestLinearDeltaWildcard(t *testing.T) {
 
 func TestLinearDeltaExistingResources(t *testing.T) {
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 	a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 	hashA := hashResource(t, a)
 	err := c.UpdateResource("a", a)
@@ -507,6 +607,7 @@ func TestLinearDeltaExistingResources(t *testing.T) {
 
 func TestLinearDeltaInitialResourcesVersionSet(t *testing.T) {
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 	a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 	hashA := hashResource(t, a)
 	err := c.UpdateResource("a", a)
@@ -539,6 +640,7 @@ func TestLinearDeltaInitialResourcesVersionSet(t *testing.T) {
 
 func TestLinearDeltaResourceUpdate(t *testing.T) {
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 	a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 	hashA := hashResource(t, a)
 	err := c.UpdateResource("a", a)
@@ -577,6 +679,7 @@ func TestLinearDeltaResourceUpdate(t *testing.T) {
 
 func TestLinearDeltaResourceDelete(t *testing.T) {
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 	a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 	hashA := hashResource(t, a)
 	err := c.UpdateResource("a", a)
@@ -610,6 +713,7 @@ func TestLinearDeltaResourceDelete(t *testing.T) {
 
 func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 
 	state := stream.NewStreamState(false, nil)
 	state.SetSubscribedResources(map[string]struct{}{"a": {}, "b": {}})
@@ -727,6 +831,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 
 func TestLinearMixedWatches(t *testing.T) {
 	c := NewLinearCache(testType)
+	c.log = newTestLogger(t)
 	a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 	err := c.UpdateResource("a", a)
 	assert.NoError(t, err)
@@ -739,6 +844,11 @@ func TestLinearMixedWatches(t *testing.T) {
 	sotwState := stream.NewStreamState(false, nil)
 	w := make(chan Response, 1)
 	c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: c.getVersion()}, &sotwState, w)
+	verifyResponse(t, w, c.getVersion(), 2)
+	sotwState.GetKnownResources()["a"] = c.getVersion()
+	sotwState.GetKnownResources()["b"] = c.getVersion()
+
+	c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: c.getVersion()}, &sotwState, w)
 	mustBlock(t, w)
 	checkVersionMapNotSet(t, c)
 
@@ -748,8 +858,10 @@ func TestLinearMixedWatches(t *testing.T) {
 	hashA := hashResource(t, a)
 	err = c.UpdateResources(map[string]types.Resource{"a": a}, nil)
 	assert.NoError(t, err)
-	// This behavior is currently invalid for cds and lds, but due to a current limitation of linear cache sotw implementation
+	// For non-wildcard, we only return the state of the resource that has been updated
+	// This is non-applicable for cds/lds that will always send wildcard requests
 	verifyResponse(t, w, c.getVersion(), 1)
+	sotwState.GetKnownResources()["a"] = c.getVersion()
 	checkVersionMapNotSet(t, c)
 
 	c.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: c.getVersion()}, &sotwState, w)

--- a/pkg/cache/v3/mux.go
+++ b/pkg/cache/v3/mux.go
@@ -17,8 +17,6 @@ package cache
 import (
 	"context"
 	"errors"
-
-	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 )
 
 // MuxCache multiplexes across several caches using a classification function.
@@ -37,7 +35,7 @@ type MuxCache struct {
 
 var _ Cache = &MuxCache{}
 
-func (mux *MuxCache) CreateWatch(request *Request, state stream.StreamState, value chan Response) func() {
+func (mux *MuxCache) CreateWatch(request *Request, state ClientState, value chan Response) func() {
 	key := mux.Classify(request)
 	cache, exists := mux.Caches[key]
 	if !exists {
@@ -47,7 +45,7 @@ func (mux *MuxCache) CreateWatch(request *Request, state stream.StreamState, val
 	return cache.CreateWatch(request, state, value)
 }
 
-func (mux *MuxCache) CreateDeltaWatch(request *DeltaRequest, state stream.StreamState, value chan DeltaResponse) func() {
+func (mux *MuxCache) CreateDeltaWatch(request *DeltaRequest, state ClientState, value chan DeltaResponse) func() {
 	key := mux.ClassifyDelta(request)
 	cache, exists := mux.Caches[key]
 	if !exists {

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -433,6 +433,7 @@ func (cache *snapshotCache) respond(ctx context.Context, request *Request, value
 
 func createResponse(ctx context.Context, request *Request, resources map[string]types.ResourceWithTTL, version string, heartbeat bool) Response {
 	filtered := make([]types.ResourceWithTTL, 0, len(resources))
+	resourceNames := make([]string, 0, len(resources))
 
 	// Reply only with the requested resources. Envoy may ask each resource
 	// individually in a separate stream. It is ok to reply with the same version
@@ -442,20 +443,23 @@ func createResponse(ctx context.Context, request *Request, resources map[string]
 		for name, resource := range resources {
 			if set[name] {
 				filtered = append(filtered, resource)
+				resourceNames = append(resourceNames, name)
 			}
 		}
 	} else {
-		for _, resource := range resources {
+		for name, resource := range resources {
 			filtered = append(filtered, resource)
+			resourceNames = append(resourceNames, name)
 		}
 	}
 
 	return &RawResponse{
-		Request:   request,
-		Version:   version,
-		Resources: filtered,
-		Heartbeat: heartbeat,
-		Ctx:       ctx,
+		Request:       request,
+		Version:       version,
+		Resources:     filtered,
+		ResourceNames: resourceNames,
+		Heartbeat:     heartbeat,
+		Ctx:           ctx,
 	}
 }
 

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -91,10 +91,22 @@ type logger struct {
 	t *testing.T
 }
 
-func (log logger) Debugf(format string, args ...interface{}) { log.t.Logf(format, args...) }
-func (log logger) Infof(format string, args ...interface{})  { log.t.Logf(format, args...) }
-func (log logger) Warnf(format string, args ...interface{})  { log.t.Logf(format, args...) }
-func (log logger) Errorf(format string, args ...interface{}) { log.t.Logf(format, args...) }
+func (log logger) Debugf(format string, args ...interface{}) {
+	log.t.Helper()
+	log.t.Logf(format, args...)
+}
+func (log logger) Infof(format string, args ...interface{}) {
+	log.t.Helper()
+	log.t.Logf(format, args...)
+}
+func (log logger) Warnf(format string, args ...interface{}) {
+	log.t.Helper()
+	log.t.Logf(format, args...)
+}
+func (log logger) Errorf(format string, args ...interface{}) {
+	log.t.Helper()
+	log.t.Logf(format, args...)
+}
 
 func TestSnapshotCacheWithTTL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/server/sotw/v3/watches.go
+++ b/pkg/server/sotw/v3/watches.go
@@ -63,7 +63,6 @@ func (w *watches) recompute(ctx context.Context, req <-chan *discovery.Discovery
 // watch contains the necessary modifiables for receiving resource responses
 type watch struct {
 	cancel   func()
-	nonce    string
 	response chan cache.Response
 }
 

--- a/pkg/server/stream/v3/stream.go
+++ b/pkg/server/stream/v3/stream.go
@@ -33,55 +33,28 @@ type StreamState struct { // nolint:golint,revive
 	// ResourceVersions contains a hash of the resource as the value and the resource name as the key.
 	// This field stores the last state sent to the client.
 	resourceVersions map[string]string
-
-	// knownResourceNames contains resource names that a client has received previously
-	knownResourceNames map[string]map[string]struct{}
-
-	// indicates whether the object has been modified since its creation
-	first bool
 }
 
 // GetSubscribedResourceNames returns the list of resources currently explicitly subscribed to
 // If the request is set to wildcard it may be empty
 // Currently populated only when using delta-xds
-func (s *StreamState) GetSubscribedResourceNames() map[string]struct{} {
+func (s *StreamState) GetSubscribedResources() map[string]struct{} {
 	return s.subscribedResourceNames
 }
 
 // SetSubscribedResourceNames is setting the list of resources currently explicitly subscribed to
 // It is decorrelated from the wildcard state of the stream
 // Currently used only when using delta-xds
-func (s *StreamState) SetSubscribedResourceNames(subscribedResourceNames map[string]struct{}) {
+func (s *StreamState) SetSubscribedResources(subscribedResourceNames map[string]struct{}) {
 	s.subscribedResourceNames = subscribedResourceNames
 }
 
-// WatchesResources returns whether at least one of the resource provided is currently watch by the stream
-// It is currently only applicable to delta-xds
-// If the request is wildcard, it will always return true
-// Otherwise it will compare the provided resources to the list of resources currently subscribed
-func (s *StreamState) WatchesResources(resourceNames map[string]struct{}) bool {
-	if s.IsWildcard() {
-		return true
-	}
-	for resourceName := range resourceNames {
-		if _, ok := s.subscribedResourceNames[resourceName]; ok {
-			return true
-		}
-	}
-	return false
-}
-
-func (s *StreamState) GetResourceVersions() map[string]string {
+func (s *StreamState) GetKnownResources() map[string]string {
 	return s.resourceVersions
 }
 
 func (s *StreamState) SetResourceVersions(resourceVersions map[string]string) {
-	s.first = false
 	s.resourceVersions = resourceVersions
-}
-
-func (s *StreamState) IsFirst() bool {
-	return s.first
 }
 
 func (s *StreamState) SetWildcard(wildcard bool) {
@@ -92,30 +65,12 @@ func (s *StreamState) IsWildcard() bool {
 	return s.wildcard
 }
 
-func (s *StreamState) SetKnownResourceNames(url string, names map[string]struct{}) {
-	s.knownResourceNames[url] = names
-}
-
-func (s *StreamState) SetKnownResourceNamesAsList(url string, names []string) {
-	m := map[string]struct{}{}
-	for _, name := range names {
-		m[name] = struct{}{}
-	}
-	s.knownResourceNames[url] = m
-}
-
-func (s *StreamState) GetKnownResourceNames(url string) map[string]struct{} {
-	return s.knownResourceNames[url]
-}
-
 // NewStreamState initializes a stream state.
 func NewStreamState(wildcard bool, initialResourceVersions map[string]string) StreamState {
 	state := StreamState{
 		wildcard:                wildcard,
 		subscribedResourceNames: map[string]struct{}{},
 		resourceVersions:        initialResourceVersions,
-		first:                   true,
-		knownResourceNames:      map[string]map[string]struct{}{},
 	}
 
 	if initialResourceVersions == nil {

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -15,12 +15,11 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
 )
 
-func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryRequest, state stream.StreamState, out chan cache.DeltaResponse) func() {
+func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryRequest, state cache.ClientState, out chan cache.DeltaResponse) func() {
 	config.deltaCounts[req.TypeUrl] = config.deltaCounts[req.TypeUrl] + 1
 
 	// This is duplicated from pkg/cache/v3/delta.go as private there
@@ -37,7 +36,7 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 	// If we are handling a wildcard request, we want to respond with all resources
 	switch {
 	case state.IsWildcard():
-		if len(state.GetResourceVersions()) == 0 {
+		if len(state.GetKnownResources()) == 0 {
 			filtered = make([]types.Resource, 0, len(resourceMap))
 		}
 		nextVersionMap = make(map[string]string, len(resourceMap))
@@ -46,24 +45,24 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 			// we can just set it here to be used for comparison later
 			version := versionMap[name]
 			nextVersionMap[name] = version
-			prevVersion, found := state.GetResourceVersions()[name]
+			prevVersion, found := state.GetKnownResources()[name]
 			if !found || (prevVersion != version) {
 				filtered = append(filtered, r)
 			}
 		}
 
 		// Compute resources for removal
-		for name := range state.GetResourceVersions() {
+		for name := range state.GetKnownResources() {
 			if _, ok := resourceMap[name]; !ok {
 				toRemove = append(toRemove, name)
 			}
 		}
 	default:
-		nextVersionMap = make(map[string]string, len(state.GetSubscribedResourceNames()))
+		nextVersionMap = make(map[string]string, len(state.GetSubscribedResources()))
 		// state.GetResourceVersions() may include resources no longer subscribed
 		// In the current code this gets silently cleaned when updating the version map
-		for name := range state.GetSubscribedResourceNames() {
-			prevVersion, found := state.GetResourceVersions()[name]
+		for name := range state.GetSubscribedResources() {
+			prevVersion, found := state.GetKnownResources()[name]
 			if r, ok := resourceMap[name]; ok {
 				nextVersion := versionMap[name]
 				if prevVersion != nextVersion {
@@ -155,36 +154,36 @@ func makeMockDeltaStream(t *testing.T) *mockDeltaStream {
 
 func makeDeltaResources() map[string]map[string]types.Resource {
 	return map[string]map[string]types.Resource{
-		rsrc.EndpointType: map[string]types.Resource{
+		rsrc.EndpointType: {
 			endpoint.GetClusterName(): endpoint,
 		},
-		rsrc.ClusterType: map[string]types.Resource{
+		rsrc.ClusterType: {
 			cluster.Name: cluster,
 		},
-		rsrc.RouteType: map[string]types.Resource{
+		rsrc.RouteType: {
 			route.Name: route,
 		},
-		rsrc.ScopedRouteType: map[string]types.Resource{
+		rsrc.ScopedRouteType: {
 			scopedRoute.Name: scopedRoute,
 		},
-		rsrc.VirtualHostType: map[string]types.Resource{
+		rsrc.VirtualHostType: {
 			virtualHost.Name: virtualHost,
 		},
-		rsrc.ListenerType: map[string]types.Resource{
+		rsrc.ListenerType: {
 			httpListener.Name:       httpListener,
 			httpScopedListener.Name: httpScopedListener,
 		},
-		rsrc.SecretType: map[string]types.Resource{
+		rsrc.SecretType: {
 			secret.Name: secret,
 		},
-		rsrc.RuntimeType: map[string]types.Resource{
+		rsrc.RuntimeType: {
 			runtime.Name: runtime,
 		},
-		rsrc.ExtensionConfigType: map[string]types.Resource{
+		rsrc.ExtensionConfigType: {
 			extensionConfig.Name: extensionConfig,
 		},
 		// Pass-through type (types without explicit handling)
-		opaqueType: map[string]types.Resource{
+		opaqueType: {
 			"opaque": opaque,
 		},
 	}
@@ -460,7 +459,7 @@ func TestDeltaCallbackError(t *testing.T) {
 func TestDeltaWildcardSubscriptions(t *testing.T) {
 	config := makeMockConfigWatcher()
 	config.deltaResources = map[string]map[string]types.Resource{
-		rsrc.EndpointType: map[string]types.Resource{
+		rsrc.EndpointType: {
 			"endpoints0": resource.MakeEndpoint("endpoints0", 1234),
 			"endpoints1": resource.MakeEndpoint("endpoints1", 1234),
 			"endpoints2": resource.MakeEndpoint("endpoints2", 1234),

--- a/pkg/server/v3/server.go
+++ b/pkg/server/v3/server.go
@@ -29,7 +29,6 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	endpointservice "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
 	extensionconfigservice "github.com/envoyproxy/go-control-plane/envoy/service/extension/v3"
 	listenerservice "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
@@ -48,7 +47,7 @@ type Server interface {
 	routeservice.ScopedRoutesDiscoveryServiceServer
 	routeservice.VirtualHostDiscoveryServiceServer
 	listenerservice.ListenerDiscoveryServiceServer
-	discoverygrpc.AggregatedDiscoveryServiceServer
+	discovery.AggregatedDiscoveryServiceServer
 	secretservice.SecretDiscoveryServiceServer
 	runtimeservice.RuntimeDiscoveryServiceServer
 	extensionconfigservice.ExtensionConfigDiscoveryServiceServer
@@ -184,7 +183,7 @@ func (s *server) StreamHandler(stream stream.Stream, typeURL string) error {
 	return s.sotw.StreamHandler(stream, typeURL)
 }
 
-func (s *server) StreamAggregatedResources(stream discoverygrpc.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+func (s *server) StreamAggregatedResources(stream discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
 	return s.StreamHandler(stream, resource.AnyType)
 }
 
@@ -297,7 +296,7 @@ func (s *server) DeltaStreamHandler(stream stream.DeltaStream, typeURL string) e
 	return s.delta.DeltaStreamHandler(stream, typeURL)
 }
 
-func (s *server) DeltaAggregatedResources(stream discoverygrpc.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+func (s *server) DeltaAggregatedResources(stream discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
 	return s.DeltaStreamHandler(stream, resource.AnyType)
 }
 

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
 )
@@ -48,7 +47,7 @@ type mockConfigWatcher struct {
 	mu *sync.RWMutex
 }
 
-func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, state stream.StreamState, out chan cache.Response) func() {
+func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, state cache.ClientState, out chan cache.Response) func() {
 	config.counts[req.TypeUrl] = config.counts[req.TypeUrl] + 1
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out <- config.responses[req.TypeUrl][0]

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -708,11 +708,11 @@ type LinearCacheMock struct {
 	mu sync.Mutex
 }
 
-func (m *LinearCacheMock) setExpectation(assert Assert, version string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.assert = assert
-	m.version = version
+func (mock *LinearCacheMock) setExpectation(assert Assert, version string) {
+	mock.mu.Lock()
+	defer mock.mu.Unlock()
+	mock.assert = assert
+	mock.version = version
 }
 
 func (mock *LinearCacheMock) CreateWatch(req *discovery.DiscoveryRequest, state cache.ClientState, out chan cache.Response) func() {

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -50,7 +50,9 @@ type mockConfigWatcher struct {
 func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, state cache.ClientState, out chan cache.Response) func() {
 	config.counts[req.TypeUrl] = config.counts[req.TypeUrl] + 1
 	if len(config.responses[req.TypeUrl]) > 0 {
-		out <- config.responses[req.TypeUrl][0]
+		resp := config.responses[req.TypeUrl][0].(*cache.RawResponse)
+		resp.Request = req
+		out <- resp
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]
 	} else {
 		config.watches++
@@ -177,73 +179,83 @@ func makeResponses() map[string][]cache.Response {
 	return map[string][]cache.Response{
 		rsrc.EndpointType: {
 			&cache.RawResponse{
-				Version:   "1",
-				Resources: []types.ResourceWithTTL{{Resource: endpoint}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
+				Version:       "1",
+				Resources:     []types.ResourceWithTTL{{Resource: endpoint}},
+				ResourceNames: []string{clusterName},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
 			},
 		},
 		rsrc.ClusterType: {
 			&cache.RawResponse{
-				Version:   "2",
-				Resources: []types.ResourceWithTTL{{Resource: cluster}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
+				Version:       "2",
+				Resources:     []types.ResourceWithTTL{{Resource: cluster}},
+				ResourceNames: []string{clusterName},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
 			},
 		},
 		rsrc.RouteType: {
 			&cache.RawResponse{
-				Version:   "3",
-				Resources: []types.ResourceWithTTL{{Resource: route}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
+				Version:       "3",
+				Resources:     []types.ResourceWithTTL{{Resource: route}},
+				ResourceNames: []string{routeName},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
 			},
 		},
 		rsrc.ScopedRouteType: {
 			&cache.RawResponse{
-				Version:   "4",
-				Resources: []types.ResourceWithTTL{{Resource: scopedRoute}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ScopedRouteType},
+				Version:       "4",
+				Resources:     []types.ResourceWithTTL{{Resource: scopedRoute}},
+				ResourceNames: []string{routeName},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: rsrc.ScopedRouteType},
 			},
 		},
 		rsrc.VirtualHostType: {
 			&cache.RawResponse{
-				Version:   "5",
-				Resources: []types.ResourceWithTTL{{Resource: virtualHost}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.VirtualHostType},
+				Version:       "5",
+				Resources:     []types.ResourceWithTTL{{Resource: virtualHost}},
+				ResourceNames: []string{virtualHostName},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: rsrc.VirtualHostType},
 			},
 		},
 		rsrc.ListenerType: {
 			&cache.RawResponse{
-				Version:   "6",
-				Resources: []types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
+				Version:       "6",
+				Resources:     []types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
+				ResourceNames: []string{listenerName, scopedListenerName},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
 			},
 		},
 		rsrc.SecretType: {
 			&cache.RawResponse{
-				Version:   "7",
-				Resources: []types.ResourceWithTTL{{Resource: secret}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
+				Version:       "7",
+				Resources:     []types.ResourceWithTTL{{Resource: secret}},
+				ResourceNames: []string{secretName},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
 			},
 		},
 		rsrc.RuntimeType: {
 			&cache.RawResponse{
-				Version:   "8",
-				Resources: []types.ResourceWithTTL{{Resource: runtime}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
+				Version:       "8",
+				Resources:     []types.ResourceWithTTL{{Resource: runtime}},
+				ResourceNames: []string{runtimeName},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
 			},
 		},
 		rsrc.ExtensionConfigType: {
 			&cache.RawResponse{
-				Version:   "9",
-				Resources: []types.ResourceWithTTL{{Resource: extensionConfig}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
+				Version:       "9",
+				Resources:     []types.ResourceWithTTL{{Resource: extensionConfig}},
+				ResourceNames: []string{extensionConfigName},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
 			},
 		},
 		// Pass-through type (xDS does not exist for this type)
 		opaqueType: {
 			&cache.RawResponse{
-				Version:   "10",
-				Resources: []types.ResourceWithTTL{{Resource: opaque}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: opaqueType},
+				Version:       "10",
+				Resources:     []types.ResourceWithTTL{{Resource: opaque}},
+				ResourceNames: []string{"opaque"},
+				Request:       &discovery.DiscoveryRequest{TypeUrl: opaqueType},
 			},
 		},
 	}
@@ -679,5 +691,141 @@ func TestCallbackError(t *testing.T) {
 
 			close(resp.recv)
 		})
+	}
+}
+
+type LinearCacheMock struct {
+	// name -> version
+	assert        func(req *discovery.DiscoveryRequest, state cache.ClientState)
+	resources     []types.ResourceWithTTL
+	resourceNames []string
+	version       string
+}
+
+func (mock *LinearCacheMock) CreateWatch(req *discovery.DiscoveryRequest, state cache.ClientState, out chan cache.Response) func() {
+	if mock.assert != nil {
+		mock.assert(req, state)
+	}
+	if mock.version != "" {
+		out <- &cache.RawResponse{
+			Request:       req,
+			Version:       mock.version,
+			Resources:     mock.resources,
+			ResourceNames: mock.resourceNames,
+		}
+	}
+	return func() {}
+}
+
+func (mock *LinearCacheMock) CreateDeltaWatch(req *discovery.DeltaDiscoveryRequest, state cache.ClientState, out chan cache.DeltaResponse) func() {
+	return nil
+}
+func (mock *LinearCacheMock) Fetch(ctx context.Context, req *discovery.DiscoveryRequest) (cache.Response, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func TestSubscriptionsThroughLinearCache(t *testing.T) {
+	resp := makeMockStream(t)
+	linearCache := LinearCacheMock{}
+	defer close(resp.recv)
+
+	go func() {
+		s := server.NewServer(context.Background(), &linearCache, server.CallbackFuncs{})
+		assert.NoError(t, s.StreamAggregatedResources(resp))
+	}()
+
+	linearCache.version = "1"
+	linearCache.resources = []types.ResourceWithTTL{
+		{Resource: endpoint},
+	}
+	linearCache.resourceNames = []string{clusterName}
+	linearCache.assert = func(req *discovery.DiscoveryRequest, state cache.ClientState) {
+		assert.Equal(t, []string{clusterName}, req.ResourceNames)
+		assert.Empty(t, state.GetKnownResources())
+	}
+
+	var nonce string
+	resp.recv <- &discovery.DiscoveryRequest{
+		Node:          node,
+		ResponseNonce: nonce,
+		TypeUrl:       rsrc.EndpointType,
+		ResourceNames: []string{clusterName},
+	}
+
+	select {
+	case epResponse := <-resp.sent:
+		assert.Len(t, epResponse.Resources, 1)
+		nonce = epResponse.Nonce
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "no response received")
+	}
+
+	linearCache.version = ""
+	linearCache.assert = func(req *discovery.DiscoveryRequest, state cache.ClientState) {
+		assert.Equal(t, []string{}, req.ResourceNames)
+		// This should also be empty
+		assert.Empty(t, state.GetKnownResources())
+	}
+
+	// No longer listen to this resource
+	resp.recv <- &discovery.DiscoveryRequest{
+		Node:          node,
+		ResponseNonce: nonce,
+		TypeUrl:       rsrc.EndpointType,
+		ResourceNames: []string{},
+	}
+
+	select {
+	case epResponse := <-resp.sent:
+		assert.Fail(t, "unexpected response")
+		nonce = epResponse.Nonce
+	case <-time.After(100 * time.Millisecond):
+		// go on
+	}
+
+	// Cache version did not change
+	linearCache.version = "1"
+	linearCache.assert = func(req *discovery.DiscoveryRequest, state cache.ClientState) {
+		assert.Equal(t, []string{clusterName}, req.ResourceNames)
+		// This should also be empty
+		assert.Empty(t, state.GetKnownResources())
+	}
+
+	//Subscribe to it again
+	resp.recv <- &discovery.DiscoveryRequest{
+		Node:          node,
+		ResponseNonce: nonce,
+		TypeUrl:       rsrc.EndpointType,
+		ResourceNames: []string{clusterName},
+	}
+
+	select {
+	case epResponse := <-resp.sent:
+		assert.Len(t, epResponse.Resources, 1)
+		nonce = epResponse.Nonce
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "no response received")
+	}
+
+	// Cache version did not change
+	linearCache.version = ""
+	linearCache.assert = func(req *discovery.DiscoveryRequest, state cache.ClientState) {
+		assert.Equal(t, []string{clusterName}, req.ResourceNames)
+		// This should also be empty
+		assert.Equal(t, map[string]string{clusterName: "1"}, state.GetKnownResources())
+	}
+
+	// Don't change anything, simply ack the current one
+	resp.recv <- &discovery.DiscoveryRequest{
+		Node:          node,
+		ResponseNonce: nonce,
+		TypeUrl:       rsrc.EndpointType,
+		ResourceNames: []string{clusterName},
+	}
+	select {
+	case <-resp.sent:
+		assert.Fail(t, "unexpected response")
+	case <-time.After(100 * time.Millisecond):
+		// go on
 	}
 }


### PR DESCRIPTION
This PR is part of the fix for the issue related to resources being unsubscribed from then subscribed to again
This one applies to both simple and linear cache when using the sotw protocol.
Actionable cases would likely only impact sotw-ADS as EDS outside of ADS does not share streams and will therefore usually not have multiple resources this way

This PR is built on top of https://github.com/envoyproxy/go-control-plane/pull/584 as it's relying on the client state being provided to the cache

It is also fixing a few bugs found during testing:
- in linear cache, the request set in the response was not the actual request. It was breaking some sotw parts as this was actually relied upon for some behavior (though not the bug of the issue)
- in linear cache, when using sotw, if a request has multiple resources (at least three) and receive at least two subsequent updates of subsets of those resources, there is a deadlock as the watch is leaked in the watches of resources requested but not yet updated. As this channel won't be listened after the first reply, the second update will fill the buffer and any subsequent cache update impacting a resource requested and not yet updated will deadlock

It is updating a few other aspects in order to implement the fix:
- Adds a staged resources map within the streamState. In sotw it is storing resources returned but not yet ACKed. This behavior should be ported to delta, but is out of the scope here. It allows removing the bespoke lastResponse value set only in sotw and parallel to streamState
- Adds a new returned attribute in the rawResponse, providing the list of resources included in the opaque response. This is needed to know which resources are actually known to the client. The previous implementation based on the request was actually opening edge cases as there is no guarantee a requested resource has ever been replied
- Adds cache logging in linear_test.go (helping while writing tests)

Finally, reasoning on the fixing through proper tracking of resources rather than basic resend of everything on doubts is explained within #584, and is even more applicable in the context of this issue (EDS through sotw-ads) when a single client can track thousands of endpoints within hundreds of CLAs