### PR TITLE
[sotw][issue-540] Return full state when applicable for watches in linear cache

### DIFF
--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -40,7 +40,14 @@ func testResource(s string) types.Resource {
 
 func verifyResponse(t *testing.T, ch <-chan Response, version string, num int) {
 	t.Helper()
-	r := <-ch
+	var r Response
+	select {
+	case r = <-ch:
+	case <-time.After(1 * time.Second):
+		t.Error("failed to receive response after 1 second")
+		return
+	}
+
 	if r.GetRequest().GetTypeUrl() != testType {
 		t.Errorf("unexpected empty request type URL: %q", r.GetRequest().GetTypeUrl())
 	}
@@ -62,6 +69,9 @@ func verifyResponse(t *testing.T, ch <-chan Response, version string, num int) {
 	}
 	if out.GetTypeUrl() != testType {
 		t.Errorf("unexpected type URL: %q", out.GetTypeUrl())
+	}
+	if len(r.GetRequest().GetResourceNames()) != 0 && len(r.GetRequest().GetResourceNames()) < len(out.Resources) {
+		t.Errorf("received more resources (%d) than requested (%d)", len(r.GetRequest().GetResourceNames()), len(out.Resources))
 	}
 }
 
@@ -772,4 +782,82 @@ func TestLinearMixedWatches(t *testing.T) {
 
 	verifyResponse(t, w, c.getVersion(), 0)
 	verifyDeltaResponse(t, wd, nil, []string{"b"})
+}
+
+func TestLinearSotwWatches(t *testing.T) {
+	t.Run("watches are properly removed from all objects", func(t *testing.T) {
+		cache := NewLinearCache(testType)
+		a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
+		err := cache.UpdateResource("a", a)
+		require.NoError(t, err)
+		b := &endpoint.ClusterLoadAssignment{ClusterName: "b"}
+		err = cache.UpdateResource("b", b)
+		require.NoError(t, err)
+		assert.Equal(t, 2, cache.NumResources())
+
+		// A watch tracks three different objects.
+		// An update is done for the three objects in a row
+		// If the watches are no properly purged, all three updates will send responses in the channel, but only the first one is tracked
+		// The buffer will therefore saturate and the third request will deadlock the entire cache as occurring under the mutex
+		sotwState := stream.NewStreamState(false, nil)
+		w := make(chan Response, 1)
+		_ = cache.CreateWatch(&Request{ResourceNames: []string{"a", "b", "c"}, TypeUrl: testType, VersionInfo: cache.getVersion()}, sotwState, w)
+		mustBlock(t, w)
+		checkVersionMapNotSet(t, cache)
+
+		assert.Len(t, cache.watches["a"], 1)
+		assert.Len(t, cache.watches["b"], 1)
+		assert.Len(t, cache.watches["c"], 1)
+
+		// Update a and c without touching b
+		a = &endpoint.ClusterLoadAssignment{ClusterName: "a", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
+			{Priority: 25},
+		}}
+		err = cache.UpdateResources(map[string]types.Resource{"a": a}, nil)
+		require.NoError(t, err)
+		verifyResponse(t, w, cache.getVersion(), 1)
+		checkVersionMapNotSet(t, cache)
+
+		assert.Empty(t, cache.watches["a"])
+		assert.Empty(t, cache.watches["b"])
+		assert.Empty(t, cache.watches["c"])
+
+		// c no longer watched
+		w = make(chan Response, 1)
+		_ = cache.CreateWatch(&Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: cache.getVersion()}, sotwState, w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+		checkVersionMapNotSet(t, cache)
+
+		b = &endpoint.ClusterLoadAssignment{ClusterName: "b", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
+			{Priority: 15},
+		}}
+		err = cache.UpdateResources(map[string]types.Resource{"b": b}, nil)
+
+		assert.Empty(t, cache.watches["a"])
+		assert.Empty(t, cache.watches["b"])
+		assert.Empty(t, cache.watches["c"])
+
+		require.NoError(t, err)
+		verifyResponse(t, w, cache.getVersion(), 1)
+		checkVersionMapNotSet(t, cache)
+
+		w = make(chan Response, 1)
+		_ = cache.CreateWatch(&Request{ResourceNames: []string{"c"}, TypeUrl: testType, VersionInfo: cache.getVersion()}, sotwState, w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+		checkVersionMapNotSet(t, cache)
+
+		c := &endpoint.ClusterLoadAssignment{ClusterName: "c", Endpoints: []*endpoint.LocalityLbEndpoints{ // resource update
+			{Priority: 15},
+		}}
+		err = cache.UpdateResources(map[string]types.Resource{"c": c}, nil)
+		require.NoError(t, err)
+		verifyResponse(t, w, cache.getVersion(), 1)
+		checkVersionMapNotSet(t, cache)
+
+		assert.Empty(t, cache.watches["a"])
+		assert.Empty(t, cache.watches["b"])
+		assert.Empty(t, cache.watches["c"])
+	})
 }

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -97,6 +97,23 @@ func GetResourceName(res types.Resource) string {
 	}
 }
 
