### PR TITLE
[Linear] Ensure a resource is only serialized/hashed at most once to reply it

### DIFF
--- a/pkg/cache/v3/cache_test.go
+++ b/pkg/cache/v3/cache_test.go
@@ -1,4 +1,4 @@
-package cache_test
+package cache
 
 import (
 	"testing"
@@ -12,7 +12,6 @@ import (
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 )
 
@@ -21,11 +20,11 @@ const (
 )
 
 func TestResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []types.ResourceWithTTL{{Resource: &route.RouteConfiguration{Name: resourceName}}}
-	resp := cache.RawResponse{
+	routes := []*cachedResource{newCachedResource(resourceName, &route.RouteConfiguration{Name: resourceName}, "v")}
+	resp := RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
-		Resources: routes,
+		resources: routes,
 	}
 
 	discoveryResponse, err := resp.GetDiscoveryResponse()
@@ -52,7 +51,7 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 		Resources:   []*anypb.Any{rsrc},
 		VersionInfo: "v",
 	}
-	resp := cache.PassthroughResponse{
+	resp := PassthroughResponse{
 		Request:           &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		DiscoveryResponse: dr,
 	}
@@ -70,11 +69,11 @@ func TestPassthroughResponseGetDiscoveryResponse(t *testing.T) {
 }
 
 func TestHeartbeatResponseGetDiscoveryResponse(t *testing.T) {
-	routes := []types.ResourceWithTTL{{Resource: &route.RouteConfiguration{Name: resourceName}}}
-	resp := cache.RawResponse{
+	routes := []*cachedResource{newCachedResource(resourceName, &route.RouteConfiguration{Name: resourceName}, "v")}
+	resp := RawResponse{
 		Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
 		Version:   "v",
-		Resources: routes,
+		resources: routes,
 		Heartbeat: true,
 	}
 

--- a/pkg/cache/v3/cached_resource.go
+++ b/pkg/cache/v3/cached_resource.go
@@ -1,0 +1,69 @@
+package cache
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+)
+
+// cachedResource is used to track resources added by the user in the cache.
+// It contains the resource itself and its associated version (currently in two different modes).
+type cachedResource struct {
+	name string
+
+	// resource must not be modified once the cachedResource is created.
+	resource types.Resource
+	ttl      *time.Duration
+
+	// cacheVersion is the version of the cache at the time of last update, used in sotw.
+	cacheVersion string
+
+	marshalFunc                func() ([]byte, error)
+	computeResourceVersionFunc func() (string, error)
+}
+
+func newCachedResource(name string, res types.Resource, cacheVersion string) *cachedResource {
+	marshalFunc := sync.OnceValues(func() ([]byte, error) {
+		return MarshalResource(res)
+	})
+	return &cachedResource{
+		name:         name,
+		resource:     res,
+		cacheVersion: cacheVersion,
+		marshalFunc:  marshalFunc,
+		computeResourceVersionFunc: sync.OnceValues(func() (string, error) {
+			marshaled, err := marshalFunc()
+			if err != nil {
+				return "", fmt.Errorf("marshaling resource: %w", err)
+			}
+			return HashResource(marshaled), nil
+		}),
+	}
+}
+
+func newCachedResourceWithTTL(name string, res types.ResourceWithTTL, cacheVersion string) *cachedResource {
+	cachedRes := newCachedResource(name, res.Resource, cacheVersion)
+	cachedRes.ttl = res.TTL
+	return cachedRes
+}
+
+// getMarshaledResource lazily marshals the resource and returns the bytes.
+func (c *cachedResource) getMarshaledResource() ([]byte, error) {
+	return c.marshalFunc()
+}
+
+// getResourceVersion lazily hashes the resource and returns the stable hash used to track version changes.
+func (c *cachedResource) getResourceVersion() (string, error) {
+	return c.computeResourceVersionFunc()
+}
+
+// getVersion returns the requested version.
+func (c *cachedResource) getVersion(useResourceVersion bool) (string, error) {
+	if !useResourceVersion {
+		return c.cacheVersion, nil
+	}
+
+	return c.getResourceVersion()
+}

--- a/pkg/cache/v3/delta_test.go
+++ b/pkg/cache/v3/delta_test.go
@@ -56,7 +56,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
+				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).GetRawResources()), snapshot.GetResourcesAndTTL(typ))
 				sub := subscriptions[typ]
 				sub.SetReturnedResources(out.GetNextVersionMap())
 				subscriptions[typ] = sub
