### PR TITLE
filepath-clean-misuse

### DIFF
--- a/pkg/server/v3/gateway.go
+++ b/pkg/server/v3/gateway.go
@@ -16,10 +16,12 @@ package server
 
 import (
 	"errors"
+	"path/filepath"
 	"fmt"
 	"io"
 	"net/http"
 	"path"
+	"strings"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -36,7 +38,7 @@ type HTTPGateway struct {
 }
 
 func (h *HTTPGateway) ServeHTTP(req *http.Request) ([]byte, int, error) {
-	p := path.Clean(req.URL.Path)
+	p := filepath.FromSlash(path.Clean("/" + strings.Trim(req.URL.Path, "/")))
 
 	typeURL := ""
 	switch p {


### PR DESCRIPTION
`Clean` is not intended to sanitize against path traversal attacks. This function is for finding the shortest path name equivalent to the given input. Using `Clean` to sanitize file reads may expose this application to path traversal attacks, where an attacker could access arbitrary files on the server. To fix this easily, write this: `filepath.FromSlash(path.Clean("/"+strings.Trim(req.URL.Path, "/")))` However, a better solution is using the `SecureJoin` function in the package `filepath-securejoin`. See https://pkg.go.dev/github.com/cyphar/filepath-securejoin#section-readme.
Branch: main
Line: 39
File Path:
/tools/scanResult/unzipped-2407813448/pkg/server/v3/gateway.go

