### PR TITLE
bump Go version and toolchain to 1.24.0 and 1.24.9 across all modules

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,3 +1,3 @@
-FROM golang:1.23@sha256:77a21b3e354c03e9f66b13bc39f4f0db8085c70f8414406af66b29c6d6c4dd85
+FROM golang:1.24@sha256:8b788ecf5fddb91cd04e532205d6411de68a08b510885bb8fb1c93f54c03f737
 
 COPY --from=envoyproxy/envoy-dev:latest /usr/local/bin/envoy /usr/local/bin/envoy

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ feedback, we might decide to revisit this aspect at a later point in time.
 
 ## Requirements
 
-1. Go 1.23+
+1. Go 1.24+
 
 ## Quick start
 

--- a/contrib/go.mod
+++ b/contrib/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/contrib
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.9
 
 replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 

--- a/envoy/go.mod
+++ b/envoy/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/envoy
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.9
 
 // Used to resolve import issues related to go-control-plane package split (https://github.com/envoyproxy/go-control-plane/issues/1074)
 replace github.com/envoyproxy/go-control-plane@v0.13.4 => ../

--- a/examples/dyplomat/Dockerfile
+++ b/examples/dyplomat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23@sha256:77a21b3e354c03e9f66b13bc39f4f0db8085c70f8414406af66b29c6d6c4dd85
+FROM golang:1.24@sha256:8b788ecf5fddb91cd04e532205d6411de68a08b510885bb8fb1c93f54c03f737
 
 WORKDIR /go/src/dyplomat
 COPY . /go/src/dyplomat

--- a/examples/dyplomat/go.mod
+++ b/examples/dyplomat/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/examples/dyplomat
 
-go 1.23.4
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.9
 
 replace (
 	github.com/envoyproxy/go-control-plane => ../..

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.9
 
 replace (
 	github.com/envoyproxy/go-control-plane/envoy => ./envoy

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/internal/tools
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.9
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.3.1

--- a/pkg/server/sotw/v3/ads.go
+++ b/pkg/server/sotw/v3/ads.go
@@ -49,7 +49,7 @@ func (s *server) processADS(sw *streamWrapper, reqCh chan *discovery.DiscoveryRe
 		// We only watch the multiplexed channel since we don't use per watch channels.
 		case res := <-respChan:
 			if err := sw.send(res); err != nil {
-				return status.Errorf(codes.Unavailable, err.Error())
+				return status.Errorf(codes.Unavailable, "%s", err.Error())
 			}
 		case req, ok := <-reqCh:
 			// Input stream ended or failed.

--- a/ratelimit/go.mod
+++ b/ratelimit/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/ratelimit
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.9
 
 replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 

--- a/xdsmatcher/go.mod
+++ b/xdsmatcher/go.mod
@@ -1,8 +1,8 @@
 module github.com/envoyproxy/go-control-plane/xdsmatcher
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.9
 
 replace github.com/envoyproxy/go-control-plane/envoy => ../envoy
 


### PR DESCRIPTION
#### Description

Go 1.25 is available since August 2025, see https://go.dev/doc/go1.25 

bump Go version and toolchain to 1.24.0 and 1.24.9 across all modules