### PR TITLE
chore(deps): upgrade golang version to 1.23.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ feedback, we might decide to revisit this aspect at a later point in time.
 
 ## Requirements
 
-1. Go 1.21+
+1. Go 1.23+
 
 ## Quick start
 

--- a/examples/dyplomat/Dockerfile
+++ b/examples/dyplomat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21@sha256:672a2286da3ee7a854c3e0a56e0838918d0dbb1c18652992930293312de898a6
+FROM golang:1.23@sha256:ad5c126b5cf501a8caef751a243bb717ec204ab1aa56dc41dc11be089fafcb4f
 
 WORKDIR /go/src/dyplomat
 COPY . /go/src/dyplomat

--- a/examples/dyplomat/go.mod
+++ b/examples/dyplomat/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/go-control-plane/examples/dyplomat
 
-go 1.21
+go 1.23.2
 
 require (
 	github.com/envoyproxy/go-control-plane v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/go-control-plane
 
-go 1.21
+go 1.23.2
 
 require (
 	github.com/census-instrumentation/opencensus-proto v0.4.1

--- a/xdsmatcher/go.mod
+++ b/xdsmatcher/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/go-control-plane/xdsmatcher
 
-go 1.21
+go 1.23.2
 
 require (
 	github.com/cncf/xds/go v0.0.0-20240423153145-555b57ec207b


### PR DESCRIPTION
Since golang 1.21 is out of life, I've upgraded Golang to 1.23.2