### PR TITLE
Fix golangci-lint errors on main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint:
 		--rm \
 		--volume $$(pwd):/src \
 		--workdir /src \
-		golangci/golangci-lint:v1.43.0 \
+		golangci/golangci-lint:v1.50.1 \
 	golangci-lint -v run
 
 #-----------------

--- a/internal/example/logger.go
+++ b/internal/example/logger.go
@@ -11,6 +11,7 @@
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
+
 package example
 
 import (

--- a/internal/example/main/main.go
+++ b/internal/example/main/main.go
@@ -11,6 +11,7 @@
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
+
 package main
 
 import (

--- a/internal/example/resource.go
+++ b/internal/example/resource.go
@@ -11,6 +11,7 @@
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
+
 package example
 
 import (

--- a/internal/example/server.go
+++ b/internal/example/server.go
@@ -11,6 +11,7 @@
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
+
 package example
 
 import (

--- a/internal/upstream/main.go
+++ b/internal/upstream/main.go
@@ -11,6 +11,7 @@
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
+
 package main
 
 import (

--- a/internal/upstream/main.go
+++ b/internal/upstream/main.go
@@ -37,6 +37,8 @@ func main() {
 			log.Println(err)
 		}
 	})
+	// Ignore: G114: Use of net/http serve function that has no support for setting timeouts
+	// nolint:gosec
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", upstreamPort), nil); err != nil {
 		log.Println(err)
 	}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -11,6 +11,7 @@
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
+
 package log
 
 import (

--- a/pkg/server/delta/v3/watches_test.go
+++ b/pkg/server/delta/v3/watches_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDeltaWatches(t *testing.T) {
-	t.Run("watches response channels are properly closed when the watches are cancelled", func(t *testing.T) {
+	t.Run("watches response channels are properly closed when the watches are canceled", func(t *testing.T) {
 		watches := newWatches()
 
 		cancelCount := 0

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -155,36 +155,36 @@ func makeMockDeltaStream(t *testing.T) *mockDeltaStream {
 
 func makeDeltaResources() map[string]map[string]types.Resource {
 	return map[string]map[string]types.Resource{
-		rsrc.EndpointType: map[string]types.Resource{
+		rsrc.EndpointType: {
 			endpoint.GetClusterName(): endpoint,
 		},
-		rsrc.ClusterType: map[string]types.Resource{
+		rsrc.ClusterType: {
 			cluster.Name: cluster,
 		},
-		rsrc.RouteType: map[string]types.Resource{
+		rsrc.RouteType: {
 			route.Name: route,
 		},
-		rsrc.ScopedRouteType: map[string]types.Resource{
+		rsrc.ScopedRouteType: {
 			scopedRoute.Name: scopedRoute,
 		},
-		rsrc.VirtualHostType: map[string]types.Resource{
+		rsrc.VirtualHostType: {
 			virtualHost.Name: virtualHost,
 		},
-		rsrc.ListenerType: map[string]types.Resource{
+		rsrc.ListenerType: {
 			httpListener.Name:       httpListener,
 			httpScopedListener.Name: httpScopedListener,
 		},
-		rsrc.SecretType: map[string]types.Resource{
+		rsrc.SecretType: {
 			secret.Name: secret,
 		},
-		rsrc.RuntimeType: map[string]types.Resource{
+		rsrc.RuntimeType: {
 			runtime.Name: runtime,
 		},
-		rsrc.ExtensionConfigType: map[string]types.Resource{
+		rsrc.ExtensionConfigType: {
 			extensionConfig.Name: extensionConfig,
 		},
 		// Pass-through type (types without explicit handling)
-		opaqueType: map[string]types.Resource{
+		opaqueType: {
 			"opaque": opaque,
 		},
 	}
@@ -460,7 +460,7 @@ func TestDeltaCallbackError(t *testing.T) {
 func TestDeltaWildcardSubscriptions(t *testing.T) {
 	config := makeMockConfigWatcher()
 	config.deltaResources = map[string]map[string]types.Resource{
-		rsrc.EndpointType: map[string]types.Resource{
+		rsrc.EndpointType: {
 			"endpoints0": resource.MakeEndpoint("endpoints0", 1234),
 			"endpoints1": resource.MakeEndpoint("endpoints1", 1234),
 			"endpoints2": resource.MakeEndpoint("endpoints2", 1234),
@@ -531,7 +531,7 @@ func TestDeltaWildcardSubscriptions(t *testing.T) {
 
 	})
 
-	t.Run("* subscribtion/unsubscription support", func(t *testing.T) {
+	t.Run("* subscription/unsubscription support", func(t *testing.T) {
 		resp := makeMockDeltaStream(t)
 		defer close(resp.recv)
 		s := server.NewServer(context.Background(), config, server.CallbackFuncs{})
@@ -576,7 +576,7 @@ func TestDeltaWildcardSubscriptions(t *testing.T) {
 		validateResponse(t, resp.sent, []string{"endpoints1", "endpoints2"}, nil)
 	})
 
-	t.Run("resource specific subscribtions while using wildcard", func(t *testing.T) {
+	t.Run("resource specific subscriptions while using wildcard", func(t *testing.T) {
 		resp := makeMockDeltaStream(t)
 		defer close(resp.recv)
 		s := server.NewServer(context.Background(), config, server.CallbackFuncs{})

--- a/pkg/server/v3/gateway.go
+++ b/pkg/server/v3/gateway.go
@@ -17,7 +17,7 @@ package server
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
 
@@ -64,7 +64,7 @@ func (h *HTTPGateway) ServeHTTP(req *http.Request) ([]byte, int, error) {
 		return nil, http.StatusBadRequest, fmt.Errorf("empty body")
 	}
 
-	body, err := ioutil.ReadAll(req.Body)
+	body, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, http.StatusBadRequest, fmt.Errorf("cannot read body")
 	}

--- a/pkg/test/main/main.go
+++ b/pkg/test/main/main.go
@@ -20,7 +20,7 @@ import (
 	cryptotls "crypto/tls"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -343,7 +343,7 @@ func callEcho() (int, int) {
 				ch <- err
 				return
 			}
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				resp.Body.Close()
 				ch <- err

--- a/pkg/test/server.go
+++ b/pkg/test/server.go
@@ -96,6 +96,8 @@ func RunManagementServer(ctx context.Context, srv server.Server, port uint) {
 // RunManagementGateway starts an HTTP gateway to an xDS server.
 func RunManagementGateway(ctx context.Context, srv server.Server, port uint) {
 	log.Printf("gateway listening HTTP/1.1 on %d\n", port)
+	// Ignore: G114: Use of net/http serve function that has no support for setting timeouts
+	// nolint:gosec
 	server := &http.Server{
 		Addr: fmt.Sprintf(":%d", port),
 		Handler: &HTTPGateway{


### PR DESCRIPTION
Includes:
- bump Makefile golangci-lint version to 1.50.1
- spelling fixes
- add line between license/package name
- other gofmt issues
- stop using ioutil package (deprecated in go 1.16)
- ignore a couple gosec issues in test code