### PR TITLE
stream: guard delta subscriptions against nil returned resource maps

### DIFF
--- a/pkg/server/stream/v3/subscription.go
+++ b/pkg/server/stream/v3/subscription.go
@@ -221,5 +221,8 @@ func (s Subscription) ReturnedResources() map[string]string {
 // SetReturnedResources sets a list of resource versions currently known by the client
 // The cache can use this state to compute resources added/updated/deleted.
 func (s *Subscription) SetReturnedResources(resourceVersions map[string]string) {
+	if resourceVersions == nil {
+		resourceVersions = make(map[string]string)
+	}
 	s.returnedResources = resourceVersions
 }

--- a/pkg/server/stream/v3/subscription_test.go
+++ b/pkg/server/stream/v3/subscription_test.go
@@ -268,3 +268,15 @@ func TestDeltaSubscriptionsWithDeactivatedLegacyWildcardForTypes(t *testing.T) {
 		assert.True(t, subRoute.IsWildcard())
 	})
 }
+
+func TestDeltaSubscriptionsSetReturnedResourcesNilDoesNotPanicOnWildcardUnsubscribe(t *testing.T) {
+	sub := NewDeltaSubscription([]string{"*", "resource"}, nil, map[string]string{"resource": "version"}, false)
+	assert.True(t, sub.IsWildcard())
+
+	sub.SetReturnedResources(nil)
+
+	assert.NotPanics(t, func() {
+		sub.UpdateResourceSubscriptions(nil, []string{"resource"})
+	})
+	assert.Equal(t, map[string]string{"resource": ""}, sub.ReturnedResources())
+}


### PR DESCRIPTION
# Description

Small bug fix in delta subscription state.

`SetReturnedResources(nil)` leaves `returnedResources` nil. If the subscription is wildcard and later unsubscribes a named resource, `UpdateResourceSubscriptions` writes into that map and panics with `assignment to entry in nil map`.

This patch normalizes `nil` to an empty map, so that path stays safe. Pretty small footgun, easy fix.

#<issue>

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Repro before fix:

```go
sub := stream.NewDeltaSubscription([]string{"*", "resource"}, nil, map[string]string{"resource": "version"}, false)
sub.SetReturnedResources(nil)
sub.UpdateResourceSubscriptions(nil, []string{"resource"})
```

Before this patch, that panics. After it, no panic and `resource` is tracked as removed, as expected.

- [x] `go test ./...`
- [x] `go test -race ./pkg/server/stream/v3 ./pkg/cache/v3 ./pkg/server/v3`

**Test Configuration**:
* Go Toolchain: `go1.25.0`

# Checklist:

- [ ] I have made corresponding changes to the changelog
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I've added sufficient test coverage for my change. If not, please explain why.
