### PR TITLE
Set safe directory in CI script to fix build issue related to VCS stamping in binaries

### DIFF
--- a/build/do_ci.sh
+++ b/build/do_ci.sh
@@ -3,6 +3,9 @@
 set -e
 set -x
 
+# Needed to avoid issues with go version stamping in CI build
+git config --global --add safe.directory /go-control-plane
+
 go install golang.org/x/tools/cmd/goimports@latest
 
 cd /go-control-plane


### PR DESCRIPTION
A change in go 1.18 now include some versioning metadata in binaries. 
This became broken in CI, potentially related to an update of git in the base image of the build image

We can flag our own repo as safe to avoid this issue as we know it is the mounter volume