### PR TITLE
ci/sync: Remove nonunset from script

### DIFF
--- a/ci/sync_envoy.sh
+++ b/ci/sync_envoy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -e
 
 set -o pipefail
 


### PR DESCRIPTION
this does not work as it source an Envoy script that uses vars that are not set here