### PR TITLE
ignore var-naming on pkg/cache/types

### DIFF
--- a/pkg/cache/types/types.go
+++ b/pkg/cache/types/types.go
@@ -1,4 +1,4 @@
-package types
+package types //nolint:revive // var-naming: avoid meaningless package names
 
 import (
 	"time"


### PR DESCRIPTION
#### Description

I'm wondering if the content of `pkg/cache/type` be moved inside `pkg/cache` instead with a ducplication and deprecation strategy ?