### PR TITLE
Revert "Fix for the SDS update failure (#615)" as no longer needed on top of #559

### DIFF
--- a/build/do_ci.sh
+++ b/build/do_ci.sh
@@ -3,6 +3,9 @@
 set -e
 set -x
 
+# Needed to avoid issues with go version stamping in CI build
+git config --global --add safe.directory /go-control-plane
+
 go install golang.org/x/tools/cmd/goimports@latest
 
 cd /go-control-plane

--- a/pkg/server/delta/v3/server.go
+++ b/pkg/server/delta/v3/server.go
@@ -119,26 +119,8 @@ func (s *server) processDelta(str stream.DeltaStream, reqCh <-chan *discovery.De
 
 			watch := watches.deltaWatches[typ]
 			watch.nonce = nonce
-			// As per XDS protocol, for the non wildcard resources, management server should only respond to the resources
-			// requested by the client. Since we were replacing (instead of updating) the complete state resource version
-			// map after responding to the client, it was overriding/removing the resources subscribed by the client intermittently.
-			// As a result, the update of the such resources was never sent to the client.
-			// In order to address the issue, started updating the resources hash in the existing map instead of replacing
-			// the completed map.
-			// In case of wildcard resources, client never subscribes for the resources, replacing the state resource version based
-			// on the response by the management server is not an issue. Hence, the fix is only applicable for the non wildcard resources.
-			if !watch.state.IsWildcard() {
-				for k, hash := range resp.GetNextVersionMap() {
-					if currHash, found := watch.state.GetResourceVersions()[k]; found {
-						if currHash != hash {
-							watch.state.GetResourceVersions()[k] = hash
-						}
-					}
-				}
-			} else {
-				watch.state.SetResourceVersions(resp.GetNextVersionMap())
-			}
 
+			watch.state.SetResourceVersions(resp.GetNextVersionMap())
 			watches.deltaWatches[typ] = watch
 		case req, more := <-reqCh:
 			// input stream ended or errored out


### PR DESCRIPTION
As discussed in this [issue](https://github.com/envoyproxy/go-control-plane/issues/612#issuecomment-1460947797), the fix done in #615 is creating issues:
 - it is no longer applicable on top of #559 which already makes sure subscription changes are properly reflected without modifying the VersionMap
 - it is invalid in the context of new resources being subscribed to or being removed, leading to further issues in this context (e.g. a resource deletion will never be notified if not originally watched)

#615 did not include any test so it is hard to know if we are properly covering the use case, but from discussions we should already be. If it is not the case (e.g. if in sotw), a fix alike #559 will likely be required 