### PR TITLE
chore: use testify instead of t.Fatal or t.Error

### DIFF
--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -77,12 +77,10 @@ func TestValidate(t *testing.T) {
 		}},
 	}
 
-	if err := invalidRoute.Validate(); err == nil {
-		t.Error("expected an error")
-	}
-	if err := invalidRoute.GetVirtualHosts()[0].Validate(); err == nil {
-		t.Error("expected an error")
-	}
+	err := invalidRoute.Validate()
+	require.Errorf(t, err, "expected an error")
+	err = invalidRoute.GetVirtualHosts()[0].Validate()
+	assert.Errorf(t, err, "expected an error")
 }
 
 type customResource struct {
@@ -96,33 +94,24 @@ func (cs *customResource) GetName() string { return customName }
 var _ types.ResourceWithName = &customResource{}
 
 func TestGetResourceName(t *testing.T) {
-	if name := cache.GetResourceName(testEndpoint); name != clusterName {
-		t.Errorf("GetResourceName(%v) => got %q, want %q", testEndpoint, name, clusterName)
-	}
-	if name := cache.GetResourceName(testCluster); name != clusterName {
-		t.Errorf("GetResourceName(%v) => got %q, want %q", testCluster, name, clusterName)
-	}
-	if name := cache.GetResourceName(testRoute); name != routeName {
-		t.Errorf("GetResourceName(%v) => got %q, want %q", testRoute, name, routeName)
-	}
-	if name := cache.GetResourceName(testScopedRoute); name != scopedRouteName {
-		t.Errorf("GetResourceName(%v) => got %q, want %q", testScopedRoute, name, scopedRouteName)
-	}
-	if name := cache.GetResourceName(testVirtualHost); name != virtualHostName {
-		t.Errorf("GetResourceName(%v) => got %q, want %q", testVirtualHost, name, virtualHostName)
-	}
-	if name := cache.GetResourceName(testListener); name != listenerName {
-		t.Errorf("GetResourceName(%v) => got %q, want %q", testListener, name, listenerName)
-	}
-	if name := cache.GetResourceName(testRuntime); name != runtimeName {
-		t.Errorf("GetResourceName(%v) => got %q, want %q", testRuntime, name, runtimeName)
-	}
-	if name := cache.GetResourceName(&customResource{}); name != customName {
-		t.Errorf("GetResourceName(nil) => got %q, want %q", name, customName)
-	}
-	if name := cache.GetResourceName(nil); name != "" {
-		t.Errorf("GetResourceName(nil) => got %q, want none", name)
-	}
+	name := cache.GetResourceName(testEndpoint)
+	assert.Equalf(t, clusterName, name, "GetResourceName(%v) => got %q, want %q", testEndpoint, name, clusterName)
+	name = cache.GetResourceName(testCluster)
+	assert.Equalf(t, clusterName, name, "GetResourceName(%v) => got %q, want %q", testCluster, name, clusterName)
+	name = cache.GetResourceName(testRoute)
+	assert.Equalf(t, routeName, name, "GetResourceName(%v) => got %q, want %q", testRoute, name, routeName)
+	name = cache.GetResourceName(testScopedRoute)
+	assert.Equalf(t, scopedRouteName, name, "GetResourceName(%v) => got %q, want %q", testScopedRoute, name, scopedRouteName)
+	name = cache.GetResourceName(testVirtualHost)
+	assert.Equalf(t, virtualHostName, name, "GetResourceName(%v) => got %q, want %q", testVirtualHost, name, virtualHostName)
+	name = cache.GetResourceName(testListener)
+	assert.Equalf(t, listenerName, name, "GetResourceName(%v) => got %q, want %q", testListener, name, listenerName)
+	name = cache.GetResourceName(testRuntime)
+	assert.Equalf(t, runtimeName, name, "GetResourceName(%v) => got %q, want %q", testRuntime, name, runtimeName)
+	name = cache.GetResourceName(&customResource{})
+	assert.Equalf(t, customName, name, "GetResourceName(nil) => got %q, want %q", name, customName)
+	name = cache.GetResourceName(nil)
+	assert.Emptyf(t, name, "GetResourceName(nil) => got %q, want none", name)
 }
 
 func TestGetResourceNames(t *testing.T) {
@@ -218,9 +207,7 @@ func TestGetResourceReferences(t *testing.T) {
 	}
 	for _, cs := range cases {
 		names := cache.GetResourceReferences(cache.IndexResourcesByName([]types.ResourceWithTTL{{Resource: cs.in}}))
-		if !reflect.DeepEqual(names, cs.out) {
-			t.Errorf("GetResourceReferences(%v) => got %v, want %v", cs.in, names, cs.out)
-		}
+		assert.Truef(t, reflect.DeepEqual(names, cs.out), "GetResourceReferences(%v) => got %v, want %v", cs.in, names, cs.out)
 	}
 }
 
@@ -238,7 +225,5 @@ func TestGetAllResourceReferencesReturnsExpectedRefs(t *testing.T) {
 	resources[types.ScopedRoute] = cache.NewResources("1", []types.Resource{testScopedRoute})
 	actual := cache.GetAllResourceReferences(resources)
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("GetAllResourceReferences(%v) => got %v, want %v", resources, actual, expected)
-	}
+	assert.Truef(t, reflect.DeepEqual(actual, expected), "GetAllResourceReferences(%v) => got %v, want %v", resources, actual, expected)
 }

