### PR TITLE
ci: fixup envoy-sync with libtinfo

### DIFF
--- a/.github/workflows/envoy-sync.yaml
+++ b/.github/workflows/envoy-sync.yaml
@@ -45,6 +45,12 @@ jobs:
         path: upstream
 
     - run: mv upstream ../envoy
+
+    - name: Install libtinfo5
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libtinfo5
+
     - run: ci/sync_envoy.sh
       env:
         ENVOY_SRC_DIR: ../envoy


### PR DESCRIPTION
trying to fix sync envoy job as it currently fails with:
```
../../../../../external/llvm_toolchain_llvm/bin/clang: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
stdlib: error running subcommand external/go_sdk/bin/go: exit status 1
```

https://github.com/envoyproxy/go-control-plane/actions/runs/20104565778/job/57684566232

I am honestly not sure where this is the right place to change this, let me know how we should approach it.