### PR TITLE
RFC: Sync Envoy protobufs to a nested proto module.

### DIFF
--- a/proto/go.mod
+++ b/proto/go.mod
@@ -1,0 +1,5 @@
+module github.com/envoyproxy/go-control-plane/proto
+
+go 1.17
+
+require github.com/golang/protobuf v1.5.3 // indirect

--- a/proto/go.sum
+++ b/proto/go.sum
@@ -1,0 +1,7 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=


### PR DESCRIPTION
Create a new "proto" directory for publishing the Envoy API protobufs. This lets core and contrib protobuf APIs be packaged in the same module, which is versioned independently of the main Go control plane.

***This PR is an RFC to show people what the combined envoy+contrib module would look like. The GitHub envoy sync action ran on my fork, and you can see the results [here](https://github.com/jpeach/go-control-plane/tree/main/proto).***

Per the discussion in #714, this approach retains compatibility for existing users of go-control-plane, since we do no remove any existing code (we just stop updating it). Note that if everyone like this approach, we will need to update all the `option go_package` specifications in the Envoy protobufs. This means that when projects do adopt the new module, they will need to edit all their import paths.