### PR TITLE
cache: support custom resource name

### DIFF
--- a/pkg/cache/types/types.go
+++ b/pkg/cache/types/types.go
@@ -17,6 +17,12 @@ type ResourceWithTTL struct {
 	TTL      *time.Duration
 }
 
+// ResourceWithName provides a name for out-of-tree resources.
+type ResourceWithName interface {
+	proto.Message
+	GetName() string
+}
+
 // MarshaledResource is an alias for the serialized binary array.
 type MarshaledResource = []byte
 

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -104,6 +104,8 @@ func GetResourceName(res types.Resource) string {
 		return v.GetName()
 	case *core.TypedExtensionConfig:
 		return v.GetName()
+	case types.ResourceWithName:
+		return v.GetName()
 	default:
 		return ""
 	}

--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -83,6 +83,16 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+type customResource struct {
+	cluster.Filter // Any proto would work here.
+}
+
+const customName = "test-name"
+
+func (cs *customResource) GetName() string { return customName }
+
+var _ types.ResourceWithName = &customResource{}
+
 func TestGetResourceName(t *testing.T) {
 	if name := cache.GetResourceName(testEndpoint); name != clusterName {
 		t.Errorf("GetResourceName(%v) => got %q, want %q", testEndpoint, name, clusterName)
@@ -104,6 +114,9 @@ func TestGetResourceName(t *testing.T) {
 	}
 	if name := cache.GetResourceName(testRuntime); name != runtimeName {
 		t.Errorf("GetResourceName(%v) => got %q, want %q", testRuntime, name, runtimeName)
+	}
+	if name := cache.GetResourceName(&customResource{}); name != customName {
+		t.Errorf("GetResourceName(nil) => got %q, want %q", name, customName)
 	}
 	if name := cache.GetResourceName(nil); name != "" {
 		t.Errorf("GetResourceName(nil) => got %q, want none", name)


### PR DESCRIPTION
This change allows using external protos with delta xDS. There is a call to populate the resource name  in xDS delta response that requires extensibility that this PR provides.

Signed-off-by: Kuat Yessenov <kuat@google.com>