@@ -104,7 +104,7 @@ func TestSnapshotCacheDeltaWatch(t *testing.T) {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
 		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{resource.MakeEndpoint(clusterName, 9090)})
-		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
+		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).GetRawResources()), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
 		sub := subscriptions[testTypes[0]]
 		sub.SetReturnedResources(out.GetNextVersionMap())
 		subscriptions[testTypes[0]] = sub
@@ -140,7 +140,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 			select {
 			case out := <-watches[typ]:
 				snapshot := fixture.snapshot()
-				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot.GetResourcesAndTTL(typ))
+				assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).GetRawResources()), snapshot.GetResourcesAndTTL(typ))
 				nextVersionMap := out.GetNextVersionMap()
 				subscriptions[typ].SetReturnedResources(nextVersionMap)
 			case <-time.After(time.Second):
@@ -176,7 +176,7 @@ func TestDeltaRemoveResources(t *testing.T) {
 	case out := <-watches[testTypes[0]]:
 		snapshot2 := fixture.snapshot()
 		snapshot2.Resources[types.Endpoint] = cache.NewResources(fixture.version2, []types.Resource{})
-		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).Resources), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
+		assertResourceMapEqual(t, cache.IndexResourcesByName(out.(*cache.RawDeltaResponse).GetRawResources()), snapshot2.GetResourcesAndTTL(rsrc.EndpointType))
 		nextVersionMap := out.GetNextVersionMap()
 
 		// make sure the version maps are different since we no longer are tracking any endpoint resources

--- a/pkg/cache/v3/resource.go
+++ b/pkg/cache/v3/resource.go
@@ -124,6 +124,15 @@ func GetResourceNames(resources []types.ResourceWithTTL) []string {
 	return out
 }
 
+// getCachedResourceNames returns the resource names for a list of valid xDS response types.
+func getCachedResourceNames(resources []*cachedResource) []string {
+	out := make([]string, len(resources))
+	for i, r := range resources {
+		out[i] = GetResourceName(r.resource)
+	}
+	return out
+}
+
 // MarshalResource converts the Resource to MarshaledResource.
 func MarshalResource(resource types.Resource) (types.MarshaledResource, error) {
 	return proto.MarshalOptions{Deterministic: true}.Marshal(resource)

--- a/pkg/cache/v3/simple_test.go
+++ b/pkg/cache/v3/simple_test.go
@@ -131,7 +131,7 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 			case out := <-value:
 				gotVersion, _ := out.GetVersion()
 				assert.Equalf(t, gotVersion, fixture.version, "got version %q, want %q", gotVersion, fixture.version)
-				assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResourcesAndTTL(typ))
+				assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshotWithTTL.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshotWithTTL.GetResourcesAndTTL(typ))
 
 				updateFromSotwResponse(out, &sub, req)
 				subs[typ] = sub
@@ -162,9 +162,9 @@ func TestSnapshotCacheWithTTL(t *testing.T) {
 				case out := <-value:
 					gotVersion, _ := out.GetVersion()
 					assert.Equalf(t, gotVersion, fixture.version, "got version %q, want %q", gotVersion, fixture.version)
-					assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
+					assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshotWithTTL.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshotWithTTL.GetResources(typ))
 
-					assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshotWithTTL.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshotWithTTL.GetResources(typ))
+					assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshotWithTTL.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshotWithTTL.GetResources(typ))
 
 					updatesByType[typ]++
 