+// ResourceRequiresFullStateInSotw indicates whether when building the reply in Sotw,
+// the response must include all existing resources or can return only the modified ones
+func ResourceRequiresFullStateInSotw(typeURL resource.Type) bool {
+	// From https://www.envoyproxy.io/docs/envoy/v1.28.0/api-docs/xds_protocol#grouping-resources-into-responses,
+	// when using sotw the control-plane MUST return all requested resources (or simply all if wildcard)
+	// for some types. This is relied on by xds-grpc which is explicitly requesting clusters but expect
+	// to receive all existing resources
+	switch typeURL {
+	case resource.ClusterType:
+		return true
+	case resource.ListenerType:
+		return true
+	default:
+		return false
+	}
+}
+
 // GetResourceName returns the resource names for a list of valid xDS response types.
 func GetResourceNames(resources []types.Resource) []string {
 	out := make([]string, len(resources))

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -102,8 +102,9 @@ func GetResourceName(res types.Resource) string {
 func ResourceRequiresFullStateInSotw(typeURL resource.Type) bool {
 	// From https://www.envoyproxy.io/docs/envoy/v1.28.0/api-docs/xds_protocol#grouping-resources-into-responses,
 	// when using sotw the control-plane MUST return all requested resources (or simply all if wildcard)
-	// for some types. This is relied on by xds-grpc which is explicitly requesting clusters but expect
-	// to receive all existing resources
+	// for some types. This is relied on by xds-grpc which is explicitly requesting clusters and listeners
+	// but expects to receive all existing resources for those types. Missing clusters or listeners are 
+	// considered deleted.
 	switch typeURL {
 	case resource.ClusterType:
 		return true

--- a/pkg/log/test.go
+++ b/pkg/log/test.go
@@ -1,0 +1,33 @@
+package log
+
+import "testing"
+
+type testLogger struct {
+	t testing.TB
+}
+
+var _ Logger = testLogger{}
+
+func NewTestLogger(t testing.TB) Logger {
+	return testLogger{t}
+}
+
+// Debugf logs a message at level debug on the test logger.
+func (l testLogger) Debugf(msg string, args ...interface{}) {
+	l.t.Logf("[debug] "+msg, args...)
+}
+
+// Infof logs a message at level info on the test logger.
+func (l testLogger) Infof(msg string, args ...interface{}) {
+	l.t.Logf("[info] "+msg, args...)
+}
+
+// Warnf logs a message at level warn on the test logger.
+func (l testLogger) Warnf(msg string, args ...interface{}) {
+	l.t.Logf("[warn] "+msg, args...)
+}
+
+// Errorf logs a message at level error on the test logger.
+func (l testLogger) Errorf(msg string, args ...interface{}) {
+	l.t.Logf("[error] "+msg, args...)
+}


### PR DESCRIPTION
This PR is currently based on #854, and include its diff too, but in a separate commit

Fixes #540 

This PR is fixing issue #540: the xds protocol defines that for the resource types `Listener` and `Cluster`, when using sotw watches, the cache must return as part of the response **all** existing resources matching the requests if not wildcard. 
Currently the control-plane will only return the modified resources on cache updates, and the protocol states that the client should interpret such a response as a deletion

In simple cache this distinction is not applicable as we currently always return all resources. While we may want to improve this behavior in the future (e.g. to avoid sending all clusters if only one was updated in delta, or to send a single route configuration in sotw on update), this is out of scope of this PR as this requires keeping more state