### PR TITLE
[cache/linear] Propagate err in SetResources

### DIFF
--- a/pkg/cache/v3/linear.go
+++ b/pkg/cache/v3/linear.go
@@ -443,7 +443,7 @@ func (cache *LinearCache) UpdateResources(toUpdate map[string]types.Resource, to
 // SetResources replaces current resources with a new set of resources.
 // Given the use of lazy serialization, if most resources are actually the same
 // using UpdateResources instead will be much more efficient.
-func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
+func (cache *LinearCache) SetResources(resources map[string]types.Resource) error {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
@@ -468,7 +468,10 @@ func (cache *LinearCache) SetResources(resources map[string]types.Resource) {
 
 	if err := cache.notifyAll(modified); err != nil {
 		cache.log.Errorf("Failed to notify watches: %s", err.Error())
+		return err
 	}
+
+	return nil
 }
 
 // GetResources returns current resources stored in the cache.

--- a/pkg/cache/v3/linear_test.go
+++ b/pkg/cache/v3/linear_test.go
@@ -336,10 +336,10 @@ func TestLinearSetResources(t *testing.T) {
 	require.NoError(t, err)
 	mustBlock(t, w2)
 
-	c.SetResources(map[string]types.Resource{
+	require.NoError(t, c.SetResources(map[string]types.Resource{
 		"a": testResource("a"),
 		"b": testResource("b"),
-	})
+	}))
 	resp1 := verifyResponse(t, w1, "1", 1)
 	updateFromSotwResponse(resp1, &sub1, req1)
 	resp2 := verifyResponse(t, w2, "1", 2) // the version was only incremented once for all resources
@@ -353,11 +353,11 @@ func TestLinearSetResources(t *testing.T) {
 	require.NoError(t, err)
 	mustBlock(t, w2)
 
-	c.SetResources(map[string]types.Resource{
+	require.NoError(t, c.SetResources(map[string]types.Resource{
 		"a": testResource("aa"),
 		"b": testResource("b"),
 		"c": testResource("c"),
-	})
+	}))
 	resp1 = verifyResponse(t, w1, "2", 1)
 	updateFromSotwResponse(resp1, &sub1, req1)
 	resp2 = verifyResponse(t, w2, "2", 3)
@@ -371,10 +371,10 @@ func TestLinearSetResources(t *testing.T) {
 	require.NoError(t, err)
 	mustBlock(t, w2)
 
-	c.SetResources(map[string]types.Resource{
+	require.NoError(t, c.SetResources(map[string]types.Resource{
 		"b": testResource("b"),
 		"c": testResource("c"),
-	})
+	}))
 	mustBlock(t, w1) // removing a resource from the set does not trigger the watch for non full state resources
 	verifyResponse(t, w2, "3", 2)
 }
@@ -387,7 +387,7 @@ func TestLinearGetResources(t *testing.T) {
 		"b": testResource("b"),
 	}
 
-	c.SetResources(expectedResources)
+	require.NoError(t, c.SetResources(expectedResources))
 
 	resources := c.GetResources()
 
@@ -778,7 +778,7 @@ func TestLinearDeltaResourceDelete(t *testing.T) {
 		{Priority: 10},
 	}}
 	hashA = hashResource(t, a)
-	c.SetResources(map[string]types.Resource{"a": a})
+	require.NoError(t, c.SetResources(map[string]types.Resource{"a": a}))
 	verifyDeltaResponse(t, w, []resourceInfo{{"a", hashA}}, []string{"b"})
 }
 


### PR DESCRIPTION
# Description

Propagate error in SetResources method to the caller (instead of just logging).

#<issue>

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Go Toolchain:

# Checklist:

- [ ] I have made corresponding changes to the changelog
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I've added sufficient test coverage for my change. If not, please explain why.
