### PR TITLE
Enhance GetHTTPConnectionManager and Update superset for Dynamic Configuration

### DIFF
--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -375,9 +375,9 @@ func nameSet(names []string) map[string]bool {
 
 // superset checks that all resources are listed in the names set.
 func superset(names map[string]bool, resources map[string]types.ResourceWithTTL) error {
-	for resourceName := range resources {
-		if _, exists := names[resourceName]; !exists {
-			return fmt.Errorf("%q not listed", resourceName)
+	for name := range names {
+		if _, exists := resources[name]; !exists {
+			return fmt.Errorf("%q not listed in resources", name)
 		}
 	}
 	return nil

--- a/pkg/resource/v3/resource.go
+++ b/pkg/resource/v3/resource.go
@@ -7,6 +7,7 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 // Type is an alias to string which we expose to users of the snapshot API which accepts `resource.Type` resource URLs.


### PR DESCRIPTION
Refactor `GetHTTPConnectionManager` and Update `superset` for Better Resource Handling

This PR introduces two changes to improve dynamic configuration handling in `go-control-plane`:

1. **`GetHTTPConnectionManager` Enhancement:**
   - The function now supports `ConfigDiscovery` in addition to `TypedConfig`.
   - An additional parameter `extensions`, a map of `types.ResourceWithTTL`, is introduced to facilitate this.

2. **`superset` Function Update:**
   - Modified the `superset` function to iterate over `names` instead of `resources`.
   - This change ensures that the function only checks for the presence of resources that are specifically required by Envoy, addressing the issue where Envoy sends resources one at a time.
   - It prevents errors that occurred when Envoy requested a subset of resources, enhancing the robustness of resource validation.

These updates collectively enhance the capability of `go-control-plane` to handle more complex and dynamic Envoy proxy configurations, particularly useful in scenarios involving dynamic resource management and partial resource updates. 

#823