### PR TITLE
[Sotw][Linear cache] Ensure watches are properly considering subscription changes to not miss new resources

### DIFF
--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -118,6 +118,11 @@ type Response interface {
 	// Get the version in the Response.
 	GetVersion() (string, error)
 
+	// GetReturnedResources returns the map of resources and their versions returned in the subscription.
+	// It may include more resources than directly set in the response to consider the full state of the client.
+	// The caller is expected to provide this unchanged to the next call to CreateWatch as part of the subscription.
+	GetReturnedResources() map[string]string
+
 	// Get the context provided during response creation.
 	GetContext() context.Context
 }
@@ -154,6 +159,12 @@ type RawResponse struct {
 
 	// Resources to be included in the response.
 	Resources []types.ResourceWithTTL
+
+	// ReturnedResources tracks the resources returned for the subscription and the version when it was last returned,
+	// including previously returned ones when using non-full state resources.
+	// It allows the cache to know what the client knows. The server will transparently forward this
+	// across requests, and the cache is responsible for its interpretation.
+	ReturnedResources map[string]string
 
 	// Whether this is a heartbeat response. For xDS versions that support TTL, this
 	// will be converted into a response that doesn't contain the actual resource protobuf.
@@ -207,6 +218,12 @@ type PassthroughResponse struct {
 	DiscoveryResponse *discovery.DiscoveryResponse
 
 	ctx context.Context
+
+	// ReturnedResources tracks the resources returned for the subscription and the version when it was last returned,
+	// including previously returned ones when using non-full state resources.
+	// It allows the cache to know what the client knows. The server will transparently forward this
+	// across requests, and the cache is responsible for its interpretation.
+	ReturnedResources map[string]string
 }
 
 // DeltaPassthroughResponse is a pre constructed xDS response that need not go through marshaling transformations.
@@ -262,6 +279,10 @@ func (r *RawResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, erro
 	}
 
 	return marshaledResponse.(*discovery.DiscoveryResponse), nil
+}
+
+func (r *RawResponse) GetReturnedResources() map[string]string {
+	return r.ReturnedResources
 }
 
 // GetDeltaDiscoveryResponse performs the marshaling the first time its called and uses the cached response subsequently.
