### PR TITLE
Linearcache should respond immediately for the first wildcard delta request

### DIFF
--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -184,7 +184,9 @@ func (cache *LinearCache) respondDelta(request *DeltaRequest, value chan DeltaRe
 	})
 
 	// Only send a response if there were changes
-	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 {
+	// We want to respond immediately for the first wildcard request in a stream, even if the response is empty
+	// otherwise, envoy won't complete initialization
+	if len(resp.Resources) > 0 || len(resp.RemovedResources) > 0 || (state.IsWildcard() && state.IsFirst()) {
 		if cache.log != nil {
 			cache.log.Debugf("[linear cache] node: %s, sending delta response for typeURL %s with resources: %v removed resources: %v with wildcard: %t",
 				request.GetNode().GetId(), request.GetTypeUrl(), GetResourceNames(resp.Resources), resp.RemovedResources, state.IsWildcard())


### PR DESCRIPTION
Commit 185b42f8c4a4 ("Respond immediately for the first wildcard request in a delta stream, If the corresponding snapshot exists and the response is empty") fixed an issue that the server doesn't response with anything when the resource for the client was empty which could block client's initialization. However, it's not applied to the linear cache. Hence, clients now see different behaviors with servers using different cache and would be blocked on initialization with linear cache but not with snapshot cache.

The commit unifies the behavior of the two caches.

---
Before the commit, envoy took 30s to wait for initial fetch timeout.
```
[2024-04-22 05:05:10.538][1][info][main] [source/server/server.cc:951] starting main dispatch loop
[2024-04-22 05:05:25.539][1][warning][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:130] gRPC config: initial fetch timed out for type.googleapis.com/envoy.config.cluster.v3.Cluster
[2024-04-22 05:05:25.539][1][info][upstream] [source/common/upstream/cluster_manager_impl.cc:240] cm init: all clusters initialized
[2024-04-22 05:05:25.539][1][info][main] [source/server/server.cc:932] all clusters initialized. initializing init manager
[2024-04-22 05:05:40.540][1][warning][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:130] gRPC config: initial fetch timed out for type.googleapis.com/envoy.config.listener.v3.Listener
[2024-04-22 05:05:40.540][1][info][config] [source/common/listener_manager/listener_manager_impl.cc:926] all dependencies initialized. starting workers
```

After the commit, envoy initialized immediately:
```
[2024-04-22 05:11:56.022][1][info][main] [source/server/server.cc:951] starting main dispatch loop
[2024-04-22 05:11:56.024][1][info][upstream] [source/common/upstream/cds_api_helper.cc:32] cds: add 0 cluster(s), remove 0 cluster(s)
[2024-04-22 05:11:56.024][1][info][upstream] [source/common/upstream/cds_api_helper.cc:71] cds: added/updated 0 cluster(s), skipped 0 unmodified cluster(s)
[2024-04-22 05:11:56.024][1][info][upstream] [source/common/upstream/cluster_manager_impl.cc:240] cm init: all clusters initialized
[2024-04-22 05:11:56.024][1][info][main] [source/server/server.cc:932] all clusters initialized. initializing init manager
[2024-04-22 05:11:56.027][1][info][config] [source/common/listener_manager/listener_manager_impl.cc:926] all dependencies initialized. starting workers
```