### PR TITLE
[Linear cache] Increase mutualization between delta and sotw in linear cache to have behavior driven logic instead

### DIFF
--- a/pkg/cache/v3/cache.go
+++ b/pkg/cache/v3/cache.go
@@ -105,41 +105,67 @@ type Cache interface {
 
 // Response is a wrapper around Envoy's DiscoveryResponse.
 type Response interface {
-	// Get the Constructed DiscoveryResponse
+	// GetDiscoveryResponse returns the Constructed DiscoveryResponse.
 	GetDiscoveryResponse() (*discovery.DiscoveryResponse, error)
 
-	// Get the original Request for the Response.
+	// GetRequest returns the request that created the watch that we're now responding to.
+	// This is provided to allow the caller to correlate the response with a request.
+	// Generally this will be the latest request seen on the stream for the specific type.
 	GetRequest() *discovery.DiscoveryRequest
 
-	// Get the version in the Response.
+	// GetVersion returns the version in the Response.
+	// The version can be a property of the resources, allowing for optimizations in subsequent calls,
+	// or simply an internal property of the cache which can be used for debugging.
+	// The cache implementation should be able to determine if it can provide such optimization.
+	// Deprecated: use GetResponseVersion instead
 	GetVersion() (string, error)
+
+	// GetResponseVersion returns the version in the Response.
+	// The version can be a property of the resources, allowing for optimizations in subsequent calls,
+	// or simply an internal property of the cache which can be used for debugging.
+	// The cache implementation should be able to determine if it can provide such optimization.
+	GetResponseVersion() string
 
 	// GetReturnedResources returns the map of resources and their versions returned in the subscription.
 	// It may include more resources than directly set in the response to consider the full state of the client.
 	// The caller is expected to provide this unchanged to the next call to CreateWatch as part of the subscription.
 	GetReturnedResources() map[string]string
 
-	// Get the context provided during response creation.
+	// GetContext returns the context provided during response creation.
 	GetContext() context.Context
 }
 
-// DeltaResponse is a wrapper around Envoy's DeltaDiscoveryResponse
+// DeltaResponse is a wrapper around Envoy's DeltaDiscoveryResponse.
 type DeltaResponse interface {
-	// Get the constructed DeltaDiscoveryResponse
+	// GetDeltaDiscoveryResponse returns the constructed DeltaDiscoveryResponse.
 	GetDeltaDiscoveryResponse() (*discovery.DeltaDiscoveryResponse, error)
 
-	// Get the request that created the watch that we're now responding to. This is provided to allow the caller to correlate the
-	// response with a request. Generally this will be the latest request seen on the stream for the specific type.
+	// GetDeltaRequest returns the request that created the watch that we're now responding to.
+	// This is provided to allow the caller to correlate the response with a request.
+	// Generally this will be the latest request seen on the stream for the specific type.
 	GetDeltaRequest() *discovery.DeltaDiscoveryRequest
 
-	// Get the version in the DeltaResponse. This field is generally used for debugging purposes as noted by the Envoy documentation.
+	// GetSystemVersion returns the version in the DeltaResponse.
+	// The version in delta response is not indicative of the resources included,
+	// but an internal property of the cache which can be used for debugging.
+	// Deprecated: use GetResponseVersion instead
 	GetSystemVersion() (string, error)
 
-	// Get the version map of the internal cache.
-	// The version map consists of updated version mappings after this response is applied
+	// GetResponseVersion returns the version in the DeltaResponse.
+	// The version in delta response is not indicative of the resources included,
+	// but an internal property of the cache which can be used for debugging.
+	GetResponseVersion() string
+
+	// GetNextVersionMap provides the version map of the internal cache.
+	// The version map consists of updated version mappings after this response is applied.
+	// Deprecated: use GetReturnedResources instead
 	GetNextVersionMap() map[string]string
 
-	// Get the context provided during response creation
+	// GetReturnedResources provides the version map of the internal cache.
+	// The version map consists of updated version mappings after this response is applied.
+	GetReturnedResources() map[string]string
+
+	// GetContext returns the context provided during response creation.
 	GetContext() context.Context
 }
 
@@ -184,12 +210,12 @@ type RawDeltaResponse struct {
 	SystemVersionInfo string
 
 	// Resources to be included in the response.
-	Resources []types.Resource
+	Resources []types.ResourceWithTTL
 
 	// RemovedResources is a list of resource aliases which should be dropped by the consuming client.
 	RemovedResources []string
 
-	// NextVersionMap consists of updated version mappings after this response is applied
+	// NextVersionMap consists of updated version mappings after this response is applied.
 	NextVersionMap map[string]string
 
 	// Context provided at the time of response creation. This allows associating additional
@@ -291,8 +317,8 @@ func (r *RawDeltaResponse) GetDeltaDiscoveryResponse() (*discovery.DeltaDiscover
 		marshaledResources := make([]*discovery.Resource, len(r.Resources))
 
 		for i, resource := range r.Resources {
-			name := GetResourceName(resource)
-			marshaledResource, err := MarshalResource(resource)
+			name := GetResourceName(resource.Resource)
+			marshaledResource, err := MarshalResource(resource.Resource)
 			if err != nil {
 				return nil, err
 			}
@@ -331,23 +357,41 @@ func (r *RawResponse) GetContext() context.Context {
 	return r.Ctx
 }
 
-// GetDeltaRequest returns the original DeltaRequest
+// GetDeltaRequest returns the original DeltaRequest.
 func (r *RawDeltaResponse) GetDeltaRequest() *discovery.DeltaDiscoveryRequest {
 	return r.DeltaRequest
 }
 
 // GetVersion returns the response version.
+// Deprecated: use GetResponseVersion instead
 func (r *RawResponse) GetVersion() (string, error) {
-	return r.Version, nil
+	return r.GetResponseVersion(), nil
 }
 
-// GetSystemVersion returns the raw SystemVersion
+// GetResponseVersion returns the response version.
+func (r *RawResponse) GetResponseVersion() string {
+	return r.Version
+}
+
+// GetSystemVersion returns the raw SystemVersion.
+// Deprecated: use GetResponseVersion instead
 func (r *RawDeltaResponse) GetSystemVersion() (string, error) {
-	return r.SystemVersionInfo, nil
+	return r.GetResponseVersion(), nil
 }
 
-// NextVersionMap returns the version map which consists of updated version mappings after this response is applied
+// GetResponseVersion returns the response version.
+func (r *RawDeltaResponse) GetResponseVersion() string {
+	return r.SystemVersionInfo
+}
+
+// GetNextVersionMap returns the version map which consists of updated version mappings after this response is applied.
+// Deprecated: use GetReturnedResources instead
 func (r *RawDeltaResponse) GetNextVersionMap() map[string]string {
+	return r.GetReturnedResources()
+}
+
+// GetReturnedResources returns the version map which consists of updated version mappings after this response is applied.
+func (r *RawDeltaResponse) GetReturnedResources() map[string]string {
 	return r.NextVersionMap
 }
 
@@ -393,17 +437,18 @@ func (r *DeltaPassthroughResponse) GetDeltaDiscoveryResponse() (*discovery.Delta
 	return r.DeltaDiscoveryResponse, nil
 }
 
-// GetRequest returns the original Discovery Request
+// GetRequest returns the original Discovery Request.
 func (r *PassthroughResponse) GetRequest() *discovery.DiscoveryRequest {
 	return r.Request
 }
 
-// GetDeltaRequest returns the original Delta Discovery Request
+// GetDeltaRequest returns the original Delta Discovery Request.
 func (r *DeltaPassthroughResponse) GetDeltaRequest() *discovery.DeltaDiscoveryRequest {
 	return r.DeltaRequest
 }
 
 // GetVersion returns the response version.
+// Deprecated: use GetResponseVersion instead
 func (r *PassthroughResponse) GetVersion() (string, error) {
 	discoveryResponse, _ := r.GetDiscoveryResponse()
 	if discoveryResponse != nil {
@@ -412,11 +457,21 @@ func (r *PassthroughResponse) GetVersion() (string, error) {
 	return "", errors.New("DiscoveryResponse is nil")
 }
 
+// GetResponseVersion returns the response version, or empty if not set.
+func (r *PassthroughResponse) GetResponseVersion() string {
+	discoveryResponse, _ := r.GetDiscoveryResponse()
+	if discoveryResponse != nil {
+		return discoveryResponse.GetVersionInfo()
+	}
+	return ""
+}
+
 func (r *PassthroughResponse) GetContext() context.Context {
 	return r.ctx
 }
 
 // GetSystemVersion returns the response version.
+// Deprecated: use GetResponseVersion instead
 func (r *DeltaPassthroughResponse) GetSystemVersion() (string, error) {
 	deltaDiscoveryResponse, _ := r.GetDeltaDiscoveryResponse()
 	if deltaDiscoveryResponse != nil {
@@ -425,8 +480,23 @@ func (r *DeltaPassthroughResponse) GetSystemVersion() (string, error) {
 	return "", errors.New("DeltaDiscoveryResponse is nil")
 }
 
-// NextVersionMap returns the version map from a DeltaPassthroughResponse
+// GetResponseVersion returns the response version, or empty if not set.
+func (r *DeltaPassthroughResponse) GetResponseVersion() string {
+	deltaDiscoveryResponse, _ := r.GetDeltaDiscoveryResponse()
+	if deltaDiscoveryResponse != nil {
+		return deltaDiscoveryResponse.GetSystemVersionInfo()
+	}
+	return ""
+}
+
+// GetNextVersionMap returns the version map from a DeltaPassthroughResponse.
+// Deprecated: use GetReturnedResources instead
 func (r *DeltaPassthroughResponse) GetNextVersionMap() map[string]string {
+	return r.NextVersionMap
+}
+
+// GetReturnedResources returns the version map from a DeltaPassthroughResponse.
+func (r *DeltaPassthroughResponse) GetReturnedResources() map[string]string {
 	return r.NextVersionMap
 }
 

--- a/pkg/cache/v3/delta.go
+++ b/pkg/cache/v3/delta.go
@@ -29,14 +29,14 @@ type resourceContainer struct {
 func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscription, resources resourceContainer, cacheVersion string) *RawDeltaResponse {
 	// variables to build our response with
 	var nextVersionMap map[string]string
-	var filtered []types.Resource
+	var filtered []types.ResourceWithTTL
 	var toRemove []string
 
 	// If we are handling a wildcard request, we want to respond with all resources
 	switch {
 	case sub.IsWildcard():
 		if len(sub.ReturnedResources()) == 0 {
-			filtered = make([]types.Resource, 0, len(resources.resourceMap))
+			filtered = make([]types.ResourceWithTTL, 0, len(resources.resourceMap))
 		}
 		nextVersionMap = make(map[string]string, len(resources.resourceMap))
 		for name, r := range resources.resourceMap {
@@ -46,7 +46,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 			nextVersionMap[name] = version
 			prevVersion, found := sub.ReturnedResources()[name]
 			if !found || (prevVersion != version) {
-				filtered = append(filtered, r)
+				filtered = append(filtered, types.ResourceWithTTL{Resource: r})
 			}
 		}
 
@@ -66,7 +66,7 @@ func createDeltaResponse(ctx context.Context, req *DeltaRequest, sub Subscriptio
 			if r, ok := resources.resourceMap[name]; ok {
 				nextVersion := resources.versionMap[name]
 				if prevVersion != nextVersion {
-					filtered = append(filtered, r)
+					filtered = append(filtered, types.ResourceWithTTL{Resource: r})
 				}
 				nextVersionMap[name] = nextVersion
 			} else if found {

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
 )
 
-func assertResourceMapEqual(t *testing.T, want, got map[string]types.Resource) {
+func assertResourceMapEqual(t *testing.T, want, got map[string]types.ResourceWithTTL) {
 	t.Helper()
 
 	if !cmp.Equal(want, got, protocmp.Transform()) {
@@ -56,7 +56,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexRawResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResources(typ))
+				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
 				sub := subscriptions[typ]
 				sub.SetReturnedResources(out.GetNextVersionMap())
 				subscriptions[typ] = sub
@@ -104,7 +104,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
 		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
-		assertResourceMapEqual(t, cache.IndexRawResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResources(rsrc.EndpointType))
+		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
 		sub := subscriptions[testTypes[0]]
 		sub.SetReturnedResources(out.GetNextVersionMap())
 		subscriptions[testTypes[0]] = sub
@@ -140,7 +140,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexRawResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResources(typ))
+				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
 				nextVersionMap := out.GetNextVersionMap()
 				subscriptions[typ].SetReturnedResources(nextVersionMap)
 			case <-time.After(time.Second):
@@ -176,7 +176,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
 		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{})
-		assertResourceMapEqual(t, cache.IndexRawResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResources(rsrc.EndpointType))
+		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
 		nextVersionMap := out.GetNextVersionMap()
 
 		// make sure the version maps are different since we no longer are tracking any endpoint resources

--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -69,22 +69,29 @@ func (c *cachedResource) getVersion(useStableVersion bool) (string, error) {
 	return c.getStableVersion()
 }
 
-type watches struct {
-	// sotw keeps track of current sotw watches, indexed per watch id.
-	sotw map[uint64]ResponseWatch
-	// delta keeps track of current delta watches, indexed per watch id.
-	delta map[uint64]DeltaResponseWatch
+type watch interface {
+	// isDelta indicates whether the watch is a delta one.
+	// It should not be used to take functional decisions, but is still currently used pending final changes.
+	// It can be used to generate statistics.
+	isDelta() bool
+	// useStableVersion indicates whether versions returned in the response are built using stable versions instead of cache update versions.
+	useStableVersion() bool
+	// sendFullStateResponses requires that all resources matching the request, with no regards to which ones actually updated, must be provided in the response.
+	// As a consequence, sending a response with no resources has a functional meaning of no matching resources available.
+	sendFullStateResponses() bool
+
+	getSubscription() Subscription
+	// buildResponse computes the actual WatchResponse object to be sent on the watch.
+	buildResponse(updatedResources []types.ResourceWithTTL, removedResources []string, returnedVersions map[string]string, version string) WatchResponse
+	// sendResponse sends the response for the watch.
+	// It must be called at most once.
+	sendResponse(resp WatchResponse)
 }
+
+type watches map[uint64]watch
 
 func newWatches() watches {
-	return watches{
-		sotw:  make(map[uint64]ResponseWatch),
-		delta: make(map[uint64]DeltaResponseWatch),
-	}
-}
-
-func (w *watches) empty() bool {
-	return len(w.sotw)+len(w.delta) == 0
+	return make(watches)
 }
 
 // LinearCache supports collections of opaque resources. This cache has a
@@ -115,6 +122,8 @@ type LinearCache struct {
 	// versionPrefix is used to modify the version returned to clients, and can be used to uniquely identify
 	// cache instances and avoid issues of version reuse.
 	versionPrefix string
+
+	watchCount int
 
 	log log.Logger
 
@@ -166,9 +175,8 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 	for _, opt := range opts {
 		opt(out)
 	}
-	for name, resource := range out.resources {
+	for _, resource := range out.resources {
 		resource.cacheVersion = out.getVersion()
-		out.resources[name] = resource
 	}
 	return out
 }
@@ -176,21 +184,14 @@ func NewLinearCache(typeURL string, opts ...LinearCacheOption) *LinearCache {
 // computeResourceChange compares the subscription known resources and the cache current state to compute the list of resources
 // which have changed and should be notified to the user.
 //
-// The alwaysConsiderAllResources argument removes the consideration of the subscription known resources (e.g. if the version did not match),
-// and return all known subscribed resources.
-//
 // The useStableVersion argument defines what version type to use for resources:
 //   - if set to false versions are based on when resources were updated in the cache.
 //   - if set to true versions are a stable property of the resource, with no regard to when it was added to the cache.
-func (cache *LinearCache) computeResourceChange(sub Subscription, alwaysConsiderAllResources, useStableVersion bool) (updated, removed []string, err error) {
+func (cache *LinearCache) computeResourceChange(sub Subscription, useStableVersion bool) (updated, removed []string, err error) {
 	var changedResources []string
 	var removedResources []string
 
 	knownVersions := sub.ReturnedResources()
-	if alwaysConsiderAllResources {
-		// The response will include all resources, with no regards of resources potentially already returned.
-		knownVersions = make(map[string]string)
-	}
 
 	if sub.IsWildcard() {
 		for resourceName, resource := range cache.resources {
@@ -258,13 +259,14 @@ func (cache *LinearCache) computeResourceChange(sub Subscription, alwaysConsider
 	return changedResources, removedResources, nil
 }
 
-func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConsiderAllResources bool) (*RawResponse, error) {
-	changedResources, removedResources, err := cache.computeResourceChange(watch.subscription, alwaysConsiderAllResources, false)
+func (cache *LinearCache) computeResponse(watch watch, replyEvenIfEmpty bool) (WatchResponse, error) {
+	sub := watch.getSubscription()
+	changedResources, removedResources, err := cache.computeResourceChange(sub, watch.useStableVersion())
 	if err != nil {
 		return nil, err
 	}
 
-	if len(changedResources) == 0 && len(removedResources) == 0 && !alwaysConsiderAllResources {
+	if len(changedResources) == 0 && len(removedResources) == 0 && !replyEvenIfEmpty {
 		// Nothing changed.
 		return nil, nil
 	}
@@ -277,8 +279,9 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 	switch {
 	// For lds and cds, answers will always include all existing subscribed resources, with no regard to which resource was changed or removed.
 	// For other types, the response only includes updated resources (sotw cannot notify for deletion).
-	case !ResourceRequiresFullStateInSotw(cache.typeURL):
-		if !alwaysConsiderAllResources && len(changedResources) == 0 {
+	case !watch.sendFullStateResponses():
+		// TODO(valerian-roche): remove this leak of delta/sotw behavior here.
+		if !watch.isDelta() && !replyEvenIfEmpty && len(changedResources) == 0 {
 			// If the request is not the initial one, and the type does not require full updates,
 			// do not return if nothing is to be set.
 			// For full-state resources an empty response does have a semantic meaning.
@@ -287,7 +290,7 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 		// changedResources is already filtered based on the subscription.
 		resourcesToReturn = changedResources
 
-	case watch.subscription.IsWildcard():
+	case sub.IsWildcard():
 		// Include all resources for the type.
 		resourcesToReturn = make([]string, 0, len(cache.resources))
 		for resourceName := range cache.resources {
@@ -296,7 +299,7 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 
 	default:
 		// Include all resources matching the subscription, with no concern on whether it has been updated or not.
-		requestedResources := watch.subscription.SubscribedResources()
+		requestedResources := sub.SubscribedResources()
 		// The linear cache could be very large (e.g. containing all potential CLAs)
 		// Therefore drives on the subscription requested resources.
 		resourcesToReturn = make([]string, 0, len(requestedResources))
@@ -309,13 +312,13 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 
 	// returnedVersions includes all resources currently known to the subscription and their version.
 	// Clone the current returned versions. The cache should not alter the subscription
-	returnedVersions := maps.Clone(watch.subscription.ReturnedResources())
+	returnedVersions := maps.Clone(sub.ReturnedResources())
 
 	resources := make([]types.ResourceWithTTL, 0, len(resourcesToReturn))
 	for _, resourceName := range resourcesToReturn {
 		cachedResource := cache.resources[resourceName]
 		resources = append(resources, types.ResourceWithTTL{Resource: cachedResource.Resource})
-		version, err := cachedResource.getVersion(false)
+		version, err := cachedResource.getVersion(watch.useStableVersion())
 		if err != nil {
 			return nil, fmt.Errorf("failed to compute version of %s: %w", resourceName, err)
 		}
@@ -329,122 +332,42 @@ func (cache *LinearCache) computeSotwResponse(watch ResponseWatch, alwaysConside
 		delete(returnedVersions, resourceName)
 	}
 
-	return &RawResponse{
-		Request:           watch.Request,
-		Resources:         resources,
-		ReturnedResources: returnedVersions,
-		Version:           cache.getVersion(),
-		Ctx:               context.Background(),
-	}, nil
-}
-
-func (cache *LinearCache) computeDeltaResponse(watch DeltaResponseWatch) (*RawDeltaResponse, error) {
-	changedResources, removedResources, err := cache.computeResourceChange(watch.subscription, false, true)
-	if err != nil {
-		return nil, err
-	}
-
-	// On first request on a wildcard subscription, envoy does expect a response to come in to
-	// conclude initialization.
-	isFirstWildcardRequest := watch.subscription.IsWildcard() && watch.Request.GetResponseNonce() == ""
-	if len(changedResources) == 0 && len(removedResources) == 0 && !isFirstWildcardRequest {
-		// Nothing changed.
-		return nil, nil
-	}
-
-	// Clone the current returned versions. The cache should not alter the subscription
-	returnedVersions := maps.Clone(watch.subscription.ReturnedResources())
-
-	cacheVersion := cache.getVersion()
-	resources := make([]types.Resource, 0, len(changedResources))
-	for _, resourceName := range changedResources {
-		resource := cache.resources[resourceName]
-		resources = append(resources, resource.Resource)
-		version, err := resource.getStableVersion()
-		if err != nil {
-			return nil, fmt.Errorf("failed to compute stable version of %s: %w", resourceName, err)
-		}
-		returnedVersions[resourceName] = version
-	}
-	// Cleanup resources no longer existing in the cache or no longer subscribed.
-	for _, resourceName := range removedResources {
-		delete(returnedVersions, resourceName)
-	}
-
-	return &RawDeltaResponse{
-		DeltaRequest:      watch.Request,
-		Resources:         resources,
-		RemovedResources:  removedResources,
-		NextVersionMap:    returnedVersions,
-		SystemVersionInfo: cacheVersion,
-		Ctx:               context.Background(),
-	}, nil
+	return watch.buildResponse(resources, removedResources, returnedVersions, cache.getVersion()), nil
 }
 
 func (cache *LinearCache) notifyAll(modified []string) error {
 	// Gather the list of watches impacted by the modified resources.
-	sotwWatches := make(map[uint64]ResponseWatch)
-	deltaWatches := make(map[uint64]DeltaResponseWatch)
+	resourceWatches := newWatches()
 	for _, name := range modified {
-		maps.Copy(sotwWatches, cache.resourceWatches[name].sotw)
-		maps.Copy(deltaWatches, cache.resourceWatches[name].delta)
+		maps.Copy(resourceWatches, cache.resourceWatches[name])
 	}
 
-	// sotw watches
-	for watchID, watch := range sotwWatches {
-		response, err := cache.computeSotwResponse(watch, false)
+	// non-wildcard watches
+	for watchID, watch := range resourceWatches {
+		response, err := cache.computeResponse(watch, false)
 		if err != nil {
 			return err
 		}
 
 		if response != nil {
-			watch.Response <- response
-			cache.removeWatch(watchID, watch.subscription)
+			watch.sendResponse(response)
+			cache.removeWatch(watchID, watch.getSubscription())
 		} else {
 			cache.log.Infof("[Linear cache] Watch %d detected as triggered but no change was found", watchID)
 		}
 	}
 
-	for watchID, watch := range cache.wildcardWatches.sotw {
-		response, err := cache.computeSotwResponse(watch, false)
+	for watchID, watch := range cache.wildcardWatches {
+		response, err := cache.computeResponse(watch, false)
 		if err != nil {
 			return err
 		}
 
 		if response != nil {
-			watch.Response <- response
-			delete(cache.wildcardWatches.sotw, watchID)
+			watch.sendResponse(response)
+			cache.removeWildcardWatch(watchID)
 		} else {
 			cache.log.Infof("[Linear cache] Wildcard watch %d detected as triggered but no change was found", watchID)
-		}
-	}
-
-	// delta watches
-	for watchID, watch := range deltaWatches {
-		response, err := cache.computeDeltaResponse(watch)
-		if err != nil {
-			return err
-		}
-
-		if response != nil {
-			watch.Response <- response
-			cache.removeDeltaWatch(watchID, watch.subscription)
-		} else {
-			cache.log.Infof("[Linear cache] Delta watch %d detected as triggered but no change was found", watchID)
-		}
-	}
-
-	for watchID, watch := range cache.wildcardWatches.delta {
-		response, err := cache.computeDeltaResponse(watch)
-		if err != nil {
-			return err
-		}
-
-		if response != nil {
-			watch.Response <- response
-			delete(cache.wildcardWatches.delta, watchID)
-		} else {
-			cache.log.Infof("[Linear cache] Wildcard delta watch %d detected as triggered but no change was found", watchID)
 		}
 	}
 
@@ -553,10 +476,10 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 
 	// If the request does not include a version the client considers it has no current state.
 	// In this case we will always reply to allow proper initialization of dependencies in the client.
-	ignoreCurrentSubscriptionResources := request.GetVersionInfo() == ""
+	replyEvenIfEmpty := request.GetVersionInfo() == ""
 	if !strings.HasPrefix(request.GetVersionInfo(), cache.versionPrefix) {
 		// If the version of the request does not match the cache prefix, we will send a response in all cases to match the legacy behavior.
-		ignoreCurrentSubscriptionResources = true
+		replyEvenIfEmpty = true
 		cache.log.Debugf("[linear cache] received watch with version %s not matching the cache prefix %s. Will return all known resources", request.GetVersionInfo(), cache.versionPrefix)
 	}
 
@@ -571,60 +494,27 @@ func (cache *LinearCache) CreateWatch(request *Request, sub Subscription, value 
 	// For now it is not done as:
 	//  - for the first case, while the protocol documentation does not explicitly mention the case, it does not mark it impossible and explicitly references unsubscribing from wildcard.
 	//  - for the second one we could likely do it with little difficulty if need be, but if users rely on the current monotonic version it could impact their callbacks implementations.
-	watch := ResponseWatch{Request: request, Response: value, subscription: sub}
+	watch := ResponseWatch{
+		Request:            request,
+		Response:           value,
+		subscription:       sub,
+		fullStateResponses: ResourceRequiresFullStateInSotw(cache.typeURL),
+	}
 
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	response, err := cache.computeSotwResponse(watch, ignoreCurrentSubscriptionResources)
+	response, err := cache.computeResponse(watch, replyEvenIfEmpty)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute the watch respnse: %w", err)
 	}
 	if response != nil {
 		cache.log.Debugf("[linear cache] replying to the watch with resources %v (subscription values %v, known %v)", response.GetReturnedResources(), sub.SubscribedResources(), sub.ReturnedResources())
-		watch.Response <- response
+		watch.sendResponse(response)
 		return func() {}, nil
 	}
 
-	watchID := cache.nextWatchID()
-	// Create open watches since versions are up to date.
-	if sub.IsWildcard() {
-		cache.log.Infof("[linear cache] open watch %d for all %s resources, system version %q", watchID, cache.typeURL, cache.getVersion())
-		cache.wildcardWatches.sotw[watchID] = watch
-		return func() {
-			cache.mu.Lock()
-			defer cache.mu.Unlock()
-			delete(cache.wildcardWatches.sotw, watchID)
-		}, nil
-	}
-
-	cache.log.Infof("[linear cache] open watch %d for %s resources %v, system version %q", watchID, cache.typeURL, sub.SubscribedResources(), cache.getVersion())
-	for name := range sub.SubscribedResources() {
-		watches, exists := cache.resourceWatches[name]
-		if !exists {
-			watches = newWatches()
-			cache.resourceWatches[name] = watches
-		}
-		watches.sotw[watchID] = watch
-	}
-	return func() {
-		cache.mu.Lock()
-		defer cache.mu.Unlock()
-		cache.removeWatch(watchID, watch.subscription)
-	}, nil
-}
-
-// Must be called under lock
-func (cache *LinearCache) removeWatch(watchID uint64, sub Subscription) {
-	// Make sure we clean the watch for ALL resources it might be associated with,
-	// as the channel will no longer be listened to
-	for resource := range sub.SubscribedResources() {
-		resourceWatches := cache.resourceWatches[resource]
-		delete(resourceWatches.sotw, watchID)
-		if resourceWatches.empty() {
-			delete(cache.resourceWatches, resource)
-		}
-	}
+	return cache.trackWatch(watch), nil
 }
 
 func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, sub Subscription, value chan DeltaResponse) (func(), error) {
@@ -634,63 +524,25 @@ func (cache *LinearCache) CreateDeltaWatch(request *DeltaRequest, sub Subscripti
 
 	watch := DeltaResponseWatch{Request: request, Response: value, subscription: sub}
 
+	// On first request on a wildcard subscription, envoy does expect a response to come in to
+	// conclude initialization.
+	replyEvenIfEmpty := sub.IsWildcard() && request.GetResponseNonce() == ""
+
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	response, err := cache.computeDeltaResponse(watch)
+	response, err := cache.computeResponse(watch, replyEvenIfEmpty)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute the watch respnse: %w", err)
 	}
 
 	if response != nil {
 		cache.log.Debugf("[linear cache] replying to the delta watch (subscription values %v, known %v)", sub.SubscribedResources(), sub.ReturnedResources())
-		watch.Response <- response
+		watch.sendResponse(response)
 		return nil, nil
 	}
 
-	watchID := cache.nextWatchID()
-	// Create open watches since versions are up to date.
-	if sub.IsWildcard() {
-		cache.log.Infof("[linear cache] open delta watch %d for all %s resources, system version %q", watchID, cache.typeURL, cache.getVersion())
-		cache.wildcardWatches.delta[watchID] = watch
-		return func() {
-			cache.mu.Lock()
-			defer cache.mu.Unlock()
-			delete(cache.wildcardWatches.delta, watchID)
-		}, nil
-	}
-
-	cache.log.Infof("[linear cache] open delta watch %d for %s resources %v, system version %q", watchID, cache.typeURL, sub.SubscribedResources(), cache.getVersion())
-	for name := range sub.SubscribedResources() {
-		watches, exists := cache.resourceWatches[name]
-		if !exists {
-			watches = newWatches()
-			cache.resourceWatches[name] = watches
-		}
-		watches.delta[watchID] = watch
-	}
-	return func() {
-		cache.mu.Lock()
-		defer cache.mu.Unlock()
-		cache.removeDeltaWatch(watchID, watch.subscription)
-	}, nil
-}
-
-func (cache *LinearCache) getVersion() string {
-	return cache.versionPrefix + strconv.FormatUint(cache.version, 10)
-}
-
-// cancellation function for cleaning stale watches
-func (cache *LinearCache) removeDeltaWatch(watchID uint64, sub Subscription) {
-	// Make sure we clean the watch for ALL resources it might be associated with,
-	// as the channel will no longer be listened to
-	for resource := range sub.SubscribedResources() {
-		resourceWatches := cache.resourceWatches[resource]
-		delete(resourceWatches.delta, watchID)
-		if resourceWatches.empty() {
-			delete(cache.resourceWatches, resource)
-		}
-	}
+	return cache.trackWatch(watch), nil
 }
 
 func (cache *LinearCache) nextWatchID() uint64 {
@@ -699,6 +551,65 @@ func (cache *LinearCache) nextWatchID() uint64 {
 		panic("watch id count overflow")
 	}
 	return cache.currentWatchID
+}
+
+// Must be called under lock
+func (cache *LinearCache) trackWatch(watch watch) func() {
+	cache.watchCount++
+
+	watchID := cache.nextWatchID()
+	sub := watch.getSubscription()
+
+	if sub.IsWildcard() {
+		cache.log.Infof("[linear cache] open watch %d for %s all resources", watchID, cache.typeURL)
+		cache.log.Debugf("[linear cache] subscription details for watch %d: known versions %v, system version %q", watchID, sub.ReturnedResources(), cache.getVersion())
+		cache.wildcardWatches[watchID] = watch
+		return func() {
+			cache.mu.Lock()
+			defer cache.mu.Unlock()
+			cache.removeWildcardWatch(watchID)
+		}
+	}
+
+	cache.log.Infof("[linear cache] open watch %d for %s resources %v", watchID, cache.typeURL, sub.SubscribedResources())
+	cache.log.Debugf("[linear cache] subscription details for watch %d: known versions %v, system version %q", watchID, sub.ReturnedResources(), cache.getVersion())
+	for name := range sub.SubscribedResources() {
+		watches, exists := cache.resourceWatches[name]
+		if !exists {
+			watches = newWatches()
+			cache.resourceWatches[name] = watches
+		}
+		watches[watchID] = watch
+	}
+	return func() {
+		cache.mu.Lock()
+		defer cache.mu.Unlock()
+		cache.removeWatch(watchID, sub)
+	}
+}
+
+// Must be called under lock
+func (cache *LinearCache) removeWildcardWatch(watchID uint64) {
+	cache.watchCount--
+	delete(cache.wildcardWatches, watchID)
+}
+
+// Must be called under lock
+func (cache *LinearCache) removeWatch(watchID uint64, sub Subscription) {
+	// Make sure we clean the watch for ALL resources it might be associated with,
+	// as the channel will no longer be listened to
+	for resource := range sub.SubscribedResources() {
+		resourceWatches := cache.resourceWatches[resource]
+		delete(resourceWatches, watchID)
+		if len(resourceWatches) == 0 {
+			delete(cache.resourceWatches, resource)
+		}
+	}
+	cache.watchCount--
+}
+
+func (cache *LinearCache) getVersion() string {
+	return cache.versionPrefix + strconv.FormatUint(cache.version, 10)
 }
 
 func (cache *LinearCache) Fetch(context.Context, *Request) (Response, error) {
@@ -713,30 +624,23 @@ func (cache *LinearCache) NumResources() int {
 	return len(cache.resources)
 }
 
-// NumWatches returns the number of active sotw watches for a resource name.
-func (cache *LinearCache) NumSotwWatches(name string) int {
+// NumWatches returns the number of active watches for a resource name, including wildcard ones.
+func (cache *LinearCache) NumWatches(name string) int {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
-	return len(cache.resourceWatches[name].sotw) + len(cache.wildcardWatches.sotw)
+	return len(cache.resourceWatches[name]) + len(cache.wildcardWatches)
 }
 
-// NumDeltaWatchesForResource returns the number of active delta watches for a resource name.
-func (cache *LinearCache) NumDeltaWatchesForResource(name string) int {
+// NumWildcardWatches returns the number of wildcard watches.
+func (cache *LinearCache) NumWildcardWatches() int {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
-	return len(cache.resourceWatches[name].delta) + len(cache.wildcardWatches.delta)
+	return len(cache.wildcardWatches)
 }
 
-// NumDeltaWatches returns the total number of active delta watches.
-// Warning: it is quite inefficient, and NumDeltaWatchesForResource should be preferred.
-func (cache *LinearCache) NumDeltaWatches() int {
+// NumCacheWatches returns the number of active watches on the cache in general.
+func (cache *LinearCache) NumCacheWatches() int {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()
-	uniqueWatches := map[uint64]struct{}{}
-	for _, watches := range cache.resourceWatches {
-		for id := range watches.delta {
-			uniqueWatches[id] = struct{}{}
-		}
-	}
-	return len(uniqueWatches) + len(cache.wildcardWatches.delta)
+	return cache.watchCount
 }

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -116,10 +116,10 @@ func ResourceRequiresFullStateInSotw(typeURL resource.Type) bool {
 }
 
 // GetResourceName returns the resource names for a list of valid xDS response types.
-func GetResourceNames(resources []types.Resource) []string {
+func GetResourceNames(resources []types.ResourceWithTTL) []string {
 	out := make([]string, len(resources))
 	for i, r := range resources {
-		out[i] = GetResourceName(r)
+		out[i] = GetResourceName(r.Resource)
 	}
 	return out
 }

--- a/pkg/cache/v3/resource_test.go
+++ b/pkg/cache/v3/resource_test.go
@@ -117,17 +117,17 @@ func TestGetResourceName(t *testing.T) {
 func TestGetResourceNames(t *testing.T) {
 	tests := []struct {
 		name  string
-		input []types.Resource
+		input []types.ResourceWithTTL
 		want  []string
 	}{
 		{
 			name:  "empty",
-			input: []types.Resource{},
+			input: []types.ResourceWithTTL{},
 			want:  []string{},
 		},
 		{
 			name:  "many",
-			input: []types.Resource{testRuntime, testListener, testListenerDefault, testVirtualHost},
+			input: []types.ResourceWithTTL{{Resource: testRuntime}, {Resource: testListener}, {Resource: testListenerDefault}, {Resource: testVirtualHost}},
 			want:  []string{runtimeName, listenerName, listenerName, virtualHostName},
 		},
 	}

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -413,7 +413,7 @@ func (cache *snapshotCache) CreateWatch(request *Request, sub Subscription, valu
 		return cache.cancelWatch(nodeID, watchID)
 	}
 
-	watch := ResponseWatch{Request: request, Response: value, subscription: sub}
+	watch := ResponseWatch{Request: request, Response: value, subscription: sub, fullStateResponses: ResourceRequiresFullStateInSotw(request.GetTypeUrl())}
 
 	snapshot, exists := cache.snapshots[nodeID]
 	if !exists {

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -15,11 +15,13 @@
 package cache
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 // NodeHash computes string identifiers for Envoy nodes.
@@ -83,6 +85,11 @@ type statusInfo struct {
 	mu sync.RWMutex
 }
 
+type WatchResponse interface {
+	GetReturnedResources() map[string]string
+	GetResponseVersion() string
+}
+
 // ResponseWatch is a watch record keeping both the request and an open channel for the response.
 type ResponseWatch struct {
 	// Request is the original request for the watch.
@@ -93,6 +100,39 @@ type ResponseWatch struct {
 
 	// Subscription stores the current client subscription state.
 	subscription Subscription
+
+	// fullStateResponses requires that all resources matching the request, with no regards to which ones actually updated, must be provided in the response.
+	fullStateResponses bool
+}
+
+func (w ResponseWatch) isDelta() bool {
+	return false
+}
+
+func (w ResponseWatch) useStableVersion() bool {
+	return false
+}
+
+func (w ResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, _ []string, returnedVersions map[string]string, version string) WatchResponse {
+	return &RawResponse{
+		Request:           w.Request,
+		Resources:         updatedResources,
+		ReturnedResources: returnedVersions,
+		Version:           version,
+		Ctx:               context.Background(),
+	}
+}
+
+func (w ResponseWatch) sendFullStateResponses() bool {
+	return w.fullStateResponses
+}
+
+func (w ResponseWatch) getSubscription() Subscription {
+	return w.subscription
+}
+
+func (w ResponseWatch) sendResponse(resp WatchResponse) {
+	w.Response <- resp.(*RawResponse)
 }
 
 // DeltaResponseWatch is a watch record keeping both the delta request and an open channel for the delta response.
@@ -105,6 +145,37 @@ type DeltaResponseWatch struct {
 
 	// Subscription stores the current client subscription state.
 	subscription Subscription
+}
+
+func (w DeltaResponseWatch) isDelta() bool {
+	return true
+}
+
+func (w DeltaResponseWatch) useStableVersion() bool {
+	return true
+}
+
+func (w DeltaResponseWatch) sendFullStateResponses() bool {
+	return false
+}
+
+func (w DeltaResponseWatch) getSubscription() Subscription {
+	return w.subscription
+}
+
+func (w DeltaResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
+	return &RawDeltaResponse{
+		DeltaRequest:      w.Request,
+		Resources:         updatedResources,
+		RemovedResources:  removedResources,
+		NextVersionMap:    returnedVersions,
+		SystemVersionInfo: version,
+		Ctx:               context.Background(),
+	}
+}
+
+func (w DeltaResponseWatch) sendResponse(resp WatchResponse) {
+	w.Response <- resp.(*RawDeltaResponse)
 }
 
 // newStatusInfo initializes a status info data structure.

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -34,14 +34,14 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 		versionMap[name] = cache.HashResource(marshaledResource)
 	}
 	var nextVersionMap map[string]string
-	var filtered []types.Resource
+	var filtered []types.ResourceWithTTL
 	var toRemove []string
 
 	// If we are handling a wildcard request, we want to respond with all resources
 	switch {
 	case sub.IsWildcard():
 		if len(sub.ReturnedResources()) == 0 {
-			filtered = make([]types.Resource, 0, len(resourceMap))
+			filtered = make([]types.ResourceWithTTL, 0, len(resourceMap))
 		}
 		nextVersionMap = make(map[string]string, len(resourceMap))
 		for name, r := range resourceMap {
@@ -51,7 +51,7 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 			nextVersionMap[name] = version
 			prevVersion, found := sub.ReturnedResources()[name]
 			if !found || (prevVersion != version) {
-				filtered = append(filtered, r)
+				filtered = append(filtered, types.ResourceWithTTL{Resource: r})
 			}
 		}
 
@@ -70,7 +70,7 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 			if r, ok := resourceMap[name]; ok {
 				nextVersion := versionMap[name]
 				if prevVersion != nextVersion {
-					filtered = append(filtered, r)
+					filtered = append(filtered, types.ResourceWithTTL{Resource: r})
 				}
 				nextVersionMap[name] = nextVersion
 			} else if found {


### PR DESCRIPTION
Following previous rework of sotw and delta handling, the remaining differences of behavior between the two are:
 - on first request, check the returned version in sotw to validate version prefix. Also compute the version differently
 - in some cases, return full state in sotw. In other cases don't return if the only change is deletion
 - compute the version differently

In this context, the code can now be mostly merged, apart from the type differences on requests and responses (which I think can be reduced to none soon, but requires more rework on simple side and would be somewhat backward incompatible). In this commit, the linear cache no longer treats sotw and delta watches differently. They are tracked in the same maps and the changes and responses are computed in a common method. Differences in behavior (e.g. full state or which version to use) is now a functional attribute of the watch itself. There are two main parts not yet fully merged:
 - changing the version in sotw when using stable versions. The requirement to prepend cache version prefix makes it harder to abstract
 - defining whether a change only removing resources should trigger a response. This could be made a functional flag but given its intersection with `fullStateResponses` seemed fragile