--- a/pkg/cache/v3/status_test.go
+++ b/pkg/cache/v3/status_test.go
@@ -18,40 +18,35 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
 func TestIDHash(t *testing.T) {
 	node := &core.Node{Id: "test"}
-	if got := (IDHash{}).ID(node); got != "test" {
-		t.Errorf("IDHash.ID(%v) => got %s, want %s", node, got, node.GetId())
-	}
-	if got := (IDHash{}).ID(nil); got != "" {
-		t.Errorf("IDHash.ID(nil) => got %s, want empty", got)
-	}
+	got := (IDHash{}).ID(node)
+	assert.Equalf(t, "test", got, "IDHash.ID(%v) => got %s, want %s", node, got, node.GetId())
+	got = (IDHash{}).ID(nil)
+	assert.Emptyf(t, got, "IDHash.ID(nil) => got %s, want empty", got)
 }
 
 func TestNewStatusInfo(t *testing.T) {
 	node := &core.Node{Id: "test"}
 	info := newStatusInfo(node)
 
-	if got := info.GetNode(); !reflect.DeepEqual(got, node) {
-		t.Errorf("GetNode() => got %#v, want %#v", got, node)
-	}
+	gotNode := info.GetNode()
+	assert.Truef(t, reflect.DeepEqual(gotNode, node), "GetNode() => got %#v, want %#v", gotNode, node)
 
-	if got := info.GetNumWatches(); got != 0 {
-		t.Errorf("GetNumWatches() => got %d, want 0", got)
-	}
+	gotNumWatches := info.GetNumWatches()
+	assert.Equalf(t, 0, gotNumWatches, "GetNumWatches() => got %d, want 0", gotNumWatches)
 
-	if got := info.GetLastWatchRequestTime(); !got.IsZero() {
-		t.Errorf("GetLastWatchRequestTime() => got %v, want zero time", got)
-	}
+	gotLastWatchRequestTime := info.GetLastWatchRequestTime()
+	assert.Truef(t, gotLastWatchRequestTime.IsZero(), "GetLastWatchRequestTime() => got %v, want zero time", gotLastWatchRequestTime)
 
-	if got := info.GetNumDeltaWatches(); got != 0 {
-		t.Errorf("GetNumDeltaWatches() => got %d, want 0", got)
-	}
+	gotNumDeltaWatches := info.GetNumDeltaWatches()
+	assert.Equalf(t, 0, gotNumDeltaWatches, "GetNumDeltaWatches() => got %d, want 0", gotNumDeltaWatches)
 
-	if got := info.GetLastDeltaWatchRequestTime(); !got.IsZero() {
-		t.Errorf("GetLastDeltaWatchRequestTime() => got %v, want zero time", got)
-	}
+	gotLastDeltaWatchRequestTime := info.GetLastDeltaWatchRequestTime()
+	assert.Truef(t, gotLastDeltaWatchRequestTime.IsZero(), "GetLastDeltaWatchRequestTime() => got %v, want zero time", gotLastDeltaWatchRequestTime)
 }

