### PR TITLE
sync/ci: Update github auth action

### DIFF
--- a/.github/workflows/envoy-sync.yaml
+++ b/.github/workflows/envoy-sync.yaml
@@ -22,7 +22,7 @@ jobs:
       }}
     steps:
     - id: appauth
-      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0
+      uses: envoyproxy/toolshed/gh-actions/appauth@actions-v0.0.1
       with:
         key: ${{ secrets.ENVOY_CI_UPDATE_BOT_KEY }}
         app_id: ${{ secrets.ENVOY_CI_UPDATE_APP_ID }}
@@ -33,7 +33,7 @@ jobs:
       with:
         ref: main
         fetch-depth: 0
-        token: ${{ steps.appauth.outputs.value }}
+        token: ${{ steps.appauth.outputs.token }}
 
     # Checkout the Envoy repo
     - name: 'Checkout Repository'


### PR DESCRIPTION
The action is updated to mark outputs as secrets to prevent accidental logging

The output token is also renamed to `value` -> `token`