@@ -227,7 +227,7 @@ func TestSnapshotCache(t *testing.T) {
 				snapshot := fixture.snapshot()
 				gotVersion, _ := out.GetVersion()
 				assert.Equalf(t, gotVersion, fixture.version, "got version %q, want %q", gotVersion, fixture.version)
-				assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
+				assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshot.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshot.GetResourcesAndTTL(typ))
 			case <-time.After(time.Second):
 				t.Fatal("failed to receive snapshot response")
 			}
@@ -283,7 +283,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 				gotVersion, _ := out.GetVersion()
 				assert.Equalf(t, gotVersion, fixture.version, "got version %q, want %q", gotVersion, fixture.version)
 				snapshot := fixture.snapshot()
-				assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot.GetResourcesAndTTL(typ))
+				assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshot.GetResourcesAndTTL(typ)), "get resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshot.GetResourcesAndTTL(typ))
 				returnedResources := make(map[string]string)
 				// Update sub to track what was returned
 				for _, resource := range out.GetRequest().GetResourceNames() {
@@ -320,7 +320,7 @@ func TestSnapshotCacheWatch(t *testing.T) {
 	case out := <-watches[rsrc.EndpointType]:
 		gotVersion, _ := out.GetVersion()
 		assert.Equalf(t, gotVersion, fixture.version2, "got version %q, want %q", gotVersion, fixture.version2)
-		assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items), "got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
+		assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshot2.Resources[types.Endpoint].Items), "got resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshot2.Resources[types.Endpoint].Items)
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")
 	}
@@ -443,7 +443,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 		gotVersion, _ := out.GetVersion()
 		assert.Equalf(t, gotVersion, fixture.version, "got version %q, want %q", gotVersion, fixture.version)
 		want := map[string]types.ResourceWithTTL{clusterName: snapshot2.Resources[types.Endpoint].Items[clusterName]}
-		assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), want), "got resources %v, want %v", out.(*cache.RawResponse).Resources, want)
+		assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), want), "got resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), want)
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")
 	}
@@ -464,7 +464,7 @@ func TestSnapshotCreateWatchWithResourcePreviouslyNotRequested(t *testing.T) {
 	case out := <-watch:
 		gotVersion, _ := out.GetVersion()
 		assert.Equalf(t, gotVersion, fixture.version, "got version %q, want %q", gotVersion, fixture.version)
-		assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).Resources), snapshot2.Resources[types.Endpoint].Items), "got resources %v, want %v", out.(*cache.RawResponse).Resources, snapshot2.Resources[types.Endpoint].Items)
+		assert.Truef(t, reflect.DeepEqual(cache.IndexResourcesByName(out.(*cache.RawResponse).GetRawResources()), snapshot2.Resources[types.Endpoint].Items), "got resources %v, want %v", out.(*cache.RawResponse).GetRawResources(), snapshot2.Resources[types.Endpoint].Items)
 	case <-time.After(time.Second):
 		t.Fatal("failed to receive snapshot response")
 	}

--- a/pkg/cache/v3/status.go
+++ b/pkg/cache/v3/status.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 // NodeHash computes string identifiers for Envoy nodes.
@@ -109,15 +108,15 @@ func (w ResponseWatch) isDelta() bool {
 	return false
 }
 
