### PR TITLE
ci/sync: Remove `NO_BUILD_SETUP` to ensure llvm is setup

### DIFF
--- a/.github/workflows/envoy-sync.yaml
+++ b/.github/workflows/envoy-sync.yaml
@@ -48,4 +48,3 @@ jobs:
     - run: ci/sync_envoy.sh
       env:
         ENVOY_SRC_DIR: ../envoy
-        NO_BUILD_SETUP: 1


### PR DESCRIPTION
Fix #811