### PR TITLE
Add GRPCFieldExtractor as a well known filter

### DIFF
--- a/pkg/wellknown/wellknown.go
+++ b/pkg/wellknown/wellknown.go
@@ -30,6 +30,8 @@ const (
 	Dynamo = "envoy.filters.http.dynamo"
 	// Fault HTTP filter
 	Fault = "envoy.filters.http.fault"
+        // GRPCFieldExtraction HTTP filter
+	GRPCFieldExtraction = "envoy.filters.http.grpc_field_extraction"
 	// GRPCHTTP1Bridge HTTP filter
 	GRPCHTTP1Bridge = "envoy.filters.http.grpc_http1_bridge"
 	// GRPCJSONTranscoder HTTP filter


### PR DESCRIPTION
Adding GRPCFieldExtractor as a well known filter to allow its usage [GoogleCloudPlatform/esp-v2](https://github.com/GoogleCloudPlatform/esp-v2)

This is to allow importing of `envoy/extensions/filters/http/grpc_field_extraction/v3`.