-func (w ResponseWatch) useStableVersion() bool {
+func (w ResponseWatch) useResourceVersion() bool {
 	return false
 }
 
-func (w ResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, _ []string, returnedVersions map[string]string, version string) WatchResponse {
+func (w ResponseWatch) buildResponse(updatedResources []*cachedResource, _ []string, returnedVersions map[string]string, version string) WatchResponse {
 	return &RawResponse{
 		Request:           w.Request,
-		Resources:         updatedResources,
-		ReturnedResources: returnedVersions,
+		resources:         updatedResources,
+		returnedResources: returnedVersions,
 		Version:           version,
 		Ctx:               context.Background(),
 	}
@@ -151,7 +150,7 @@ func (w DeltaResponseWatch) isDelta() bool {
 	return true
 }
 
-func (w DeltaResponseWatch) useStableVersion() bool {
+func (w DeltaResponseWatch) useResourceVersion() bool {
 	return true
 }
 
@@ -163,12 +162,12 @@ func (w DeltaResponseWatch) getSubscription() Subscription {
 	return w.subscription
 }
 
-func (w DeltaResponseWatch) buildResponse(updatedResources []types.ResourceWithTTL, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
+func (w DeltaResponseWatch) buildResponse(updatedResources []*cachedResource, removedResources []string, returnedVersions map[string]string, version string) WatchResponse {
 	return &RawDeltaResponse{
 		DeltaRequest:      w.Request,
-		Resources:         updatedResources,
-		RemovedResources:  removedResources,
-		NextVersionMap:    returnedVersions,
+		resources:         updatedResources,
+		removedResources:  removedResources,
+		returnedResources: returnedVersions,
 		SystemVersionInfo: version,
 		Ctx:               context.Background(),
 	}

--- a/pkg/server/v3/delta_test.go
+++ b/pkg/server/v3/delta_test.go
@@ -80,13 +80,13 @@ func (config *mockConfigWatcher) CreateDeltaWatch(req *discovery.DeltaDiscoveryR
 	}
 
 	if len(filtered)+len(toRemove) > 0 {
-		out <- &cache.RawDeltaResponse{
-			DeltaRequest:      req,
-			Resources:         filtered,
-			RemovedResources:  toRemove,
-			SystemVersionInfo: "",
-			NextVersionMap:    nextVersionMap,
-		}
+		out <- cache.NewTestRawDeltaResponse(
+			req,
+			"",
+			filtered,
+			toRemove,
+			nextVersionMap,
+		)
 	} else {
 		config.deltaWatches++
 		return func() {

--- a/pkg/server/v3/gateway_test.go
+++ b/pkg/server/v3/gateway_test.go
@@ -36,25 +36,25 @@ func TestGateway(t *testing.T) {
 	config := makeMockConfigWatcher()
 	config.responses = map[string][]cache.Response{
 		resource.ClusterType: {
-			&cache.RawResponse{
-				Version:   "2",
-				Resources: []types.ResourceWithTTL{{Resource: cluster}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: resource.ClusterType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: resource.ClusterType},
+				"2",
+				[]types.ResourceWithTTL{{Resource: cluster}},
+			),
 		},
 		resource.RouteType: {
-			&cache.RawResponse{
-				Version:   "3",
-				Resources: []types.ResourceWithTTL{{Resource: route}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: resource.RouteType},
+				"3",
+				[]types.ResourceWithTTL{{Resource: route}},
+			),
 		},
 		resource.ListenerType: {
-			&cache.RawResponse{
-				Version:   "4",
-				Resources: []types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: resource.ListenerType},
-			},
+			cache.NewTestRawResponse(
+				&discovery.DiscoveryRequest{TypeUrl: resource.ListenerType},
+				"4",
+				[]types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
+			),
 		},
 	}
 	gtw := server.HTTPGateway{Server: server.NewServer(context.Background(), config, nil)}

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -187,79 +187,65 @@ var (
 )
 
 func makeResponses() map[string][]cache.Response {
-	return map[string][]cache.Response{
-		rsrc.EndpointType: {
-			&cache.RawResponse{
-				Version:   "1",
-				Resources: []types.ResourceWithTTL{{Resource: endpoint}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.EndpointType},
-			},
+	testTypes := []struct {
+		typeURL   string
+		resources []types.Resource
+	}{
+		{
+			typeURL:   rsrc.EndpointType,
+			resources: []types.Resource{endpoint},
 		},
-		rsrc.ClusterType: {
-			&cache.RawResponse{
-				Version:   "2",
-				Resources: []types.ResourceWithTTL{{Resource: cluster}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ClusterType},
-			},
+		{
+			typeURL:   rsrc.ClusterType,
+			resources: []types.Resource{cluster},
 		},
-		rsrc.RouteType: {
-			&cache.RawResponse{
-				Version:   "3",
-				Resources: []types.ResourceWithTTL{{Resource: route}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RouteType},
-			},
+		{
+			typeURL:   rsrc.RouteType,
+			resources: []types.Resource{route},
 		},
-		rsrc.ScopedRouteType: {
-			&cache.RawResponse{
-				Version:   "4",
-				Resources: []types.ResourceWithTTL{{Resource: scopedRoute}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ScopedRouteType},
-			},
+		{
+			typeURL:   rsrc.ScopedRouteType,
+			resources: []types.Resource{scopedRoute},
 		},
-		rsrc.VirtualHostType: {
-			&cache.RawResponse{
-				Version:   "5",
-				Resources: []types.ResourceWithTTL{{Resource: virtualHost}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.VirtualHostType},
-			},
+		{
+			typeURL:   rsrc.VirtualHostType,
+			resources: []types.Resource{virtualHost},
 		},
-		rsrc.ListenerType: {
-			&cache.RawResponse{
-				Version:   "6",
-				Resources: []types.ResourceWithTTL{{Resource: httpListener}, {Resource: httpScopedListener}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ListenerType},
-			},
+		{
+			typeURL:   rsrc.ListenerType,
+			resources: []types.Resource{httpListener, httpScopedListener},
 		},
-		rsrc.SecretType: {
-			&cache.RawResponse{
-				Version:   "7",
-				Resources: []types.ResourceWithTTL{{Resource: secret}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.SecretType},
-			},
+		{
+			typeURL:   rsrc.SecretType,
+			resources: []types.Resource{secret},
 		},
-		rsrc.RuntimeType: {
-			&cache.RawResponse{
-				Version:   "8",
-				Resources: []types.ResourceWithTTL{{Resource: runtime}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.RuntimeType},
-			},
+		{
+			typeURL:   rsrc.RuntimeType,
+			resources: []types.Resource{runtime},
 		},
-		rsrc.ExtensionConfigType: {
-			&cache.RawResponse{
-				Version:   "9",
-				Resources: []types.ResourceWithTTL{{Resource: extensionConfig}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: rsrc.ExtensionConfigType},
-			},
+		{
+			typeURL:   rsrc.ExtensionConfigType,
+			resources: []types.Resource{extensionConfig},
 		},
-		// Pass-through type (xDS does not exist for this type)
-		opaqueType: {
-			&cache.RawResponse{
-				Version:   "10",
-				Resources: []types.ResourceWithTTL{{Resource: opaque}},
-				Request:   &discovery.DiscoveryRequest{TypeUrl: opaqueType},
-			},
+		{
+			typeURL:   opaqueType,
+			resources: []types.Resource{opaque},
 		},
 	}
+
+	responses := map[string][]cache.Response{}
+	for i, res := range testTypes {
+		resWithTTL := []types.ResourceWithTTL{}
+		for _, r := range res.resources {
+			resWithTTL = append(resWithTTL, types.ResourceWithTTL{Resource: r})
+		}
+		responses[res.typeURL] = []cache.Response{cache.NewTestRawResponse(
+			&discovery.DiscoveryRequest{TypeUrl: res.typeURL},
+			strconv.Itoa(i+1),
+			resWithTTL,
+		)}
+	}
+	return responses
 }
 
 func TestServerShutdown(t *testing.T) {


### PR DESCRIPTION
Currently the go-control-plane caches (both linear and snapshots) will serialize the resource as many times as there are clients receiving it. This is an issue with control-planes watched by a lot of clients, especially with large resources (e.g. endpoints)

This commit ensures that the serialization occurs at most once per resource, in all cases (sotw/delta watches and linear/snapshot cache). A resource will still only be serialized if:
  - it is returned to at least one client.
  - its version had to be considered to be returned (i.e. the resource was added again with the same stable version).

This does not yet remove the use of the version map in snapshot mode.
In linear mode a major gain already occurred in https://github.com/envoyproxy/go-control-plane/pull/1320 removing the hashing of resources never considered to be returned (which could be significant for endpoints depending on how the cache is managed).