### PR TITLE
Add logic for get nodeIDs from snapshot cache

### DIFF
--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -83,6 +83,9 @@ type SnapshotCache interface {
 	// ClearSnapshot removes all status and snapshot information associated with a node.
 	ClearSnapshot(node string)
 
+	// GetNodeIDs gets the all node ID in cache.
+	GetNodeIDs() []string
+
 	// GetStatusInfo retrieves status information for a node ID.
 	GetStatusInfo(string) StatusInfo
 
@@ -604,6 +607,20 @@ func (cache *snapshotCache) Fetch(ctx context.Context, request *Request) (Respon
 	}
 
 	return nil, fmt.Errorf("missing snapshot for %q", nodeID)
+}
+
+// GetNodeIDs gets the all node ID in cache.
+func (cache *snapshotCache) GetNodeIDs() []string {
+	cache.mu.RLock()
+	defer cache.mu.RUnlock()
+
+	nodeIDs := []string{}
+
+	for nodeID := range cache.snapshots {
+		nodeIDs = append(nodeIDs, nodeID)
+	}
+
+	return nodeIDs
 }
 
 // GetStatusInfo retrieves the status info for the node.

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -640,3 +640,17 @@ func TestAvertPanicForWatchOnNonExistentSnapshot(t *testing.T) {
 
 	<-responder
 }
+
+func TestGetNodeIDs(t *testing.T) {
+	nodeIDs := []string{"node1", "node2", "node3"}
+
+	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	for _, nodeID := range nodeIDs {
+		if err := c.SetSnapshot(context.Background(), nodeID, fixture.snapshot()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	collectedNodeIDs := c.GetNodeIDs()
+	assert.Equal(t, nodeIDs, collectedNodeIDs)
+}


### PR DESCRIPTION
Hello. 

In my case, I use many nodeIDs when forming the cache. During processing, it's necessary to know which nodeIDs are present in the cache. 

Please consider reviewing this PR.