### PR TITLE
Error out for duplicate name instead of silently overwriting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
   - unparam
   - unused
   - whitespace
+  - exhaustive
 
 linters-settings:
   exhaustive:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Release v0.13.0
+
+### Changed
+
+- Error out on duplicated names instead of silently overwriting.
+
 ## Release v0.11.0
 
 ### Added

--- a/pkg/cache/types/types.go
+++ b/pkg/cache/types/types.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -55,3 +56,33 @@ const (
 	RateLimitConfig
 	UnknownType // token to count the total number of supported types
 )
+
+// String returns the string representation of the ResponseType.
+func (rt ResponseType) String() string {
+	switch rt {
+	case Cluster:
+		return "Cluster"
+	case Endpoint:
+		return "Endpoint"
+	case Listener:
+		return "Listener"
+	case Route:
+		return "Route"
+	case ScopedRoute:
+		return "ScopedRoute"
+	case VirtualHost:
+		return "VirtualHost"
+	case Secret:
+		return "Secret"
+	case Runtime:
+		return "Runtime"
+	case ExtensionConfig:
+		return "ExtensionConfig"
+	case RateLimitConfig:
+		return "RateLimitConfig"
+	case UnknownType:
+		return "UnknownType"
+	}
+
+	panic(fmt.Sprintf("unknown response type: %d", int(rt)))
+}

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -55,7 +55,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexRawResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResources(typ))
+				assertResourceMapEqual(t, mustIndexRawResourcesByName(t, out.(*cache.RawDeltaResponse).Resources), snapshot.GetResources(typ))
 				vMap := out.GetNextVersionMap()
 				versionMap[typ] = vMap
 			case <-time.After(time.Second):
@@ -87,7 +87,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 
 	// set partially-versioned snapshot
 	snapshot2 := fixture.snapshot()
