### PR TITLE
Release go-control-plane v0.14.0

### DIFF
--- a/contrib/go.mod
+++ b/contrib/go.mod
@@ -8,7 +8,7 @@ replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 
 require (
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443
-	github.com/envoyproxy/go-control-plane/envoy v1.35.0
+	github.com/envoyproxy/go-control-plane/envoy v1.36.0
 	github.com/envoyproxy/protoc-gen-validate v1.2.1
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10
 	google.golang.org/grpc v1.75.1

--- a/examples/dyplomat/go.mod
+++ b/examples/dyplomat/go.mod
@@ -12,7 +12,7 @@ replace (
 
 require (
 	github.com/envoyproxy/go-control-plane v0.13.4
-	github.com/envoyproxy/go-control-plane/envoy v1.35.0
+	github.com/envoyproxy/go-control-plane/envoy v1.36.0
 	google.golang.org/grpc v1.75.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.32.3

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace (
 )
 
 require (
-	github.com/envoyproxy/go-control-plane/envoy v1.35.0
+	github.com/envoyproxy/go-control-plane/envoy v1.36.0
 	github.com/envoyproxy/go-control-plane/ratelimit v0.1.0
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.11.1

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,11 +1,11 @@
 module-sets:
   go-control-plane:
-    version: v0.13.4
+    version: v0.14.0
     modules:
       - github.com/envoyproxy/go-control-plane
       - github.com/envoyproxy/go-control-plane/xdsmatcher
   envoy:
-    version: v1.35.0
+    version: v1.36.0
     modules:
       - github.com/envoyproxy/go-control-plane/envoy
       - github.com/envoyproxy/go-control-plane/contrib

--- a/xdsmatcher/go.mod
+++ b/xdsmatcher/go.mod
@@ -8,7 +8,7 @@ replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 
 require (
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443
-	github.com/envoyproxy/go-control-plane/envoy v1.35.0
+	github.com/envoyproxy/go-control-plane/envoy v1.36.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v2 v2.4.0


### PR DESCRIPTION
There has been many recent updates on `go-control-plane`, mostly targeted towards improving gRPC-XDS support, improving linear cache performances and limiting drift between delta and sotw protocol implementations. 
Cut a new tag to allow simple import for users.

**/!\ There is API breakage in this release. /!\ This should not impact most usage of go-control-plane, but users implementing a Cache implementation or using it for tests will have to update the interface of CreateWatch and CreateDeltaWatch**