### PR TITLE
Fix panic in case the resourceType is not know by the caches

### DIFF
--- a/pkg/server/sotw/v3/xds.go
+++ b/pkg/server/sotw/v3/xds.go
@@ -149,11 +149,13 @@ func (s *server) process(str stream.Stream, reqCh chan *discovery.DiscoveryReque
 			sw.watches.recompute(s.ctx, reqCh)
 		default:
 			// Channel n -> these are the dynamic list of responders that correspond to the stream request typeURL
-			if !ok {
+			// nil is used to close the streams in the caches
+			if value.IsNil() || !ok {
 				// Receiver channel was closed. TODO(jpeach): probably cancel the watch or something?
 				return status.Errorf(codes.Unavailable, "resource watch %d -> failed", index)
 			}
 
+			// If a non cache.Response arrived here, there are serious issues
 			res := value.Interface().(cache.Response)
 			nonce, err := sw.send(res)
 			if err != nil {


### PR DESCRIPTION
The [MuxCache](https://github.com/envoyproxy/go-control-plane/blob/bd58d40e8ff97f5da06c9a7b979142b403d0ff26/pkg/cache/v3/mux.go#L44) and the [LinearCache](https://github.com/envoyproxy/go-control-plane/blob/bd58d40e8ff97f5da06c9a7b979142b403d0ff26/pkg/cache/v3/linear.go#L305) relies on sending a nil value in the channel to notify that the stream should be closed. This behaviour causes the xds server to panic because [the code](https://github.com/envoyproxy/go-control-plane/blob/bd58d40e8ff97f5da06c9a7b979142b403d0ff26/pkg/server/sotw/v3/xds.go#L157) expects that the conversion succeeds, otherwise it panics.

This MR adds a check in the beginning to check if value is `nil`. If it is, close the stream, otherwise, proceed as usual. 