### PR TITLE
rm printing resources in cache logs

### DIFF
--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -186,8 +186,8 @@ func (cache *LinearCache) respondDelta(request *DeltaRequest, value chan DeltaRe
 	// Only send a response if there were changes
 	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 {
 		if cache.log != nil {
-			cache.log.Debugf("[linear cache] node: %s, sending delta response with resources: %v removed resources %v wildcard: %t",
-				request.GetNode().GetId(), resp.Resources, resp.RemovedResources, state.IsWildcard())
+			cache.log.Debugf("[linear cache] node: %s, sending delta response for typeURL %s with resources: %v removed resources %v with wildcard: %t",
+				request.GetNode().GetId(), request.TypeUrl, GetResourceNames(resp.Resources), resp.RemovedResources, state.IsWildcard())
 		}
 		value <- resp
 		return resp

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -186,7 +186,7 @@ func (cache *LinearCache) respondDelta(request *DeltaRequest, value chan DeltaRe
 	// Only send a response if there were changes
 	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 {
 		if cache.log != nil {
-			cache.log.Debugf("[linear cache] node: %s, sending delta response for typeURL %s with resources: %v removed resources %v with wildcard: %t",
+			cache.log.Debugf("[linear cache] node: %s, sending delta response for typeURL %s with resources: %v removed resources: %v with wildcard: %t",
 				request.GetNode().GetId(), request.TypeUrl, GetResourceNames(resp.Resources), resp.RemovedResources, state.IsWildcard())
 		}
 		value <- resp

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -110,6 +110,15 @@ func GetResourceName(res types.Resource) string {
 	}
 }
 
+// GetResourceName returns the resource names for a list of valid xDS response types.
+func GetResourceNames(resources []types.Resource) []string {
+	out := make([]string, 0, len(resources))
+	for _, r := range resources {
+		out = append(out, GetResourceName(r))
+	}
+	return out
+}
+
 // MarshalResource converts the Resource to MarshaledResource.
 func MarshalResource(resource types.Resource) (types.MarshaledResource, error) {
 	return proto.MarshalOptions{Deterministic: true}.Marshal(resource)

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -112,9 +112,9 @@ func GetResourceName(res types.Resource) string {
 
 // GetResourceName returns the resource names for a list of valid xDS response types.
 func GetResourceNames(resources []types.Resource) []string {
-	out := make([]string, 0, len(resources))
-	for _, r := range resources {
-		out = append(out, GetResourceName(r))
+	out := make([]string, len(resources))
+	for i, r := range resources {
+		out[i] = GetResourceName(r)
 	}
 	return out
 }

--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -110,6 +110,32 @@ func TestGetResourceName(t *testing.T) {
 	}
 }
 
+func TestGetResourceNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []types.Resource
+		want  []string
+	}{
+		{
+			name:  "empty",
+			input: []types.Resource{},
+			want:  []string{},
+		},
+		{
+			name:  "many",
+			input: []types.Resource{testRuntime, testListener, testVirtualHost},
+			want:  []string{runtimeName, listenerName, virtualHostName},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got := cache.GetResourceNames(test.input)
+			assert.ElementsMatch(t, test.want, got)
+		})
+	}
+}
+
 func TestGetResourceReferences(t *testing.T) {
 	cases := []struct {
 		in  types.Resource

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -527,8 +527,8 @@ func (cache *snapshotCache) respondDelta(ctx context.Context, snapshot ResourceS
 	// otherwise, envoy won't complete initialization
 	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 || (state.IsWildcard() && state.IsFirst()) {
 		if cache.log != nil {
-			cache.log.Debugf("node: %s, sending delta response with wildcard: %t",
-				request.GetNode().GetId(), state.IsWildcard())
+			cache.log.Debugf("node: %s, sending delta response for typeURL %s with resources: %v removed resources %v with wildcard: %t",
+				request.GetNode().GetId(), request.TypeUrl, GetResourceNames(resp.Resources), resp.RemovedResources, state.IsWildcard())
 		}
 		select {
 		case value <- resp:

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -527,8 +527,8 @@ func (cache *snapshotCache) respondDelta(ctx context.Context, snapshot ResourceS
 	// otherwise, envoy won't complete initialization
 	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 || (state.IsWildcard() && state.IsFirst()) {
 		if cache.log != nil {
-			cache.log.Debugf("node: %s, sending delta response with resources: %v removed resources %v wildcard: %t",
-				request.GetNode().GetId(), resp.Resources, resp.RemovedResources, state.IsWildcard())
+			cache.log.Debugf("node: %s, sending delta response with wildcard: %t",
+				request.GetNode().GetId(), state.IsWildcard())
 		}
 		select {
 		case value <- resp:

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -527,7 +527,7 @@ func (cache *snapshotCache) respondDelta(ctx context.Context, snapshot ResourceS
 	// otherwise, envoy won't complete initialization
 	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 || (state.IsWildcard() && state.IsFirst()) {
 		if cache.log != nil {
-			cache.log.Debugf("node: %s, sending delta response for typeURL %s with resources: %v removed resources %v with wildcard: %t",
+			cache.log.Debugf("node: %s, sending delta response for typeURL %s with resources: %v removed resources: %v with wildcard: %t",
 				request.GetNode().GetId(), request.TypeUrl, GetResourceNames(resp.Resources), resp.RemovedResources, state.IsWildcard())
 		}
 		select {


### PR DESCRIPTION
Fixes: https://github.com/envoyproxy/go-control-plane/issues/599

Signed-off-by: Arko Dasgupta <arko@tetrate.io>