### PR TITLE
fix resource order

### DIFF
--- a/pkg/cache/types/types.go
+++ b/pkg/cache/types/types.go
@@ -43,12 +43,12 @@ type ResponseType int
 // ADS expects things to be returned in a specific order.
 // See the following issue for details: https://github.com/envoyproxy/go-control-plane/issues/526
 const (
-	Endpoint ResponseType = iota
-	Cluster
-	ScopedRoute
-	Route
-	VirtualHost
+	Cluster ResponseType = iota
+	Endpoint
 	Listener
+	Route
+	ScopedRoute
+	VirtualHost
 	Secret
 	Runtime
 	ExtensionConfig

--- a/pkg/cache/v3/order.go
+++ b/pkg/cache/v3/order.go
@@ -16,7 +16,7 @@ func (k keys) Len() int {
 
 // Less compares the typeURL and determines what order things should be sent.
 func (k keys) Less(i, j int) bool {
-	return GetResponseType(k[i].TypeURL) > GetResponseType(k[j].TypeURL)
+	return GetResponseType(k[i].TypeURL) < GetResponseType(k[j].TypeURL)
 }
 
 func (k keys) Swap(i, j int) {

--- a/pkg/cache/v3/order_test.go
+++ b/pkg/cache/v3/order_test.go
@@ -64,9 +64,9 @@ func TestOrderKeys(t *testing.T) {
 
 	// Ordering:
 	// === RUN   TestOrderKeys
+	// order_test.go:43: {ID:2 TypeURL:type.googleapis.com/envoy.config.cluster.v3.Cluster}
+	// order_test.go:43: {ID:1 TypeURL:type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment}
 	// order_test.go:43: {ID:4 TypeURL:type.googleapis.com/envoy.config.listener.v3.Listener}
 	// order_test.go:43: {ID:3 TypeURL:type.googleapis.com/envoy.config.route.v3.RouteConfiguration}
 	// order_test.go:43: {ID:5 TypeURL:type.googleapis.com/envoy.config.route.v3.ScopedRouteConfiguration}
-	// order_test.go:43: {ID:2 TypeURL:type.googleapis.com/envoy.config.cluster.v3.Cluster}
-	// order_test.go:43: {ID:1 TypeURL:type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment}
 }

--- a/pkg/cache/v3/order_test.go
+++ b/pkg/cache/v3/order_test.go
@@ -34,6 +34,14 @@ func TestOrderKeys(t *testing.T) {
 	}
 	expected := keys{
 		{
+			ID:      2,
+			TypeURL: resource.ClusterType,
+		},
+		{
+			ID:      1,
+			TypeURL: resource.EndpointType,
+		},
+		{
 			ID:      4,
 			TypeURL: resource.ListenerType,
 		},
@@ -44,14 +52,6 @@ func TestOrderKeys(t *testing.T) {
 		{
 			ID:      5,
 			TypeURL: resource.ScopedRouteType,
-		},
-		{
-			ID:      2,
-			TypeURL: resource.ClusterType,
-		},
-		{
-			ID:      1,
-			TypeURL: resource.EndpointType,
 		},
 	}
 


### PR DESCRIPTION
fix https://github.com/envoyproxy/go-control-plane/issues/800

According to xds doc, the order should be like: Cluster -> Endpoint -> Listener -> Route

References:

https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#eventual-consistency-considerations

@valerian-roche @AmitKatyal-Sophos 