### PR TITLE
cache/simple: handle unsubscription for a resource followed by resubscription

### DIFF
--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -95,14 +95,17 @@ func (log logger) Debugf(format string, args ...interface{}) {
 	log.t.Helper()
 	log.t.Logf(format, args...)
 }
+
 func (log logger) Infof(format string, args ...interface{}) {
 	log.t.Helper()
 	log.t.Logf(format, args...)
 }
+
 func (log logger) Warnf(format string, args ...interface{}) {
 	log.t.Helper()
 	log.t.Logf(format, args...)
 }
+
 func (log logger) Errorf(format string, args ...interface{}) {
 	log.t.Helper()
 	log.t.Logf(format, args...)


### PR DESCRIPTION
Fixes https://github.com/envoyproxy/go-control-plane/issues/431

This change attempts to fix the following problem:
- Client requests resources [A, B] and gets a response from the server for both
- Client acks the response
- Client unsubscribes from resource [A], by sending a request with the previously received version and nonce, but with only resource [B]
- Server does not send any response since it knows that the client already has B at the specified version
- Client re-subscribes to resource [A], by sending a request with the previously received version and nonce, this time with both resources [A, B]

The current behaviour of the simple cache was only not sending a response for the resubscription.

The PR addresses this issue by updating the stream state to reflect the actual resources known to the client by taking into account the set of resources requested by the client. This will ensure that when the re-subscription happens, the server will be able to respond to both resource [A, B].

The PR also adds a test for this scenario and modifies the test logger implementation to include a call to `t.Helper()`, thereby ensuring that log statements emitted by the test logger contains the actual line emitting the log statement and not the in from the test logger.