--- a/pkg/conversion/struct_test.go
+++ b/pkg/conversion/struct_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -32,9 +34,7 @@ func TestConversion(t *testing.T) {
 		Node:        &core.Node{Id: "proxy"},
 	}
 	st, err := conversion.MessageToStruct(pb)
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
+	require.NoErrorf(t, err, "unexpected error")
 	pbst := map[string]*structpb.Value{
 		"version_info": {Kind: &structpb.Value_StringValue{StringValue: "test"}},
 		"node": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{
@@ -48,19 +48,13 @@ func TestConversion(t *testing.T) {
 	}
 
 	out := &discovery.DiscoveryRequest{}
-	err = conversion.StructToMessage(st, out)
-	if err != nil {
-		t.Fatalf("unexpected error %v", err)
-	}
+	require.NoErrorf(t, conversion.StructToMessage(st, out), "unexpected error")
 	if !cmp.Equal(pb, out, cmp.Comparer(proto.Equal)) {
 		t.Errorf("StructToMessage(%v) => got %v, want %v", st, out, pb)
 	}
 
-	if _, err = conversion.MessageToStruct(nil); err == nil {
-		t.Error("MessageToStruct(nil) => got no error")
-	}
+	_, err = conversion.MessageToStruct(nil)
+	require.Errorf(t, err, "MessageToStruct(nil) => got no error")
 
-	if err = conversion.StructToMessage(nil, &discovery.DiscoveryRequest{}); err == nil {
-		t.Error("StructToMessage(nil) => got no error")
-	}
+	assert.Errorf(t, conversion.StructToMessage(nil, &discovery.DiscoveryRequest{}), "StructToMessage(nil) => got no error")
 }

--- a/pkg/server/v3/gateway_test.go
+++ b/pkg/server/v3/gateway_test.go
@@ -22,6 +22,9 @@ import (
 	"testing"
 	"testing/iotest"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -88,35 +91,19 @@ func TestGateway(t *testing.T) {
 	}
 	for _, cs := range failCases {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, cs.path, cs.body)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		resp, code, err := gtw.ServeHTTP(req)
-		if err == nil {
-			t.Errorf("ServeHTTP succeeded, but should have failed")
-		}
-		if resp != nil {
-			t.Errorf("handler returned wrong response")
-		}
-		if status := code; status != cs.expect {
-			t.Errorf("handler returned wrong status: %d, want %d", status, cs.expect)
-		}
+		require.Errorf(t, err, "ServeHTTP succeeded, but should have failed")
+		assert.Nilf(t, resp, "handler returned wrong response")
+		assert.Equalf(t, code, cs.expect, "handler returned wrong status: %d, want %d", code, cs.expect)
 	}
 
 	for _, path := range []string{resource.FetchClusters, resource.FetchRoutes, resource.FetchListeners} {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, path, strings.NewReader("{\"node\": {\"id\": \"test\"}}"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		resp, code, err := gtw.ServeHTTP(req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if resp == nil {
-			t.Errorf("handler returned wrong response")
-		}
-		if status := code; status != 200 {
-			t.Errorf("handler returned wrong status: %d, want %d", status, 200)
-		}
+		require.NoError(t, err)
+		assert.NotNilf(t, resp, "handler returned wrong response")
+		assert.Equalf(t, 200, code, "handler returned wrong status: %d, want %d", code, 200)
 	}
 }

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -293,9 +293,7 @@ func TestServerShutdown(t *testing.T) {
 				case opaqueType:
 					err = s.StreamAggregatedResources(resp)
 				}
-				if err != nil {
-					t.Errorf("Stream() => got %v, want no error", err)
-				}
+				assert.NoErrorf(t, err, "Stream() => got %v, want no error", err)
 				shutdown <- true
 			}(typ)
 
@@ -356,9 +354,8 @@ func TestResponseHandlers(t *testing.T) {
 			select {
 			case <-resp.sent:
 				close(resp.recv)
-				if want := map[string]int{typ: 1}; !reflect.DeepEqual(want, config.counts) {
-					t.Errorf("watch counts => got %v, want %v", config.counts, want)
-				}
+				want := map[string]int{typ: 1}
+				assert.Truef(t, reflect.DeepEqual(want, config.counts), "watch counts => got %v, want %v", config.counts, want)
 			case <-time.After(1 * time.Second):
 				t.Fatalf("got no response")
 			}


### PR DESCRIPTION
This uses testify instead of testing for t.Fatal or t.Error calls