### PR TITLE
cache/v3: fix loop variable scope issue and ensure no nil cancel is returned

### DIFF
--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -321,7 +321,8 @@ func superset(names map[string]bool, resources map[string]types.ResourceWithTTL)
 	return nil
 }
 
-// CreateWatch returns a watch for an xDS request.
+// CreateWatch returns a watch for an xDS request.  A nil function may be
+// returned if an error occurs.
 func (cache *snapshotCache) CreateWatch(request *Request, streamState stream.StreamState, value chan Response) func() {
 	nodeID := cache.hash.ID(request.Node)
 
@@ -365,8 +366,9 @@ func (cache *snapshotCache) CreateWatch(request *Request, streamState stream.Str
 					if err := cache.respond(context.Background(), request, value, resources, version, false); err != nil {
 						cache.log.Errorf("failed to send a response for %s%v to nodeID %q: %s", request.TypeUrl,
 							request.ResourceNames, nodeID, err)
+						return nil
 					}
-					return nil
+					return func() {}
 				}
 			}
 		}
@@ -387,9 +389,10 @@ func (cache *snapshotCache) CreateWatch(request *Request, streamState stream.Str
 	if err := cache.respond(context.Background(), request, value, resources, version, false); err != nil {
 		cache.log.Errorf("failed to send a response for %s%v to nodeID %q: %s", request.TypeUrl,
 			request.ResourceNames, nodeID, err)
+		return nil
 	}
 
-	return nil
+	return func() {}
 }
 
 func (cache *snapshotCache) nextWatchID() int64 {

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -342,6 +342,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 func TestConcurrentSetWatch(t *testing.T) {
 	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
 	for i := 0; i < 50; i++ {
+		i := i
 		t.Run(fmt.Sprintf("worker%d", i), func(t *testing.T) {
 			t.Parallel()
 			id := fmt.Sprintf("%d", i%2)
@@ -358,7 +359,6 @@ func TestConcurrentSetWatch(t *testing.T) {
 					Node:    &core.Node{Id: id},
 					TypeUrl: rsrc.EndpointType,
 				}, streamState, value)
-
 				defer cancel()
 			}
 		})


### PR DESCRIPTION
With loop variables, the variable is reused on all iterations, meaning the value of `i` for all of the worker sub-tests, run in parallel, is not reliably incrementing.

Fixing the issue leads to a panic, because `CreateWatch` can return `nil` (?).  This seems like an awkward and undesirable API, so I also made `CreateWatch` return `func(){}` instead.  If you'd prefer me to `if cancel != nil { defer cancel() }` instead, I can make that change, but I thought this change would be better.