### PR TITLE
ci: build dyplomat as part of CI

### DIFF
--- a/build/do_ci.sh
+++ b/build/do_ci.sh
@@ -22,6 +22,7 @@ make examples
 make test
 make integration
 
-cd ./xdsmatcher
-make test
+make -C xdsmatcher test
 # TODO(snowp): Output coverage in CI
+
+make -C examples/dyplomat test

--- a/examples/dyplomat/Makefile
+++ b/examples/dyplomat/Makefile
@@ -6,8 +6,3 @@ coverage:
 	go test ./... -race -covermode=atomic -coverprofile=coverage.out
 coverage_html: coverage
 	go tool cover -html=coverage.out
-.PHONY: proto
-proto: test/proto/*
-	protoc --proto_path=test/proto --go_out=test/proto --go_opt=paths=source_relative test.proto
-
-

--- a/examples/dyplomat/main.go
+++ b/examples/dyplomat/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"net"
 	"time"
+
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 
 	"google.golang.org/grpc"
 
@@ -71,7 +72,7 @@ func main() {
 	}
 
 	if err := grpcServer.Serve(lis); err != nil {
-		fmt.Errorf("", err)
+		fmt.Printf("%v", err)
 	}
 }
 


### PR DESCRIPTION
Even though dyplomat has no tests, we should still add it to CI to get a signal when dependabot wants to update the Go dependencies. We just want to know whether it still builds.