### PR TITLE
deps: update go version from 1.22.0 to 1.23.0

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,3 +1,3 @@
-FROM golang:1.22@sha256:0ca97f4ab335f4b284a5b8190980c7cdc21d320d529f2b643e8a8733a69bfb6b
+FROM golang:1.23@sha256:77a21b3e354c03e9f66b13bc39f4f0db8085c70f8414406af66b29c6d6c4dd85
 
 COPY --from=envoyproxy/envoy-dev:latest /usr/local/bin/envoy /usr/local/bin/envoy

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ feedback, we might decide to revisit this aspect at a later point in time.
 
 ## Requirements
 
-1. Go 1.22+
+1. Go 1.23+
 
 ## Quick start
 

--- a/contrib/go.mod
+++ b/contrib/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/contrib
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.5
+toolchain go1.23.6
 
 replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 

--- a/envoy/go.mod
+++ b/envoy/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/envoy
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.5
+toolchain go1.23.6
 
 // Used to resolve import issues related to go-control-plane package split (https://github.com/envoyproxy/go-control-plane/issues/1074)
 replace github.com/envoyproxy/go-control-plane@v0.13.4 => ../

--- a/examples/dyplomat/Dockerfile
+++ b/examples/dyplomat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22@sha256:0ca97f4ab335f4b284a5b8190980c7cdc21d320d529f2b643e8a8733a69bfb6b
+FROM golang:1.23@sha256:77a21b3e354c03e9f66b13bc39f4f0db8085c70f8414406af66b29c6d6c4dd85
 
 WORKDIR /go/src/dyplomat
 COPY . /go/src/dyplomat

--- a/examples/dyplomat/go.mod
+++ b/examples/dyplomat/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/examples/dyplomat
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.5
+toolchain go1.23.6
 
 replace (
 	github.com/envoyproxy/go-control-plane => ../..

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.5
+toolchain go1.23.6
 
 replace (
 	github.com/envoyproxy/go-control-plane/envoy => ./envoy

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,7 +1,8 @@
 module github.com/envoyproxy/go-control-plane/internal/tools
 
-go 1.22.1
-toolchain go1.23.4
+go 1.23.0
+
+toolchain go1.23.6
 
 require (
 	github.com/golangci/golangci-lint v1.64.5

--- a/ratelimit/go.mod
+++ b/ratelimit/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/ratelimit
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.5
+toolchain go1.23.6
 
 replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 

--- a/xdsmatcher/go.mod
+++ b/xdsmatcher/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/xdsmatcher
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.5
+toolchain go1.23.6
 
 replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 


### PR DESCRIPTION
#### Description

[Go 1.24.0](https://go.dev/blog/go1.24) has been released on since 11 February 2025

This update Go version from 1.22.0 to 1.23.0