### PR TITLE
Create releases for go-control-plane (0.13.2) and envoy API (1.32.2)

### DIFF
--- a/contrib/go.mod
+++ b/contrib/go.mod
@@ -6,7 +6,7 @@ replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 
 require (
 	github.com/cncf/xds/go v0.0.0-20240723142845-024c85f92f20
-	github.com/envoyproxy/go-control-plane/envoy v0.0.0-00010101000000-000000000000
+	github.com/envoyproxy/go-control-plane/envoy v1.32.2
 	github.com/envoyproxy/protoc-gen-validate v1.1.0
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10
 	google.golang.org/grpc v1.67.1

--- a/examples/dyplomat/go.mod
+++ b/examples/dyplomat/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/envoyproxy/go-control-plane v0.13.0
-	github.com/envoyproxy/go-control-plane/envoy v0.0.0-00010101000000-000000000000
+	github.com/envoyproxy/go-control-plane/envoy v1.32.2
 	google.golang.org/grpc v1.67.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.28.2

--- a/examples/dyplomat/go.mod
+++ b/examples/dyplomat/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/cncf/xds/go v0.0.0-20240723142845-024c85f92f20 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
-	github.com/envoyproxy/go-control-plane/ratelimit v0.0.0-00010101000000-000000000000 // indirect
+	github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/envoyproxy/go-control-plane/envoy v0.0.0-00010101000000-000000000000
+	github.com/envoyproxy/go-control-plane/envoy v1.32.2
 	github.com/envoyproxy/go-control-plane/ratelimit v0.0.0-00010101000000-000000000000
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ replace (
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.32.2
-	github.com/envoyproxy/go-control-plane/ratelimit v0.0.0-00010101000000-000000000000
+	github.com/envoyproxy/go-control-plane/ratelimit v0.1.0
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0

--- a/ratelimit/go.mod
+++ b/ratelimit/go.mod
@@ -5,7 +5,7 @@ go 1.21
 replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 
 require (
-	github.com/envoyproxy/go-control-plane/envoy v0.0.0-00010101000000-000000000000
+	github.com/envoyproxy/go-control-plane/envoy v1.32.2
 	google.golang.org/grpc v1.67.1
 	google.golang.org/protobuf v1.35.2
 )

--- a/xdsmatcher/go.mod
+++ b/xdsmatcher/go.mod
@@ -6,7 +6,7 @@ replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 
 require (
 	github.com/cncf/xds/go v0.0.0-20240723142845-024c85f92f20
-	github.com/envoyproxy/go-control-plane/envoy v0.0.0-00010101000000-000000000000
+	github.com/envoyproxy/go-control-plane/envoy v1.32.2
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/protobuf v1.35.2
 	gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
This PR updates mod files for the first release using [multimod](https://pkg.go.dev/go.opentelemetry.io/build-tools/multimod)