### PR TITLE
Fix errors from golangci-lint 1.52.2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint:
 		--rm \
 		--volume $$(pwd):/src \
 		--workdir /src \
-		golangci/golangci-lint:v1.50.1 \
+		golangci/golangci-lint:v1.52.2 \
 	golangci-lint -v run
 
 #-----------------

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -311,12 +311,12 @@ func (r *RawResponse) maybeCreateTTLResource(resource types.ResourceWithTTL) (ty
 		}
 
 		if !r.Heartbeat {
-			any, err := anypb.New(resource.Resource)
+			rsrc, err := anypb.New(resource.Resource)
 			if err != nil {
 				return nil, "", err
 			}
-			any.TypeUrl = r.Request.TypeUrl
-			wrappedResource.Resource = any
+			rsrc.TypeUrl = r.Request.TypeUrl
+			wrappedResource.Resource = rsrc
 		}
 
 		return wrappedResource, deltaResourceTypeURL, nil

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -298,7 +298,7 @@ func (cache *LinearCache) GetResources() map[string]types.Resource {
 	return resources
 }
 
-func (cache *LinearCache) CreateWatch(request *Request, streamState stream.StreamState, value chan Response) func() {
+func (cache *LinearCache) CreateWatch(request *Request, _ stream.StreamState, value chan Response) func() {
 	if request.TypeUrl != cache.typeURL {
 		value <- nil
 		return nil
@@ -450,7 +450,7 @@ func (cache *LinearCache) nextDeltaWatchID() int64 {
 	return atomic.AddInt64(&cache.deltaWatchCount, 1)
 }
 
-func (cache *LinearCache) Fetch(ctx context.Context, request *Request) (Response, error) {
+func (cache *LinearCache) Fetch(context.Context, *Request) (Response, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/pkg/cache/v3/mux.go
+++ b/pkg/cache/v3/mux.go
@@ -57,6 +57,6 @@ func (mux *MuxCache) CreateDeltaWatch(request *DeltaRequest, state stream.Stream
 	return cache.CreateDeltaWatch(request, state, value)
 }
 
-func (mux *MuxCache) Fetch(ctx context.Context, request *Request) (Response, error) {
+func (mux *MuxCache) Fetch(context.Context, *Request) (Response, error) {
 	return nil, errors.New("not implemented")
 }

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -520,6 +520,10 @@ type singleResourceSnapshot struct {
 }
 
 func (s *singleResourceSnapshot) GetVersion(typeURL string) string {
+	if typeURL != s.typeurl {
+		return ""
+	}
+
 	return s.version
 }
 

--- a/pkg/log/default.go
+++ b/pkg/log/default.go
@@ -11,17 +11,17 @@ func NewDefaultLogger() *DefaultLogger {
 }
 
 // Debugf logs a message at level debug on the standard logger.
-func (l *DefaultLogger) Debugf(format string, args ...interface{}) {
+func (l *DefaultLogger) Debugf(string, ...interface{}) {
 }
 
 // Infof logs a message at level info on the standard logger.
-func (l *DefaultLogger) Infof(format string, args ...interface{}) {
+func (l *DefaultLogger) Infof(string, ...interface{}) {
 }
 
 // Warnf logs a message at level warn on the standard logger.
-func (l *DefaultLogger) Warnf(format string, args ...interface{}) {
+func (l *DefaultLogger) Warnf(string, ...interface{}) {
 }
 
 // Errorf logs a message at level error on the standard logger.
-func (l *DefaultLogger) Errorf(format string, args ...interface{}) {
+func (l *DefaultLogger) Errorf(string, ...interface{}) {
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -41,27 +41,27 @@ func TestLoggerFuncs(t *testing.T) {
 	debug := 0
 	info := 0
 	warn := 0
-	error := 0
+	err := 0
 
 	xdsLogger := LoggerFuncs{
 		DebugFunc: func(string, ...interface{}) { debug++ },
 		InfoFunc:  func(string, ...interface{}) { info++ },
 		WarnFunc:  func(string, ...interface{}) { warn++ },
-		ErrorFunc: func(string, ...interface{}) { error++ },
+		ErrorFunc: func(string, ...interface{}) { err++ },
 	}
 
 	xdsLogger.Debugf("debug")
 	xdsLogger.Infof("info")
 	xdsLogger.Warnf("warn")
-	xdsLogger.Errorf("error")
+	xdsLogger.Errorf("err")
 
 	assert.Equal(t, debug, 1)
 	assert.Equal(t, info, 1)
 	assert.Equal(t, warn, 1)
-	assert.Equal(t, error, 1)
+	assert.Equal(t, err, 1)
 }
 
-func TestNilLoggerFuncs(t *testing.T) {
+func TestNilLoggerFuncs(_ *testing.T) {
 	xdsLogger := LoggerFuncs{}
 
 	// Just verifying that nothing panics.

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -48,7 +48,7 @@ type mockConfigWatcher struct {
 	mu *sync.RWMutex
 }
 
-func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, state stream.StreamState, out chan cache.Response) func() {
+func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, _ stream.StreamState, out chan cache.Response) func() {
 	config.counts[req.TypeUrl] = config.counts[req.TypeUrl] + 1
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out <- config.responses[req.TypeUrl][0]
@@ -62,7 +62,7 @@ func (config *mockConfigWatcher) CreateWatch(req *discovery.DiscoveryRequest, st
 	return nil
 }
 
-func (config *mockConfigWatcher) Fetch(ctx context.Context, req *discovery.DiscoveryRequest) (cache.Response, error) {
+func (config *mockConfigWatcher) Fetch(_ context.Context, req *discovery.DiscoveryRequest) (cache.Response, error) {
 	if len(config.responses[req.TypeUrl]) > 0 {
 		out := config.responses[req.TypeUrl][0]
 		config.responses[req.TypeUrl] = config.responses[req.TypeUrl][1:]

--- a/pkg/test/v3/callbacks.go
+++ b/pkg/test/v3/callbacks.go
@@ -61,12 +61,12 @@ func (cb *Callbacks) OnStreamRequest(int64, *discovery.DiscoveryRequest) error {
 }
 func (cb *Callbacks) OnStreamResponse(context.Context, int64, *discovery.DiscoveryRequest, *discovery.DiscoveryResponse) {
 }
-func (cb *Callbacks) OnStreamDeltaResponse(id int64, req *discovery.DeltaDiscoveryRequest, res *discovery.DeltaDiscoveryResponse) {
+func (cb *Callbacks) OnStreamDeltaResponse(int64, *discovery.DeltaDiscoveryRequest, *discovery.DeltaDiscoveryResponse) {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 	cb.DeltaResponses++
 }
-func (cb *Callbacks) OnStreamDeltaRequest(id int64, req *discovery.DeltaDiscoveryRequest) error {
+func (cb *Callbacks) OnStreamDeltaRequest(int64, *discovery.DeltaDiscoveryRequest) error {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 	cb.DeltaRequests++
@@ -77,7 +77,7 @@ func (cb *Callbacks) OnStreamDeltaRequest(id int64, req *discovery.DeltaDiscover
 
 	return nil
 }
-func (cb *Callbacks) OnFetchRequest(_ context.Context, req *discovery.DiscoveryRequest) error {
+func (cb *Callbacks) OnFetchRequest(context.Context, *discovery.DiscoveryRequest) error {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
 	cb.Fetches++


### PR DESCRIPTION
The GitHub action updated to golangci-lint v1.52.2, which brings in some new lint errors. Update the Docker image version and fix the new issues.