@@ -365,6 +386,10 @@ func (r *RawResponse) maybeCreateTTLResource(resource types.ResourceWithTTL) (ty
 // GetDiscoveryResponse returns the final passthrough Discovery Response.
 func (r *PassthroughResponse) GetDiscoveryResponse() (*discovery.DiscoveryResponse, error) {
 	return r.DiscoveryResponse, nil
+}
+
+func (r *PassthroughResponse) GetReturnedResources() map[string]string {
+	return r.ReturnedResources
 }
 
 // GetDeltaDiscoveryResponse returns the final passthrough Delta Discovery Response.

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -17,6 +17,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/log"
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
@@ -31,7 +32,7 @@ func assertResourceMapEqual(t *testing.T, want, got map[string]types.Resource) {
 }
 
 func TestSnapshotCacheDeltaWatch(t *testing.T) {
-	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(false, group{}, log.NewTestLogger(t))
 	watches := make(map[string]chan cache.DeltaResponse)
 	subscriptions := make(map[string]stream.Subscription)
 
@@ -113,7 +114,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 }
 
 func TestDeltaRemoveResources(t *testing.T) {
-	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(false, group{}, log.NewTestLogger(t))
 	watches := make(map[string]chan cache.DeltaResponse)
 	subscriptions := make(map[string]*stream.Subscription)
 
@@ -188,7 +189,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 }
 
 func TestConcurrentSetDeltaWatch(t *testing.T) {
-	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(false, group{}, log.NewTestLogger(t))
 	for i := 0; i < 50; i++ {
 		version := fmt.Sprintf("v%d", i)
 		func(i int) {
@@ -222,7 +223,7 @@ func TestConcurrentSetDeltaWatch(t *testing.T) {
 type testKey struct{}
 
 func TestSnapshotDeltaCacheWatchTimeout(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 
 	// Create a non-buffered channel that will block sends.
 	watchCh := make(chan cache.DeltaResponse)
@@ -267,7 +268,7 @@ func TestSnapshotDeltaCacheWatchTimeout(t *testing.T) {
 }
 
 func TestSnapshotCacheDeltaWatchCancel(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 	for _, typ := range testTypes {
 		responses := make(chan cache.DeltaResponse, 1)
 		cancel, err := c.CreateDeltaWatch(&discovery.DeltaDiscoveryRequest{

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -39,6 +39,28 @@ const (
 	testType = "google.protobuf.StringValue"
 )
 
+type validationContext struct {
+	expectedType string
+}
+
+func newValidationContext(opts []validateOption) validationContext {
+	context := validationContext{
+		expectedType: testType,
+	}
+	for _, opt := range opts {
+		opt(&context)
+	}
+	return context
+}
+
+type validateOption = func(*validationContext)
+
+func responseType(t string) validateOption {
+	return func(vo *validationContext) {
+		vo.expectedType = t
+	}
+}
+
 func testResource(s string) types.Resource {
 	return wrapperspb.String(s)
 }
@@ -49,7 +71,7 @@ func verifyResponseContent(t *testing.T, ch <-chan Response, expectedType, expec
 	select {
 	case r = <-ch:
 	case <-time.After(1 * time.Second):
-		t.Error("failed to receive response after 1 second")
+		t.Fatal("failed to receive response after 1 second")
 		return nil, nil
 	}
 
@@ -60,26 +82,26 @@ func verifyResponseContent(t *testing.T, ch <-chan Response, expectedType, expec
 	assert.NotEmptyf(t, out.GetVersionInfo(), "unexpected response empty version")
 	assert.Truef(t, expectedVersion == "" || out.GetVersionInfo() == expectedVersion, "unexpected version: got %q, want %q", out.GetVersionInfo(), expectedVersion)
 	assert.Equalf(t, expectedType, out.GetTypeUrl(), "unexpected type URL: %q", out.GetTypeUrl())
-	assert.Truef(t, len(r.GetRequest().GetResourceNames()) == 0 || len(r.GetRequest().GetResourceNames()) >= len(out.Resources), "received more resources (%d) than requested (%d)", len(r.GetRequest().GetResourceNames()), len(out.Resources))
 	return r, out
 }
 
-func verifyResponse(t *testing.T, ch <-chan Response, expectedVersion string, expectedResourcesNb int) {
+func verifyResponse(t *testing.T, ch <-chan Response, expectedVersion string, expectedResourcesNb int) Response {
 	t.Helper()
-	_, r := verifyResponseContent(t, ch, testType, expectedVersion)
+	response, r := verifyResponseContent(t, ch, testType, expectedVersion)
 	if r == nil {
-		return
+		return nil
 	}
 
 	resources := r.GetResources()
 	assert.Lenf(t, resources, expectedResourcesNb, "unexpected number of responses: got %d, want %d", len(resources), expectedResourcesNb)
+	return response
 }
 
-func verifyResponseResources(t *testing.T, ch <-chan Response, expectedType, expectedVersion string, expectedResources ...string) {
+func verifyResponseResources(t *testing.T, ch <-chan Response, expectedType, expectedVersion string, expectedResources ...string) Response {
 	t.Helper()
 	r, _ := verifyResponseContent(t, ch, expectedType, expectedVersion)
 	if r == nil {
-		return
+		return nil
 	}
 	out := r.(*RawResponse)
 	resourceNames := []string{}
@@ -87,6 +109,7 @@ func verifyResponseResources(t *testing.T, ch <-chan Response, expectedType, exp
 		resourceNames = append(resourceNames, GetResourceName(res.Resource))
 	}
 	assert.ElementsMatch(t, resourceNames, expectedResources)
+	return r
 }
 
 type resourceInfo struct {
@@ -94,10 +117,14 @@ type resourceInfo struct {
 	version string
 }
 
-func validateDeltaResponse(t *testing.T, resp DeltaResponse, resources []resourceInfo, deleted []string) {
+func validateDeltaResponse(t *testing.T, resp DeltaResponse, resources []resourceInfo, deleted []string, options ...validateOption) {
 	t.Helper()
 
-	assert.Equalf(t, testType, resp.GetDeltaRequest().GetTypeUrl(), "unexpected empty request type URL: %q", resp.GetDeltaRequest().GetTypeUrl())
+	validationCtx := newValidationContext(options)
+
+	if resp.GetDeltaRequest().GetTypeUrl() != validationCtx.expectedType {
+		t.Errorf("unexpected request type URL: received %s and expected %s", resp.GetDeltaRequest().GetTypeUrl(), validationCtx.expectedType)
+	}
 	out, err := resp.GetDeltaDiscoveryResponse()
 	require.NoError(t, err)
 	assert.Lenf(t, out.GetResources(), len(resources), "unexpected number of responses: got %d, want %d", len(out.GetResources()), len(resources))
@@ -115,7 +142,7 @@ func validateDeltaResponse(t *testing.T, resp DeltaResponse, resources []resourc
 		}
 		assert.Truef(t, found, "resource with name %q not found in response", r.name)
 	}
-	assert.Equalf(t, testType, out.GetTypeUrl(), "unexpected type URL: %q", out.GetTypeUrl())
+	assert.Equalf(t, validationCtx.expectedType, out.GetTypeUrl(), "unexpected type URL: received %s and expected %s", out.GetTypeUrl(), validationCtx.expectedType)
 	assert.Lenf(t, out.GetRemovedResources(), len(deleted), "unexpected number of removed resurces: got %d, want %d", len(out.GetRemovedResources()), len(deleted))
 	for _, r := range deleted {
 		found := false
@@ -129,7 +156,7 @@ func validateDeltaResponse(t *testing.T, resp DeltaResponse, resources []resourc
 	}
 }
 
-func verifyDeltaResponse(t *testing.T, ch <-chan DeltaResponse, resources []resourceInfo, deleted []string) DeltaResponse {
+func verifyDeltaResponse(t *testing.T, ch <-chan DeltaResponse, resources []resourceInfo, deleted []string, options ...validateOption) DeltaResponse {
 	t.Helper()
 	var r DeltaResponse
 	select {
@@ -138,7 +165,7 @@ func verifyDeltaResponse(t *testing.T, ch <-chan DeltaResponse, resources []reso
 		t.Error("timeout waiting for delta response")
 		return nil
 	}
-	validateDeltaResponse(t, r, resources, deleted)
+	validateDeltaResponse(t, r, resources, deleted, options...)
 	return r
 }
 
@@ -213,6 +240,15 @@ func subFromRequest(req *Request) stream.Subscription {
 	return stream.NewSotwSubscription(req.GetResourceNames())
 }
 
+// This method represents the expected behavior of client and servers regarding the request and the subscription.
+// For edge cases it should ignore those
+func updateFromSotwResponse(resp Response, sub *stream.Subscription, req *Request) {
+	sub.SetReturnedResources(resp.GetReturnedResources())
+	// Never returns an error when not using passthrough responses
+	version, _ := resp.GetVersion()
+	req.VersionInfo = version
+}
+
 func subFromDeltaRequest(req *DeltaRequest) stream.Subscription {
 	return stream.NewDeltaSubscription(req.GetResourceNamesSubscribe(), req.GetResourceNamesUnsubscribe(), req.GetInitialResourceVersions())
 }
@@ -269,18 +305,30 @@ func TestLinearBasic(t *testing.T) {
 	require.NoError(t, c.UpdateResource("a", testResource("a")))
 	checkWatchCount(t, c, "a", 0)
 	checkWatchCount(t, c, "b", 0)
-	verifyResponse(t, w1, "1", 1)
-	verifyResponse(t, w2, "1", 1)
+
+	resp1 := verifyResponse(t, w1, "1", 1)
+	updateFromSotwResponse(resp1, &sub1, req1)
+	resp2 := verifyResponse(t, w2, "1", 1)
+	updateFromSotwResponse(resp2, &sub2, req2)
 
 	// Request again, should get same response
+	w1 = make(chan Response, 1)
+	req1 = &Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}
+	sub1 = subFromRequest(req1)
 	_, err = c.CreateWatch(req1, sub1, w1)
 	require.NoError(t, err)
 	checkWatchCount(t, c, "a", 0)
-	verifyResponse(t, w1, "1", 1)
+	resp1 = verifyResponse(t, w1, "1", 1)
+	updateFromSotwResponse(resp1, &sub1, req1)
+
+	w2 = make(chan Response, 1)
+	req2 = &Request{TypeUrl: testType, VersionInfo: "0"}
+	sub2 = subFromRequest(req2)
 	_, err = c.CreateWatch(req2, sub2, w2)
 	require.NoError(t, err)
 	checkWatchCount(t, c, "a", 0)
-	verifyResponse(t, w2, "1", 1)
+	resp2 = verifyResponse(t, w2, "1", 1)
+	updateFromSotwResponse(resp2, &sub2, req2)
 
 	// Add another element and update the first, response should be different
 	require.NoError(t, c.UpdateResource("b", testResource("b")))
@@ -317,15 +365,15 @@ func TestLinearSetResources(t *testing.T) {
 		"a": testResource("a"),
 		"b": testResource("b"),
 	})
-	verifyResponse(t, w1, "1", 1)
-	verifyResponse(t, w2, "1", 2) // the version was only incremented once for all resources
+	resp1 := verifyResponse(t, w1, "1", 1)
+	updateFromSotwResponse(resp1, &sub1, req1)
+	resp2 := verifyResponse(t, w2, "1", 2) // the version was only incremented once for all resources
+	updateFromSotwResponse(resp2, &sub2, req2)
 
 	// Add another element and update the first, response should be different
-	req1.VersionInfo = "1"
 	_, err = c.CreateWatch(req1, sub1, w1)
 	require.NoError(t, err)
 	mustBlock(t, w1)
-	req2.VersionInfo = "1"
 	_, err = c.CreateWatch(req2, sub2, w2)
 	require.NoError(t, err)
 	mustBlock(t, w2)
@@ -335,15 +383,15 @@ func TestLinearSetResources(t *testing.T) {
 		"b": testResource("b"),
 		"c": testResource("c"),
 	})
-	verifyResponse(t, w1, "2", 1)
-	verifyResponse(t, w2, "2", 3)
+	resp1 = verifyResponse(t, w1, "2", 1)
+	updateFromSotwResponse(resp1, &sub1, req1)
+	resp2 = verifyResponse(t, w2, "2", 3)
+	updateFromSotwResponse(resp2, &sub2, req2)
 
 	// Delete resource
-	req1.VersionInfo = "2"
 	_, err = c.CreateWatch(req1, sub1, w1)
 	require.NoError(t, err)
 	mustBlock(t, w1)
-	req2.VersionInfo = "2"
 	_, err = c.CreateWatch(req2, sub2, w2)
 	require.NoError(t, err)
 	mustBlock(t, w2)
@@ -352,7 +400,7 @@ func TestLinearSetResources(t *testing.T) {
 		"b": testResource("b"),
 		"c": testResource("c"),
 	})
-	verifyResponse(t, w1, "", 0) // removing a resource from the set triggers existing watches for deleted resources
+	mustBlock(t, w1) // removing a resource from the set does not trigger the watch for non full state resources
 	verifyResponse(t, w2, "3", 2)
 }
 
@@ -379,16 +427,18 @@ func TestLinearVersionPrefix(t *testing.T) {
 	sub := subFromRequest(req)
 	_, err := c.CreateWatch(req, sub, w)
 	require.NoError(t, err)
-	verifyResponse(t, w, "instance1-0", 0)
+	resp := verifyResponse(t, w, "instance1-0", 0)
+	updateFromSotwResponse(resp, &sub, req)
 
 	require.NoError(t, c.UpdateResource("a", testResource("a")))
 
-	req.VersionInfo = "instance1-0"
 	_, err = c.CreateWatch(req, sub, w)
 	require.NoError(t, err)
-	verifyResponse(t, w, "instance1-1", 1)
+	resp = verifyResponse(t, w, "instance1-1", 1)
 
 	req.VersionInfo = "instance1-1"
+	sub.SetReturnedResources(resp.GetReturnedResources())
+	w = make(chan Response, 1)
 	_, err = c.CreateWatch(req, sub, w)
 	require.NoError(t, err)
 	mustBlock(t, w)
@@ -396,32 +446,77 @@ func TestLinearVersionPrefix(t *testing.T) {
 }
 
 func TestLinearDeletion(t *testing.T) {
-	c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
-	w := make(chan Response, 1)
-	req := &Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}
-	sub := subFromRequest(req)
-	_, err := c.CreateWatch(req, sub, w)
-	require.NoError(t, err)
-	mustBlock(t, w)
-	checkWatchCount(t, c, "a", 1)
+	t.Run("non full-state resource", func(t *testing.T) {
+		c := NewLinearCache(testType, WithInitialResources(map[string]types.Resource{"a": testResource("a"), "b": testResource("b")}))
+		w := make(chan Response, 1)
+		req := &Request{ResourceNames: []string{"a"}, TypeUrl: testType, VersionInfo: "0"}
+		sub := subFromRequest(req)
+		sub.SetReturnedResources(map[string]string{"a": "0"})
+		cancel, err := c.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+		checkWatchCount(t, c, "a", 1)
 
-	require.NoError(t, c.DeleteResource("a"))
-	verifyResponse(t, w, "1", 0)
-	checkWatchCount(t, c, "a", 0)
+		require.NoError(t, c.DeleteResource("a"))
+		// For non full-state type, we don't return on deletion
+		mustBlock(t, w)
 
-	req = &Request{TypeUrl: testType, VersionInfo: "0"}
-	sub = subFromRequest(req)
-	_, err = c.CreateWatch(req, sub, w)
-	require.NoError(t, err)
-	verifyResponse(t, w, "1", 1)
-	checkWatchCount(t, c, "b", 0)
-	require.NoError(t, c.DeleteResource("b"))
+		cancel()
+		checkWatchCount(t, c, "a", 0)
 
-	req.VersionInfo = "1"
-	_, err = c.CreateWatch(req, sub, w)
-	require.NoError(t, err)
-	verifyResponse(t, w, "2", 0)
-	checkWatchCount(t, c, "b", 0)
+		// Create a wildcard watch
+		req = &Request{TypeUrl: testType, VersionInfo: "0"}
+		sub = subFromRequest(req)
+		_, err = c.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+		resp := verifyResponse(t, w, "1", 1)
+		updateFromSotwResponse(resp, &sub, req)
+		checkWatchCount(t, c, "b", 0)
+		require.NoError(t, c.DeleteResource("b"))
+
+		req.VersionInfo = "1"
+		_, err = c.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+		// b is watched by wildcard, but for non-full-state resources we cannot report deletions
+		mustBlock(t, w)
+		assert.Len(t, c.watchAll, 1)
+	})
+
+	t.Run("full-state resource", func(t *testing.T) {
+		c := NewLinearCache(resource.ClusterType, WithInitialResources(map[string]types.Resource{"a": &cluster.Cluster{Name: "a"}, "b": &cluster.Cluster{Name: "b"}}))
+		w := make(chan Response, 1)
+		req := &Request{ResourceNames: []string{"a"}, TypeUrl: resource.ClusterType, VersionInfo: "0"}
+		sub := subFromRequest(req)
+		sub.SetReturnedResources(map[string]string{"a": "0"})
+		_, err := c.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+		mustBlock(t, w)
+		checkWatchCount(t, c, "a", 1)
+
+		require.NoError(t, c.DeleteResource("a"))
+		// We get a response with no resource as full update and only a was requested
+		resp := verifyResponseResources(t, w, resource.ClusterType, "1")
+		updateFromSotwResponse(resp, &sub, req)
+		checkWatchCount(t, c, "a", 0)
+
+		// New wildcard request
+		req = &Request{TypeUrl: resource.ClusterType, VersionInfo: "0"}
+		sub = subFromRequest(req)
+		_, err = c.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+		// b still exists in the cache
+		resp = verifyResponseResources(t, w, resource.ClusterType, "1", "b")
+		updateFromSotwResponse(resp, &sub, req)
+		checkWatchCount(t, c, "b", 0)
+		require.NoError(t, c.DeleteResource("b"))
+
+		req.VersionInfo = "1"
+		_, err = c.CreateWatch(req, sub, w)
+		require.NoError(t, err)
+		// The cache no longer contains any resource, and as full-state is requested a response is provided
+		_ = verifyResponseResources(t, w, resource.ClusterType, "2")
+		checkWatchCount(t, c, "b", 0)
+	})
 }
 
 func TestLinearWatchTwo(t *testing.T) {
@@ -430,6 +525,7 @@ func TestLinearWatchTwo(t *testing.T) {
 	w1 := make(chan Response, 1)
 	req1 := &Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: "0"}
 	sub1 := subFromRequest(req1)
+	sub1.SetReturnedResources(map[string]string{"a": "0", "b": "0"})
 	_, err := c.CreateWatch(req1, sub1, w1)
 	require.NoError(t, err)
 	mustBlock(t, w1)
@@ -437,6 +533,7 @@ func TestLinearWatchTwo(t *testing.T) {
 	w2 := make(chan Response, 1)
 	req2 := &Request{TypeUrl: testType, VersionInfo: "0"}
 	sub2 := subFromRequest(req2)
+	sub2.SetReturnedResources(map[string]string{"a": "0", "b": "0"})
 	_, err = c.CreateWatch(req2, sub2, w2)
 	require.NoError(t, err)
 	mustBlock(t, w2)
@@ -444,7 +541,7 @@ func TestLinearWatchTwo(t *testing.T) {
 	require.NoError(t, c.UpdateResource("a", testResource("aa")))
 	// should only get the modified resource
 	verifyResponse(t, w1, "1", 1)
-	verifyResponse(t, w2, "1", 2)
+	verifyResponse(t, w2, "1", 1)
 }
 
 func TestLinearCancel(t *testing.T) {
@@ -455,6 +552,7 @@ func TestLinearCancel(t *testing.T) {
 	w1 := make(chan Response, 1)
 	req1 := &Request{TypeUrl: testType, VersionInfo: "1"}
 	sub1 := subFromRequest(req1)
+	sub1.SetReturnedResources(map[string]string{"a": "1"})
 	cancel, err := c.CreateWatch(req1, sub1, w1)
 	require.NoError(t, err)
 	mustBlock(t, w1)
@@ -481,13 +579,18 @@ func TestLinearCancel(t *testing.T) {
 	require.NoError(t, err)
 
 	req2 := &Request{ResourceNames: []string{"b"}, TypeUrl: testType, VersionInfo: "1"}
-	cancel2, err := c.CreateWatch(req2, subFromRequest(req2), w2)
+	sub2 := subFromRequest(req2)
+	cancel2, err := c.CreateWatch(req2, sub2, w2)
 	require.NoError(t, err)
 	req3 := &Request{TypeUrl: testType, VersionInfo: "1"}
-	cancel3, err := c.CreateWatch(req3, subFromRequest(req3), w3)
+	sub3 := subFromRequest(req3)
+	sub3.SetReturnedResources(map[string]string{"a": "1"})
+	cancel3, err := c.CreateWatch(req3, sub3, w3)
 	require.NoError(t, err)
 	req4 := &Request{TypeUrl: testType, VersionInfo: "1"}
-	cancel4, err := c.CreateWatch(req4, subFromRequest(req4), w4)
+	sub4 := subFromRequest(req4)
+	sub4.SetReturnedResources(map[string]string{"a": "1"})
+	cancel4, err := c.CreateWatch(req4, sub4, w4)
 	require.NoError(t, err)
 	mustBlock(t, w1)
 	mustBlock(t, w2)
@@ -831,7 +934,7 @@ func TestLinearDeltaMultiResourceUpdates(t *testing.T) {
 }
 
 func TestLinearMixedWatches(t *testing.T) {
-	c := NewLinearCache(testType)
+	c := NewLinearCache(resource.EndpointType, WithLogger(log.NewTestLogger(t)))
 	a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 	err := c.UpdateResource("a", a)
 	require.NoError(t, err)
@@ -842,9 +945,10 @@ func TestLinearMixedWatches(t *testing.T) {
 	assert.Equal(t, 2, c.NumResources())
 
 	w := make(chan Response, 1)
-	sotwReq := &Request{ResourceNames: []string{"a", "b"}, TypeUrl: testType, VersionInfo: c.getVersion()}
+	sotwReq := &Request{ResourceNames: []string{"a", "b"}, TypeUrl: resource.EndpointType, VersionInfo: c.getVersion()}
 	sotwSub := subFromRequest(sotwReq)
-	_, err = c.CreateWatch(sotwReq, subFromRequest(sotwReq), w)
+	sotwSub.SetReturnedResources(map[string]string{"a": "1", "b": "2"})
+	_, err = c.CreateWatch(sotwReq, sotwSub, w)
 	require.NoError(t, err)
 	mustBlock(t, w)
 	checkVersionMapNotSet(t, c)
@@ -856,7 +960,8 @@ func TestLinearMixedWatches(t *testing.T) {
 	err = c.UpdateResources(map[string]types.Resource{"a": a}, nil)
 	require.NoError(t, err)
 	// This behavior is currently invalid for cds and lds, but due to a current limitation of linear cache sotw implementation
-	verifyResponse(t, w, c.getVersion(), 1)
+	resp := verifyResponseResources(t, w, resource.EndpointType, c.getVersion(), "a")
+	updateFromSotwResponse(resp, &sotwSub, sotwReq)
 	checkVersionMapNotSet(t, c)
 
 	sotwReq.VersionInfo = c.getVersion()
@@ -865,7 +970,7 @@ func TestLinearMixedWatches(t *testing.T) {
 	mustBlock(t, w)
 	checkVersionMapNotSet(t, c)
 
-	deltaReq := &DeltaRequest{TypeUrl: testType, ResourceNamesSubscribe: []string{"a", "b"}, InitialResourceVersions: map[string]string{"a": hashA, "b": hashB}}
+	deltaReq := &DeltaRequest{TypeUrl: resource.EndpointType, ResourceNamesSubscribe: []string{"a", "b"}, InitialResourceVersions: map[string]string{"a": hashA, "b": hashB}}
 	wd := make(chan DeltaResponse, 1)
 
 	// Initial update
@@ -878,14 +983,13 @@ func TestLinearMixedWatches(t *testing.T) {
 	err = c.UpdateResources(nil, []string{"b"})
 	require.NoError(t, err)
 	checkVersionMapSet(t, c)
-
-	verifyResponse(t, w, c.getVersion(), 0)
-	verifyDeltaResponse(t, wd, nil, []string{"b"})
+	mustBlock(t, w) // For sotw with non full-state resources, we don't report deletions
+	verifyDeltaResponse(t, wd, nil, []string{"b"}, responseType(resource.EndpointType))
 }
 
 func TestLinearSotwWatches(t *testing.T) {
 	t.Run("watches are properly removed from all objects", func(t *testing.T) {
-		cache := NewLinearCache(testType)
+		cache := NewLinearCache(testType, WithLogger(log.NewTestLogger(t)))
 		a := &endpoint.ClusterLoadAssignment{ClusterName: "a"}
 		err := cache.UpdateResource("a", a)
 		require.NoError(t, err)
@@ -901,6 +1005,7 @@ func TestLinearSotwWatches(t *testing.T) {
 		w := make(chan Response, 1)
 		sotwReq := &Request{ResourceNames: []string{"a", "b", "c"}, TypeUrl: testType, VersionInfo: cache.getVersion()}
 		sotwSub := subFromRequest(sotwReq)
+		sotwSub.SetReturnedResources(map[string]string{"a": "1", "b": "2"})
 		_, err = cache.CreateWatch(sotwReq, sotwSub, w)
 		require.NoError(t, err)
 		mustBlock(t, w)
@@ -916,7 +1021,8 @@ func TestLinearSotwWatches(t *testing.T) {
 		}}
 		err = cache.UpdateResources(map[string]types.Resource{"a": a}, nil)
 		require.NoError(t, err)
-		verifyResponseResources(t, w, testType, cache.getVersion(), "a")
+		resp := verifyResponseResources(t, w, testType, cache.getVersion(), "a")
+		updateFromSotwResponse(resp, &sotwSub, sotwReq)
 		checkVersionMapNotSet(t, cache)
 
 		assert.Empty(t, cache.watches["a"])
@@ -926,8 +1032,7 @@ func TestLinearSotwWatches(t *testing.T) {
 		// c no longer watched
 		w = make(chan Response, 1)
 		sotwReq.ResourceNames = []string{"a", "b"}
-		sotwReq.VersionInfo = cache.getVersion()
-		sotwSub.SetResourceSubscription([]string{"a", "b"})
+		sotwSub.SetResourceSubscription(sotwReq.ResourceNames)
 		_, err = cache.CreateWatch(sotwReq, sotwSub, w)
 		require.NoError(t, err)
 		mustBlock(t, w)
@@ -943,13 +1048,13 @@ func TestLinearSotwWatches(t *testing.T) {
 		assert.Empty(t, cache.watches["c"])
 
 		require.NoError(t, err)
-		verifyResponseResources(t, w, testType, cache.getVersion(), "b")
+		resp = verifyResponseResources(t, w, testType, cache.getVersion(), "b")
+		updateFromSotwResponse(resp, &sotwSub, sotwReq)
 		checkVersionMapNotSet(t, cache)
 
 		w = make(chan Response, 1)
 		sotwReq.ResourceNames = []string{"c"}
-		sotwReq.VersionInfo = cache.getVersion()
-		sotwSub.SetResourceSubscription([]string{"c"})
+		sotwSub.SetResourceSubscription(sotwReq.ResourceNames)
 		_, err = cache.CreateWatch(sotwReq, sotwSub, w)
 		require.NoError(t, err)
 		mustBlock(t, w)
@@ -983,6 +1088,7 @@ func TestLinearSotwWatches(t *testing.T) {
 		// Non-wildcard request
 		nonWildcardReq := &Request{ResourceNames: []string{"a", "b", "d"}, TypeUrl: resource.ClusterType, VersionInfo: cache.getVersion()}
 		nonWildcardSub := subFromRequest(nonWildcardReq)
+		nonWildcardSub.SetReturnedResources(map[string]string{"a": cache.getVersion(), "b": cache.getVersion()})
 		w1 := make(chan Response, 1)
 		_, err := cache.CreateWatch(nonWildcardReq, nonWildcardSub, w1)
 		require.NoError(t, err)
@@ -992,6 +1098,7 @@ func TestLinearSotwWatches(t *testing.T) {
 		// wildcard request
 		wildcardReq := &Request{ResourceNames: nil, TypeUrl: resource.ClusterType, VersionInfo: cache.getVersion()}
 		wildcardSub := subFromRequest(wildcardReq)
+		wildcardSub.SetReturnedResources(map[string]string{"a": cache.getVersion(), "b": cache.getVersion(), "c": cache.getVersion()})
 		w2 := make(chan Response, 1)
 		_, err = cache.CreateWatch(wildcardReq, wildcardSub, w2)
 		require.NoError(t, err)
@@ -1001,6 +1108,7 @@ func TestLinearSotwWatches(t *testing.T) {
 		// request not requesting b
 		otherReq := &Request{ResourceNames: []string{"a", "c", "d"}, TypeUrl: resource.ClusterType, VersionInfo: cache.getVersion()}
 		otherSub := subFromRequest(otherReq)
+		otherSub.SetReturnedResources(map[string]string{"a": cache.getVersion(), "c": cache.getVersion()})
 		w3 := make(chan Response, 1)
 		_, err = cache.CreateWatch(otherReq, otherSub, w3)
 		require.NoError(t, err)
@@ -1014,17 +1122,18 @@ func TestLinearSotwWatches(t *testing.T) {
 		// Other watch has not triggered
 		mustBlock(t, w3)
 
-		verifyResponseResources(t, w1, resource.ClusterType, cache.getVersion(), "a", "b")      // a is also returned as cluster requires full state
-		verifyResponseResources(t, w2, resource.ClusterType, cache.getVersion(), "a", "b", "c") // a and c are also returned wildcard
+		resp1 := verifyResponseResources(t, w1, resource.ClusterType, cache.getVersion(), "a", "b") // a is also returned as cluster requires full state
+		updateFromSotwResponse(resp1, &nonWildcardSub, nonWildcardReq)
+		resp2 := verifyResponseResources(t, w2, resource.ClusterType, cache.getVersion(), "a", "b", "c") // a and c are also returned wildcard
+		updateFromSotwResponse(resp2, &wildcardSub, wildcardReq)
 
 		// Recreate the watches
 		w1 = make(chan Response, 1)
-		nonWildcardReq.VersionInfo = cache.getVersion()
 		_, err = cache.CreateWatch(nonWildcardReq, nonWildcardSub, w1)
 		require.NoError(t, err)
 		mustBlock(t, w1)
+
 		w2 = make(chan Response, 1)
-		wildcardReq.VersionInfo = cache.getVersion()
 		_, err = cache.CreateWatch(wildcardReq, wildcardSub, w2)
 		require.NoError(t, err)
 		mustBlock(t, w2)
@@ -1037,5 +1146,311 @@ func TestLinearSotwWatches(t *testing.T) {
 		verifyResponseResources(t, w1, resource.ClusterType, cache.getVersion(), "a", "b", "d")
 		verifyResponseResources(t, w2, resource.ClusterType, cache.getVersion(), "a", "b", "c", "d")
 		verifyResponseResources(t, w3, resource.ClusterType, cache.getVersion(), "a", "c", "d")
+	})
+}
+
+func TestLinearSotwNonWildcard(t *testing.T) {
+	var cache *LinearCache
+	resourceType := resource.EndpointType
+
+	reqs := make([]*discovery.DiscoveryRequest, 4)
+	subs := make([]stream.Subscription, 4)
+	watches := make([]chan Response, 4)
+
+	buildRequest := func(res []string, version string) *discovery.DiscoveryRequest {
+		return &discovery.DiscoveryRequest{
+			ResourceNames: res,
+			TypeUrl:       resourceType,
+			VersionInfo:   version,
+		}
+	}
+	updateReqResources := func(index int, res []string) {
+		t.Helper()
+		reqs[index-1].ResourceNames = res
+		subs[index-1].SetResourceSubscription(reqs[index-1].ResourceNames)
+	}
+
+	createWatchWithCancel := func(index int) func() {
+		t.Helper()
+		w := make(chan Response, 1)
+		cancel, err := cache.CreateWatch(reqs[index-1], subs[index-1], w)
+		require.NoError(t, err)
+		watches[index-1] = w
+		return cancel
+	}
+	createWatch := func(index int) {
+		t.Helper()
+		_ = createWatchWithCancel(index)
+	}
+	validateResponse := func(index int, res []string) {
+		t.Helper()
+		resp := verifyResponseResources(t, watches[index-1], resourceType, cache.getVersion(), res...)
+		updateFromSotwResponse(resp, &subs[index-1], reqs[index-1])
+	}
+	checkPendingWatch := func(index int) {
+		t.Helper()
+		mustBlock(t, watches[index-1])
+	}
+
+	// We run twice the same sequence of events,
+	// First run is for endpoints, currently not a full-state resource
+	// Second run is for clusters, currently a full-state resource
+	t.Run("type not returning full state", func(t *testing.T) {
+		resourceType := resource.EndpointType
+		buildEndpoint := func(name string) *endpoint.ClusterLoadAssignment {
+			return &endpoint.ClusterLoadAssignment{ClusterName: name}
+		}
+
+		cache = NewLinearCache(resourceType, WithLogger(log.NewTestLogger(t)), WithInitialResources(
+			map[string]types.Resource{
+				"a": buildEndpoint("a"),
+				"b": buildEndpoint("b"),
+				"c": buildEndpoint("c"),
+			},
+		))
+
+		// Create watches
+		// Watch 1, wildcard, starting with the current cache version
+		reqs[0] = buildRequest(nil, cache.getVersion())
+		subs[0] = subFromRequest(reqs[0])
+		// Watch 2, wildcard, starting with no version (https://github.com/envoyproxy/go-control-plane/issues/855)
+		reqs[1] = buildRequest([]string{"*"}, "")
+		subs[1] = subFromRequest(reqs[1])
+		// Watch 3, non-wildcard, starting with a different cache prefix
+		reqs[2] = buildRequest([]string{"a", "b"}, "prefix-"+cache.getVersion())
+		subs[2] = subFromRequest(reqs[2])
+		// Watch 4, non-wildcard, starting with no version
+		reqs[3] = buildRequest([]string{"d"}, "")
+		subs[3] = subFromRequest(reqs[3])
+
+		// Create watches
+		// Version is ignored as we cannot guarantee the state, so everything is returned
+		createWatch(1)
+		validateResponse(1, []string{"a", "b", "c"})
+		// Standard first wilcard request
+		createWatch(2)
+		validateResponse(2, []string{"a", "b", "c"})
+		// Version has a different prefix and we send everything requested
+		createWatch(3)
+		validateResponse(3, []string{"a", "b"})
+		// No requested version is available, so we return an empty response on first request
+		createWatch(4)
+		validateResponse(4, []string{})
+
+		// Recreate watches
+		createWatch(1)
+		checkPendingWatch(1)
+		createWatch(2)
+		checkPendingWatch(2)
+		createWatch(3)
+		checkPendingWatch(3)
+		createWatch(4)
+		checkPendingWatch(4)
+
+		// Update the cache
+		_ = cache.UpdateResources(map[string]types.Resource{
+			"b": buildEndpoint("b"),
+			"d": buildEndpoint("d"),
+		}, []string{"a"})
+
+		validateResponse(1, []string{"b", "d"})
+		validateResponse(2, []string{"b", "d"})
+		validateResponse(3, []string{"b"})
+		validateResponse(4, []string{"d"})
+
+		createWatch(1)
+		checkPendingWatch(1)
+		// Make watch 2 no longer wildcard
+		updateReqResources(2, []string{"a", "c", "d"})
+		c2 := createWatchWithCancel(2)
+		checkPendingWatch(2)
+		c3 := createWatchWithCancel(3)
+		checkPendingWatch(3)
+		// Add a resource to watch 4 (https://github.com/envoyproxy/go-control-plane/issues/608)
+		updateReqResources(4, []string{"c", "d"})
+		createWatch(4)
+		validateResponse(4, []string{"c"}) // c is newly requested, and should be returned
+		createWatch(4)
+		checkPendingWatch(4)
+
+		// Add a new resource not requested in all subscriptions
+		_ = cache.UpdateResource("e", buildEndpoint("e"))
+		validateResponse(1, []string{"e"})
+		createWatch(1)
+		checkPendingWatch(1)
+		checkPendingWatch(2) // No longer wildcard
+		checkPendingWatch(3)
+		checkPendingWatch(4)
+
+		// Cancel two watches to change resources
+		assert.Len(t, cache.watches["c"], 2)
+		c2()
+		assert.Len(t, cache.watches["c"], 1)
+		assert.Len(t, cache.watches["b"], 1)
+		c3()
+		assert.Empty(t, cache.watches["b"])
+
+		// Remove a resource from 2 (was a, c, d)
+		updateReqResources(2, []string{"a", "d"})
+		createWatch(2)
+		checkPendingWatch(2)
+
+		// 3 is now wildcard (was a, b). The version still matches the previous one
+		updateReqResources(3, []string{"*"})
+		createWatch(3)
+		validateResponse(3, []string{"c", "d", "e"})
+		createWatch(3)
+		checkPendingWatch(3)
+
+		// Do an update removing a resource only
+		// This type is not full update, and therefore does not return
+		_ = cache.UpdateResources(nil, []string{"c"})
+		checkPendingWatch(1)
+		checkPendingWatch(2)
+		checkPendingWatch(3)
+		checkPendingWatch(4)
+
+		// Do an update in the cache to confirm all is well
+		_ = cache.UpdateResources(map[string]types.Resource{
+			"a": buildEndpoint("a"),
+			"b": buildEndpoint("b"),
+		}, nil)
+		validateResponse(1, []string{"a", "b"})
+		validateResponse(2, []string{"a"})
+		validateResponse(3, []string{"a", "b"})
+		checkPendingWatch(4)
+	})
+
+	t.Run("type returning full state", func(t *testing.T) {
+		resourceType = resource.ClusterType
+		buildCluster := func(name string) *cluster.Cluster {
+			return &cluster.Cluster{Name: name}
+		}
+
+		cache = NewLinearCache(resource.ClusterType, WithLogger(log.NewTestLogger(t)), WithInitialResources(
+			map[string]types.Resource{
+				"a": buildCluster("a"),
+				"b": buildCluster("b"),
+				"c": buildCluster("c"),
+			},
+		))
+
+		// Create watches
+		// Watch 1, wildcard, starting with the current cache version
+		reqs[0] = buildRequest(nil, cache.getVersion())
+		subs[0] = subFromRequest(reqs[0])
+		// Watch 2, wildcard, starting with no version (https://github.com/envoyproxy/go-control-plane/issues/855)
+		reqs[1] = buildRequest([]string{"*"}, "")
+		subs[1] = subFromRequest(reqs[1])
+		// Watch 3, non-wildcard, starting with a different cache prefix
+		reqs[2] = buildRequest([]string{"a", "b"}, "prefix-"+cache.getVersion())
+		subs[2] = subFromRequest(reqs[2])
+		// Watch 4, non-wildcard, starting with no version
+		reqs[3] = buildRequest([]string{"d"}, "")
+		subs[3] = subFromRequest(reqs[3])
+
+		// Create watches
+		// Version is ignored as we cannot guarantee the state, so everything is returned
+		createWatch(1)
+		validateResponse(1, []string{"a", "b", "c"})
+		// Standard first wilcard request
+		createWatch(2)
+		validateResponse(2, []string{"a", "b", "c"})
+		// Version has a different prefix and we send everything requested
+		createWatch(3)
+		validateResponse(3, []string{"a", "b"})
+		// No requested version is available, so we return an empty response on first request
+		createWatch(4)
+		validateResponse(4, []string{})
+
+		// Recreate watches
+		createWatch(1)
+		checkPendingWatch(1)
+		createWatch(2)
+		checkPendingWatch(2)
+		createWatch(3)
+		checkPendingWatch(3)
+		createWatch(4)
+		checkPendingWatch(4)
+
+		// Update the cache
+		_ = cache.UpdateResources(map[string]types.Resource{
+			"b": buildCluster("b"),
+			"d": buildCluster("d"),
+		}, []string{"a"})
+
+		validateResponse(1, []string{"b", "c", "d"})
+		validateResponse(2, []string{"b", "c", "d"})
+		validateResponse(3, []string{"b"})
+		validateResponse(4, []string{"d"})
+
+		createWatch(1)
+		checkPendingWatch(1)
+		// Make watch 2 no longer wildcard
+		updateReqResources(2, []string{"a", "c", "d"})
+		c2 := createWatchWithCancel(2)
+		checkPendingWatch(2)
+		c3 := createWatchWithCancel(3)
+		checkPendingWatch(3)
+		// Add a resource to req4 (https://github.com/envoyproxy/go-control-plane/issues/608)
+		updateReqResources(4, []string{"c", "d"})
+		createWatch(4)
+		validateResponse(4, []string{"c", "d"}) // c is newly requested, and should be returned
+		createWatch(4)
+		checkPendingWatch(4)
+
+		// Add a new resource not request in all subscriptions
+		_ = cache.UpdateResource("e", buildCluster("e"))
+		validateResponse(1, []string{"b", "c", "d", "e"})
+		createWatch(1)
+		checkPendingWatch(1)
+		checkPendingWatch(2) // No longer wildcard
+		checkPendingWatch(3)
+		checkPendingWatch(4)
+
+		// Cancel two watches to change resources
+		assert.Len(t, cache.watches["c"], 2)
+		c2()
+		assert.Len(t, cache.watches["c"], 1)
+		assert.Len(t, cache.watches["b"], 1)
+		c3()
+		assert.Empty(t, cache.watches["b"])
+
+		// Remove a resource from 2 (was a, c, d)
+		updateReqResources(2, []string{"a", "d"})
+		createWatch(2)
+		checkPendingWatch(2)
+
+		// 3 is now wildcard (was a, b). The version still matches the previous one
+		updateReqResources(3, []string{"*"})
+		createWatch(3)
+		validateResponse(3, []string{"b", "c", "d", "e"})
+		createWatch(3)
+		checkPendingWatch(3)
+
+		// Do an update removing a resource only
+		// This type is not full update, and therefore does not return
+		_ = cache.UpdateResources(nil, []string{"c"})
+		validateResponse(1, []string{"b", "d", "e"})
+		checkPendingWatch(2)
+		validateResponse(3, []string{"b", "d", "e"})
+		validateResponse(4, []string{"d"})
+
+		createWatch(1)
+		checkPendingWatch(1)
+		createWatch(3)
+		checkPendingWatch(3)
+		createWatch(4)
+		checkPendingWatch(4)
+
+		// Do an update in the cache to confirm all is well
+		_ = cache.UpdateResources(map[string]types.Resource{
+			"a": buildCluster("a"),
+			"b": buildCluster("b"),
+		}, nil)
+		validateResponse(1, []string{"a", "b", "d", "e"})
+		validateResponse(2, []string{"a", "d"})
+		validateResponse(3, []string{"a", "b", "d", "e"})
+		checkPendingWatch(4)
 	})
 }

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -34,6 +34,7 @@ import (
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/log"
 	rsrc "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/server/stream/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
@@ -50,6 +51,19 @@ func (group) ID(node *core.Node) string {
 		return node.GetId()
 	}
 	return key
+}
+
+func subFromRequest(req *cache.Request) stream.Subscription {
+	return stream.NewSotwSubscription(req.GetResourceNames())
+}
+
+// This method represents the expected behavior of client and servers regarding the request and the subscription.
+// For edge cases it should ignore those
+func updateFromSotwResponse(resp cache.Response, sub *stream.Subscription, req *cache.Request) {
+	sub.SetReturnedResources(resp.GetReturnedResources())
+	// Never returns an error when not using passthrough responses
+	version, _ := resp.GetVersion()
+	req.VersionInfo = version
 }
 
 var (
@@ -87,34 +101,10 @@ var (
 	}
 )
 
-type logger struct {
-	t *testing.T
-}
-
-func (log logger) Debugf(format string, args ...interface{}) {
-	log.t.Helper()
-	log.t.Logf(format, args...)
-}
-
-func (log logger) Infof(format string, args ...interface{}) {
-	log.t.Helper()
-	log.t.Logf(format, args...)
-}
-
-func (log logger) Warnf(format string, args ...interface{}) {
-	log.t.Helper()
-	log.t.Logf(format, args...)
-}
-
-func (log logger) Errorf(format string, args ...interface{}) {
-	log.t.Helper()
-	log.t.Logf(format, args...)
-}
-
 func TestSnapshotCacheWithTTL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := cache.NewSnapshotCacheWithHeartbeating(ctx, true, group{}, logger{t: t}, time.Second)
+	c := cache.NewSnapshotCacheWithHeartbeating(ctx, true, group{}, log.NewTestLogger(t), time.Second)
 
 	_, err := c.GetSnapshot(key)
 	require.Errorf(t, err, "unexpected snapshot found for key %q", key)
@@ -129,12 +119,13 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 	// All the resources should respond immediately when version is not up to date.
 	subs := map[string]stream.Subscription{}
 	for _, typ := range testTypes {
-		sub := stream.NewSotwSubscription(names[typ])
 		wg.Add(1)
 		t.Run(typ, func(t *testing.T) {
 			defer wg.Done()
+			req := &discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}
+			sub := subFromRequest(req)
 			value := make(chan cache.Response, 1)
-			_, err = c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}, sub, value)
+			_, err = c.CreateWatch(req, sub, value)
 			require.NoError(t, err)
 			select {
 			case out := <-value:
@@ -142,12 +133,7 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 				assert.Equalf(t, gotVersion, fixture.version, "got version %q, want %q", gotVersion, fixture.version)
 				assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResourcesAndTTL(typ))
 
-				returnedResources := make(map[string]string)
-				// Update sub to track what was returned
-				for _, resource := range out.GetRequest().GetResourceNames() {
-					returnedResources[resource] = fixture.version
-				}
-				sub.SetReturnedResources(returnedResources)
+				updateFromSotwResponse(out, &sub, req)
 				subs[typ] = sub
 			case <-time.After(2 * time.Second):
 				t.Errorf("failed to receive snapshot response")
@@ -205,7 +191,7 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 }
 
 func TestSnapshotCache(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 
 	_, err := c.GetSnapshot(key)
 	require.Errorf(t, err, "unexpected snapshot found for key %q", key)
@@ -219,9 +205,9 @@ func TestSnapshotCache(t *testing.T) {
 	// try to get endpoints with incorrect list of names
 	// should not receive response
 	value := make(chan cache.Response, 1)
-	sub := stream.NewSotwSubscription([]string{"none"})
-	_, err = c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{"none"}},
-		sub, value)
+	req := &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{"none"}}
+	sub := subFromRequest(req)
+	_, err = c.CreateWatch(req, sub, value)
 	require.NoError(t, err)
 	select {
 	case out := <-value:
@@ -232,9 +218,9 @@ func TestSnapshotCache(t *testing.T) {
 	for _, typ := range testTypes {
 		t.Run(typ, func(t *testing.T) {
 			value := make(chan cache.Response, 1)
-			sub := stream.NewSotwSubscription(names[typ])
-			_, err = c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]},
-				sub, value)
+			req := &discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}
+			sub := subFromRequest(req)
+			_, err = c.CreateWatch(req, sub, value)
 			require.NoError(t, err)
 			select {
 			case out := <-value:
@@ -250,7 +236,7 @@ func TestSnapshotCache(t *testing.T) {
 }
 
 func TestSnapshotCacheFetch(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 	require.NoError(t, c.SetSnapshot(context.Background(), key, fixture.snapshot()))
 
 	for _, typ := range testTypes {
@@ -277,14 +263,15 @@ func TestSnapshotCacheFetch(t *testing.T) {
 }
 
 func TestSnapshotCacheWatch(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 	watches := make(map[string]chan cache.Response)
 	subs := map[string]stream.Subscription{}
 	for _, typ := range testTypes {
-		sub := stream.NewSotwSubscription(names[typ])
+		req := &discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}
+		sub := subFromRequest(req)
 		subs[typ] = sub
 		watches[typ] = make(chan cache.Response, 1)
-		_, err := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}, sub, watches[typ])
+		_, err := c.CreateWatch(req, sub, watches[typ])
 		require.NoError(t, err)
 	}
 
@@ -303,7 +290,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 					returnedResources[resource] = fixture.version
 				}
 				sub := subs[typ]
-				sub.SetReturnedResources(returnedResources)
+				updateFromSotwResponse(out, &sub, out.GetRequest())
 				subs[typ] = sub
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
@@ -340,7 +327,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 }
 
 func TestConcurrentSetWatch(t *testing.T) {
-	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(false, group{}, log.NewTestLogger(t))
 	for i := 0; i < 50; i++ {
 		i := i
 		t.Run(fmt.Sprintf("worker%d", i), func(t *testing.T) {
@@ -353,11 +340,11 @@ func TestConcurrentSetWatch(t *testing.T) {
 				err := c.SetSnapshot(context.Background(), id, &snap)
 				require.NoErrorf(t, err, "failed to set snapshot %q", id)
 			} else {
-				sub := stream.NewSotwSubscription(nil)
-				cancel, err := c.CreateWatch(&discovery.DiscoveryRequest{
+				req := &discovery.DiscoveryRequest{
 					Node:    &core.Node{Id: id},
 					TypeUrl: rsrc.EndpointType,
-				}, sub, value)
+				}
+				cancel, err := c.CreateWatch(req, subFromRequest(req), value)
 				require.NoError(t, err)
 				defer cancel()
 			}
@@ -366,11 +353,11 @@ func TestConcurrentSetWatch(t *testing.T) {
 }
 
 func TestSnapshotCacheWatchCancel(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 	for _, typ := range testTypes {
-		sub := stream.NewSotwSubscription(names[typ])
+		req := &discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}
 		value := make(chan cache.Response, 1)
-		cancel, err := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: typ, ResourceNames: names[typ]}, sub, value)
+		cancel, err := c.CreateWatch(req, subFromRequest(req), value)
 		require.NoError(t, err)
 		cancel()
 	}
@@ -387,13 +374,13 @@ func TestSnapshotCacheWatchCancel(t *testing.T) {
 }
 
 func TestSnapshotCacheWatchTimeout(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 
 	// Create a non-buffered channel that will block sends.
 	watchCh := make(chan cache.Response)
-	sub := stream.NewSotwSubscription(names[rsrc.EndpointType])
-	_, err := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: names[rsrc.EndpointType]},
-		sub, watchCh)
+	req := &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: names[rsrc.EndpointType]}
+	sub := subFromRequest(req)
+	_, err := c.CreateWatch(req, sub, watchCh)
 	require.NoError(t, err)
 
 	// The first time we set the snapshot without consuming from the blocking channel, so this should time out.
@@ -430,7 +417,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 	clusterName2 := "clusterName2"
 	routeName2 := "routeName2"
 	listenerName2 := "listenerName2"
-	c := cache.NewSnapshotCache(false, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(false, group{}, log.NewTestLogger(t))
 
 	snapshot2, _ := cache.NewSnapshot(fixture.version, map[rsrc.Type][]types.Resource{
 		rsrc.EndpointType:        {testEndpoint, resource.MakeEndpoint(clusterName2, 8080)},
@@ -446,8 +433,8 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 
 	// Request resource with name=ClusterName
 	go func() {
-		_, err := c.CreateWatch(&discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{clusterName}},
-			stream.NewSotwSubscription([]string{clusterName}), watch)
+		req := &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType, ResourceNames: []string{clusterName}}
+		_, err := c.CreateWatch(req, subFromRequest(req), watch)
 		require.NoError(t, err)
 	}()
 
@@ -463,12 +450,13 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 
 	// Request additional resource with name=clusterName2 for same version
 	go func() {
-		sub := stream.NewSotwSubscription([]string{clusterName, clusterName2})
-		sub.SetReturnedResources(map[string]string{clusterName: fixture.version})
-		_, err := c.CreateWatch(&discovery.DiscoveryRequest{
+		req := &discovery.DiscoveryRequest{
 			TypeUrl: rsrc.EndpointType, VersionInfo: fixture.version,
 			ResourceNames: []string{clusterName, clusterName2},
-		}, sub, watch)
+		}
+		sub := subFromRequest(req)
+		sub.SetReturnedResources(map[string]string{clusterName: fixture.version})
+		_, err := c.CreateWatch(req, sub, watch)
 		require.NoError(t, err)
 	}()
 
@@ -482,12 +470,13 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 	}
 
 	// Repeat request for with same version and make sure a watch is created
-	sub := stream.NewSotwSubscription([]string{clusterName, clusterName2})
-	sub.SetReturnedResources(map[string]string{clusterName: fixture.version, clusterName2: fixture.version})
-	cancel, err := c.CreateWatch(&discovery.DiscoveryRequest{
+	req := &discovery.DiscoveryRequest{
 		TypeUrl: rsrc.EndpointType, VersionInfo: fixture.version,
 		ResourceNames: []string{clusterName, clusterName2},
-	}, sub, watch)
+	}
+	sub := subFromRequest(req)
+	sub.SetReturnedResources(map[string]string{clusterName: fixture.version, clusterName2: fixture.version})
+	cancel, err := c.CreateWatch(req, sub, watch)
 	require.NoError(t, err)
 	if cancel == nil {
 		t.Fatal("Should create a watch")
@@ -497,8 +486,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 }
 
 func TestSnapshotClear(t *testing.T) {
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
-
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 	require.NoError(t, c.SetSnapshot(context.Background(), key, fixture.snapshot()))
 	c.ClearSnapshot(key)
 	assert.Nilf(t, c.GetStatusInfo(key), "cache should be cleared")
@@ -574,7 +562,7 @@ func TestSnapshotSingleResourceFetch(t *testing.T) {
 		return dst
 	}
 
-	c := cache.NewSnapshotCache(true, group{}, logger{t: t})
+	c := cache.NewSnapshotCache(true, group{}, log.NewTestLogger(t))
 	require.NoError(t, c.SetSnapshot(context.Background(), key, &singleResourceSnapshot{
 		version:  "version-one",
 		typeurl:  durationTypeURL,

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -90,6 +90,9 @@ type ResponseWatch struct {
 
 	// Response is the channel to push responses to.
 	Response chan Response
+
+	// Subscription stores the current client subscription state.
+	subscription Subscription
 }
 
 // DeltaResponseWatch is a watch record keeping both the delta request and an open channel for the delta response.

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -121,17 +121,7 @@ func (s *streamWrapper) send(resp cache.Response) error {
 	}
 
 	// Track in the type subcription the nonce and objects returned to the client.
-	version, err := resp.GetVersion()
-	if err != nil {
-		return err
-	}
-	// ToDo(valerian-roche): properly return the resources actually sent to the client
-	// Currently we set all resources requested, which is non-descriptive when using wildcard.
-	resources := make(map[string]string, len(resp.GetRequest().GetResourceNames()))
-	for _, r := range resp.GetRequest().GetResourceNames() {
-		resources[r] = version
-	}
-	w.sub.SetReturnedResources(resources)
+	w.sub.SetReturnedResources(resp.GetReturnedResources())
 	w.nonce = out.Nonce
 
 	// Register with the callbacks provided that we are sending the response.


### PR DESCRIPTION
This PR leverages the new `Subscription` interface passed into the `CreateWatch` method to properly track the resources returned as well as the evolution of the watch subscription. This allows a proper handling of resource re-subscription as well as semantics needed for the new wildcard mode

Fixes: #431 