### PR TITLE
[chore]: enable perfsprint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
   - goimports
   - gosec
   - misspell
+  - perfsprint
   - revive
   - testifylint
   - unconvert
@@ -36,6 +37,17 @@ linters-settings:
       - G115
   misspell:
     locale: US
+  perfsprint:
+    # Optimizes even if it requires an int or uint type cast.
+    int-conversion: true
+    # Optimizes into `err.Error()` even if it is only equivalent for non-nil errors.
+    err-error: true
+    # Optimizes `fmt.Errorf`.
+    errorf: true
+    # Optimizes `fmt.Sprintf` with only one argument.
+    sprintf1: true
+    # Optimizes into strings concatenation.
+    strconcat: true
   testifylint:
     disable:
     - float-compare

--- a/examples/dyplomat/auth.go
+++ b/examples/dyplomat/auth.go
@@ -150,7 +150,7 @@ func (rt *TokenRoundtripper) RoundTrip(req *http.Request) (*http.Response, error
 
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token.Token))
+	req.Header.Set("Authorization", "Bearer "+token.Token)
 	return rt.RoundTripper.RoundTrip(req)
 }
 

--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -18,7 +18,6 @@ package cache
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync/atomic"
 
 	"google.golang.org/protobuf/proto"
@@ -362,7 +361,7 @@ func (r *PassthroughResponse) GetVersion() (string, error) {
 	if discoveryResponse != nil {
 		return discoveryResponse.GetVersionInfo(), nil
 	}
-	return "", fmt.Errorf("DiscoveryResponse is nil")
+	return "", errors.New("DiscoveryResponse is nil")
 }
 
 func (r *PassthroughResponse) GetContext() context.Context {
@@ -375,7 +374,7 @@ func (r *DeltaPassthroughResponse) GetSystemVersion() (string, error) {
 	if deltaDiscoveryResponse != nil {
 		return deltaDiscoveryResponse.GetSystemVersionInfo(), nil
 	}
-	return "", fmt.Errorf("DeltaDiscoveryResponse is nil")
+	return "", errors.New("DeltaDiscoveryResponse is nil")
 }
 
 // NextVersionMap returns the version map from a DeltaPassthroughResponse

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -192,7 +193,7 @@ func TestConcurrentSetDeltaWatch(t *testing.T) {
 		func(i int) {
 			t.Run(fmt.Sprintf("worker%d", i), func(t *testing.T) {
 				t.Parallel()
-				id := fmt.Sprintf("%d", i%2)
+				id := strconv.Itoa(i % 2)
 				responses := make(chan cache.DeltaResponse, 1)
 				if i < 25 {
 					snap, err := cache.NewSnapshot("", map[rsrc.Type][]types.Resource{})

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -437,12 +438,12 @@ func TestLinearConcurrentSetWatch(t *testing.T) {
 		func(i int) {
 			t.Run(fmt.Sprintf("worker%d", i), func(t *testing.T) {
 				t.Parallel()
-				id := fmt.Sprintf("%d", i)
+				id := strconv.Itoa(i)
 				if i%2 == 0 {
 					t.Logf("update resource %q", id)
 					require.NoError(t, c.UpdateResource(id, testResource(id)))
 				} else {
-					id2 := fmt.Sprintf("%d", i-1)
+					id2 := strconv.Itoa(i - 1)
 					t.Logf("request resources %q and %q", id, id2)
 					value := make(chan Response, 1)
 					c.CreateWatch(&Request{

--- a/pkg/cache/v3/snapshot.go
+++ b/pkg/cache/v3/snapshot.go
@@ -168,7 +168,7 @@ func (s *Snapshot) GetVersionMap(typeURL string) map[string]string {
 // ConstructVersionMap will construct a version map based on the current state of a snapshot
 func (s *Snapshot) ConstructVersionMap() error {
 	if s == nil {
-		return fmt.Errorf("missing snapshot")
+		return errors.New("missing snapshot")
 	}
 
 	// The snapshot resources never change, so no need to ever rebuild.

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -115,7 +116,7 @@ func (stream *mockDeltaStream) Context() context.Context {
 func (stream *mockDeltaStream) Send(resp *discovery.DeltaDiscoveryResponse) error {
 	// Check that nonce is incremented by one
 	stream.nonce++
-	if resp.GetNonce() != fmt.Sprintf("%d", stream.nonce) {
+	if resp.GetNonce() != strconv.Itoa(stream.nonce) {
 		stream.t.Errorf("Nonce => got %q, want %d", resp.GetNonce(), stream.nonce)
 	}
 	// Check that resources are non-empty
@@ -434,7 +435,7 @@ func TestDeltaOpaqueRequestsChannelMuxing(t *testing.T) {
 		resp.recv <- &discovery.DeltaDiscoveryRequest{
 			Node:                   node,
 			TypeUrl:                fmt.Sprintf("%s%d", opaqueType, i%2),
-			ResourceNamesSubscribe: []string{fmt.Sprintf("%d", i)},
+			ResourceNamesSubscribe: []string{strconv.Itoa(i)},
 		}
 	}
 	close(resp.recv)
@@ -651,7 +652,7 @@ func TestDeltaMultipleStreams(t *testing.T) {
 			config,
 			server.CallbackFuncs{
 				StreamDeltaRequestFunc: func(int64, *discovery.DeltaDiscoveryRequest) error {
-					return fmt.Errorf("error")
+					return errors.New("error")
 				},
 			},
 		)

--- a/pkg/server/v3/gateway.go
+++ b/pkg/server/v3/gateway.go
@@ -57,16 +57,16 @@ func (h *HTTPGateway) ServeHTTP(req *http.Request) ([]byte, int, error) {
 	case resource.FetchExtensionConfigs:
 		typeURL = resource.ExtensionConfigType
 	default:
-		return nil, http.StatusNotFound, fmt.Errorf("no endpoint")
+		return nil, http.StatusNotFound, errors.New("no endpoint")
 	}
 
 	if req.Body == nil {
-		return nil, http.StatusBadRequest, fmt.Errorf("empty body")
+		return nil, http.StatusBadRequest, errors.New("empty body")
 	}
 
 	body, err := io.ReadAll(req.Body)
 	if err != nil {
-		return nil, http.StatusBadRequest, fmt.Errorf("cannot read body")
+		return nil, http.StatusBadRequest, errors.New("cannot read body")
 	}
 
 	// parse as JSON

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -104,7 +105,7 @@ func (stream *mockStream) Context() context.Context {
 func (stream *mockStream) Send(resp *discovery.DiscoveryResponse) error {
 	// check that nonce is monotonically incrementing
 	stream.nonce++
-	assert.Equal(stream.t, resp.GetNonce(), fmt.Sprintf("%d", stream.nonce))
+	assert.Equal(stream.t, resp.GetNonce(), strconv.Itoa(stream.nonce))
 	// check that version is set
 	assert.NotEmpty(stream.t, resp.GetVersionInfo())
 	// check resources are non-empty
@@ -656,7 +657,7 @@ func TestOpaqueRequestsChannelMuxing(t *testing.T) {
 			Node:    node,
 			TypeUrl: fmt.Sprintf("%s%d", opaqueType, i%2),
 			// each subsequent request is assumed to supercede the previous request
-			ResourceNames: []string{fmt.Sprintf("%d", i)},
+			ResourceNames: []string{strconv.Itoa(i)},
 		}
 	}
 	close(resp.recv)
@@ -674,7 +675,7 @@ func TestNilPropagationOverResponseChannelShouldCloseTheStream(t *testing.T) {
 			Node:    node,
 			TypeUrl: nilType,
 			// each subsequent request is assumed to supercede the previous request
-			ResourceNames: []string{fmt.Sprintf("%d", i)},
+			ResourceNames: []string{strconv.Itoa(i)},
 		}
 	}
 	close(resp.recv)


### PR DESCRIPTION
#### Description

[perfsprint](https://golangci-lint.run/usage/linters/#perfsprint) checks that fmt.Sprintf can be replaced with a faster alternative.