-	snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
+	snapshot2.Resources[types.Endpoint] = mustNewResources(t, fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
 	if err := c.SetSnapshot(context.Background(), key, snapshot2); err != nil {
 		t.Fatal(err)
 	}
@@ -99,8 +99,8 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 	select {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
-		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
-		assertResourceMapEqual(t, cache.IndexRawResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResources(rsrc.EndpointType))
+		snapshot2.Resources[types.Endpoint] = mustNewResources(t, fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
+		assertResourceMapEqual(t, mustIndexRawResourcesByName(t, out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResources(rsrc.EndpointType))
 		vMap := out.GetNextVersionMap()
 		versionMap[testTypes[0]] = vMap
 	case <-time.After(time.Second):
@@ -136,7 +136,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexRawResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResources(typ))
+				assertResourceMapEqual(t, mustIndexRawResourcesByName(t, out.(*cache.RawDeltaResponse).Resources), snapshot.GetResources(typ))
 				nextVersionMap := out.GetNextVersionMap()
 				streams[typ].SetResourceVersions(nextVersionMap)
 			case <-time.After(time.Second):
@@ -163,7 +163,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 
 	// set a partially versioned snapshot with no endpoints
 	snapshot2 := fixture.snapshot()
-	snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{})
+	snapshot2.Resources[types.Endpoint] = mustNewResources(t, fixture.version2, []types.Resource{})
 	if err := c.SetSnapshot(context.Background(), key, snapshot2); err != nil {
 		t.Fatal(err)
 	}
@@ -172,8 +172,8 @@ func TestDeltaRemoveResources(t *testing.T) {
 	select {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
-		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{})
-		assertResourceMapEqual(t, cache.IndexRawResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResources(rsrc.EndpointType))
+		snapshot2.Resources[types.Endpoint] = mustNewResources(t, fixture.version2, []types.Resource{})
+		assertResourceMapEqual(t, mustIndexRawResourcesByName(t, out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResources(rsrc.EndpointType))
 		nextVersionMap := out.GetNextVersionMap()
 
 		// make sure the version maps are different since we no longer are tracking any endpoint resources
@@ -199,7 +199,7 @@ func TestConcurrentSetDeltaWatch(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					snap.Resources[types.Endpoint] = cache.NewResources(version, []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
+					snap.Resources[types.Endpoint] = mustNewResources(t, version, []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
 					if err := c.SetSnapshot(context.Background(), key, snap); err != nil {
 						t.Fatalf("snapshot failed: %s", err)
 					}

--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -217,7 +217,7 @@ func TestGetResourceReferences(t *testing.T) {
 		},
 	}
 	for _, cs := range cases {
-		names := cache.GetResourceReferences(cache.IndexResourcesByName([]types.ResourceWithTTL{{Resource: cs.in}}))
+		names := cache.GetResourceReferences(mustIndexResourcesByName(t, []types.ResourceWithTTL{{Resource: cs.in}}))
 		if !reflect.DeepEqual(names, cs.out) {
 			t.Errorf("GetResourceReferences(%v) => got %v, want %v", cs.in, names, cs.out)
 		}
@@ -231,14 +231,40 @@ func TestGetAllResourceReferencesReturnsExpectedRefs(t *testing.T) {
 	}
 
 	resources := [types.UnknownType]cache.Resources{}
-	resources[types.Endpoint] = cache.NewResources("1", []types.Resource{testEndpoint})
-	resources[types.Cluster] = cache.NewResources("1", []types.Resource{testCluster})
-	resources[types.Route] = cache.NewResources("1", []types.Resource{testRoute})
-	resources[types.Listener] = cache.NewResources("1", []types.Resource{testListener, testScopedListener})
-	resources[types.ScopedRoute] = cache.NewResources("1", []types.Resource{testScopedRoute})
+	resources[types.Endpoint] = mustNewResources(t, "1", []types.Resource{testEndpoint})
+	resources[types.Cluster] = mustNewResources(t, "1", []types.Resource{testCluster})
+	resources[types.Route] = mustNewResources(t, "1", []types.Resource{testRoute})
+	resources[types.Listener] = mustNewResources(t, "1", []types.Resource{testListener, testScopedListener})
+	resources[types.ScopedRoute] = mustNewResources(t, "1", []types.Resource{testScopedRoute})
 	actual := cache.GetAllResourceReferences(resources)
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("GetAllResourceReferences(%v) => got %v, want %v", resources, actual, expected)
 	}
+}
+
+func mustNewResources(t *testing.T, version string, items []types.Resource) cache.Resources {
+	t.Helper()
+	v, err := cache.NewResources(version, items)
+	require.NoError(t, err)
+
+	return v
+}
+
+func mustIndexResourcesByName(t *testing.T, items []types.ResourceWithTTL) map[string]types.ResourceWithTTL {
+	t.Helper()
+
+	v, err := cache.IndexResourcesByName(items)
+	require.NoError(t, err)
+
+	return v
+}
+
+func mustIndexRawResourcesByName(t *testing.T, items []types.Resource) map[string]types.Resource {
+	t.Helper()
+
+	v, err := cache.IndexRawResourcesByName(items)
+	require.NoError(t, err)
+
+	return v
 }

--- a/pkg/cache/v3/resources.go
+++ b/pkg/cache/v3/resources.go
@@ -1,6 +1,10 @@
 package cache
 
-import "github.com/envoyproxy/go-control-plane/pkg/cache/types"
+import (
+	"fmt"
+
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+)
 
 // Resources is a versioned group of resources.
 type Resources struct {
@@ -12,25 +16,34 @@ type Resources struct {
 }
 
 // IndexResourcesByName creates a map from the resource name to the resource.
-func IndexResourcesByName(items []types.ResourceWithTTL) map[string]types.ResourceWithTTL {
+func IndexResourcesByName(items []types.ResourceWithTTL) (map[string]types.ResourceWithTTL, error) {
 	indexed := make(map[string]types.ResourceWithTTL, len(items))
 	for _, item := range items {
-		indexed[GetResourceName(item.Resource)] = item
+		name := GetResourceName(item.Resource)
+		if _, seen := indexed[name]; seen {
+			return nil, fmt.Errorf("duplicate name: %q", name)
+		}
+		indexed[name] = item
 	}
-	return indexed
+	return indexed, nil
 }
 
 // IndexRawResourcesByName creates a map from the resource name to the resource.
-func IndexRawResourcesByName(items []types.Resource) map[string]types.Resource {
+func IndexRawResourcesByName(items []types.Resource) (map[string]types.Resource, error) {
 	indexed := make(map[string]types.Resource, len(items))
 	for _, item := range items {
-		indexed[GetResourceName(item)] = item
+		name := GetResourceName(item)
+		if _, seen := indexed[name]; seen {
+			return nil, fmt.Errorf("duplicate name: %q", name)
+		}
+
+		indexed[name] = item
 	}
-	return indexed
+	return indexed, nil
 }
 
 // NewResources creates a new resource group.
-func NewResources(version string, items []types.Resource) Resources {
+func NewResources(version string, items []types.Resource) (Resources, error) {
 	itemsWithTTL := make([]types.ResourceWithTTL, 0, len(items))
 	for _, item := range items {
 		itemsWithTTL = append(itemsWithTTL, types.ResourceWithTTL{Resource: item})
@@ -39,9 +52,13 @@ func NewResources(version string, items []types.Resource) Resources {
 }
 
 // NewResourcesWithTTL creates a new resource group.
-func NewResourcesWithTTL(version string, items []types.ResourceWithTTL) Resources {
+func NewResourcesWithTTL(version string, items []types.ResourceWithTTL) (Resources, error) {
+	nameIndexedItems, err := IndexResourcesByName(items)
+	if err != nil {
+		return Resources{}, fmt.Errorf("indexing resource by name: %w", err)
+	}
 	return Resources{
 		Version: version,
-		Items:   IndexResourcesByName(items),
-	}
+		Items:   nameIndexedItems,
+	}, nil
 }

--- a/pkg/cache/v3/resources_test.go
+++ b/pkg/cache/v3/resources_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -35,10 +36,28 @@ func TestIndexResourcesByName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := cache.IndexResourcesByName(tt.resources)
+			got, err := cache.IndexResourcesByName(tt.resources)
+			require.NoError(t, err)
+
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestIndexResourcesByName_DuplicateName(t *testing.T) {
+	resources := []types.ResourceWithTTL{
+		{
+			Resource: testEndpoint,
+			TTL:      &ttl,
+		},
+		{
+			Resource: testEndpoint,
+			TTL:      &ttl,
+		},
+	}
+
+	_, err := cache.IndexResourcesByName(resources)
+	require.Error(t, err, "Expected to get an error if we duplicated resource names")
 }
 
 func TestIndexRawResourceByName(t *testing.T) {
@@ -67,17 +86,20 @@ func TestIndexRawResourceByName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := cache.IndexRawResourcesByName(tt.resources)
+			got, err := cache.IndexRawResourcesByName(tt.resources)
+			require.NoError(t, err)
+
 			assert.Equal(t, tt.want, got)
 		})
 	}
 }
 
 func TestNewResources(t *testing.T) {
-	resources := cache.NewResources("x", []types.Resource{
+	resources, err := cache.NewResources("x", []types.Resource{
 		testEndpoint,
 		testRoute,
 	})
+	require.NoError(t, err)
 
 	assert.NotNil(t, resources.Items)
 	assert.Equal(t, "x", resources.Version)

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -131,7 +131,7 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+				if !reflect.DeepEqual(mustIndexResourcesByName(t, out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResourcesAndTTL(typ))
 				}
 				// Update streamState
@@ -162,11 +162,11 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 					if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 						t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 					}
-					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+					if !reflect.DeepEqual(mustIndexResourcesByName(t, out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
 					}
 
-					if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
+					if !reflect.DeepEqual(mustIndexResourcesByName(t, out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)) {
 						t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
 					}
 
@@ -235,7 +235,7 @@ func TestSnapshotCache(t *testing.T) {
 				if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
+				if !reflect.DeepEqual(mustIndexResourcesByName(t, out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
 					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
 				}
 			case <-time.After(time.Second):
@@ -295,7 +295,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 					t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 				}
 				snapshot := fixture.snapshot()
-				if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
+				if !reflect.DeepEqual(mustIndexResourcesByName(t, out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)) {
 					t.Errorf("get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
 				}
 				streamState.SetKnownResourceNamesAsList(typ, out.GetRequest().GetResourceNames())
@@ -317,7 +317,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 
 	// set partially-versioned snapshot
 	snapshot2 := fixture.snapshot()
-	snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
+	snapshot2.Resources[types.Endpoint] = mustNewResources(t, fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
 	if err := c.SetSnapshot(context.Background(), key, snapshot2); err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 		if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version2 {
 			t.Errorf("got version %q, want %q", gotVersion, fixture.version2)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
+		if !reflect.DeepEqual(mustIndexResourcesByName(t, out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
 			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):
@@ -349,7 +349,7 @@ func TestConcurrentSetWatch(t *testing.T) {
 			value := make(chan cache.Response, 1)
 			if i < 25 {
 				snap := cache.Snapshot{}
-				snap.Resources[types.Endpoint] = cache.NewResources(fmt.Sprintf("v%d", i), []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
+				snap.Resources[types.Endpoint] = mustNewResources(t, fmt.Sprintf("v%d", i), []types.Resource{resource.MakeEndpoint(clusterName, uint32(i))})
 				if err := c.SetSnapshot(context.Background(), id, &snap); err != nil {
 					t.Fatalf("failed to set snapshot %q: %s", id, err)
 				}
@@ -460,7 +460,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 			t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 		}
 		want := map[string]types.ResourceWithTTL{clusterName: snapshot2.Resources[types.Endpoint].Items[clusterName]}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), want) {
+		if !reflect.DeepEqual(mustIndexResourcesByName(t, out.(*cache.RawResponse).Resources), want) {
 			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, want)
 		}
 	case <-time.After(time.Second):
@@ -482,7 +482,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 		if gotVersion, _ := out.GetVersion(); gotVersion != fixture.version {
 			t.Errorf("got version %q, want %q", gotVersion, fixture.version)
 		}
-		if !reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
+		if !reflect.DeepEqual(mustIndexResourcesByName(t, out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items) {
 			t.Errorf("got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
 		}
 	case <-time.After(time.Second):

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -45,10 +45,15 @@ func NewSnapshot(version string, resources map[resource.Type][]types.Resource) (
 	for typ, resource := range resources {
 		index := GetResponseType(typ)
 		if index == types.UnknownType {
-			return nil, errors.New("unknown resource type: " + typ)
+			return nil, fmt.Errorf("unknown resource type: %q", typ)
 		}
 
-		out.Resources[index] = NewResources(version, resource)
+		versionedResource, err := NewResources(version, resource)
+		if err != nil {
+			return nil, fmt.Errorf("creating resources for resource type: %q", index)
+		}
+
+		out.Resources[index] = versionedResource
 	}
 
 	return &out, nil
@@ -62,10 +67,15 @@ func NewSnapshotWithTTLs(version string, resources map[resource.Type][]types.Res
 	for typ, resource := range resources {
 		index := GetResponseType(typ)
 		if index == types.UnknownType {
-			return nil, errors.New("unknown resource type: " + typ)
+			return nil, fmt.Errorf("unknown resource type: %q", typ)
 		}
 
-		out.Resources[index] = NewResourcesWithTTL(version, resource)
+		versionedResource, err := NewResourcesWithTTL(version, resource)
+		if err != nil {
+			return nil, fmt.Errorf("creating resources for resource type: %q", index)
+		}
+
+		out.Resources[index] = versionedResource
 	}
 
 	return &out, nil


### PR DESCRIPTION
I'm updating the behaviour of NewSnapshot to error out for duplicate names instead of silently overwriting.

For more context, I recently ran into a bug using the xDS for [RLS](https://github.com/envoyproxy/ratelimit), where our program was parsing some YAML files and inserting them into the config. Since none of the [file-based examples](https://github.com/envoyproxy/ratelimit) enter a name, we didn't either. This created an odd situation where we were non-deterministically selecting different rate limit configs.

I think it's unlikely there are valid cases for silently overwriting resources, but to be ultra-safe we can guard this change via an environment variable. 

We can't error out in the RateLimit library because go-control-plane won't send the duplicated resource. So, the change has to be done in this library