### PR TITLE
server: drop stale ADS responses after unsubscribe

### DIFF
--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -125,7 +125,11 @@ func (s *streamWrapper) send(resp cache.Response) error {
 		return errors.New("missing response")
 	}
 
-	typeURL := resp.GetRequest().GetTypeUrl()
+	req := resp.GetRequest()
+	if req == nil {
+		return errors.New("missing request in response")
+	}
+	typeURL := req.GetTypeUrl()
 	w, ok := s.watches.responders[typeURL]
 	if !ok {
 		return fmt.Errorf("no current watch for %s", typeURL)

--- a/pkg/server/sotw/v3/server.go
+++ b/pkg/server/sotw/v3/server.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync/atomic"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -124,6 +125,15 @@ func (s *streamWrapper) send(resp cache.Response) error {
 		return errors.New("missing response")
 	}
 
+	typeURL := resp.GetRequest().GetTypeUrl()
+	w, ok := s.watches.responders[typeURL]
+	if !ok {
+		return fmt.Errorf("no current watch for %s", typeURL)
+	}
+	if !responseMatchesCurrentSubscription(resp, w.sub) {
+		return nil
+	}
+
 	out, err := resp.GetDiscoveryResponse()
 	if err != nil {
 		return err
@@ -131,12 +141,6 @@ func (s *streamWrapper) send(resp cache.Response) error {
 
 	// increment nonce and convert it to base10
 	out.Nonce = strconv.FormatInt(s.nonce.Add(1), 10)
-
-	typeURL := resp.GetRequest().GetTypeUrl()
-	w, ok := s.watches.responders[typeURL]
-	if !ok {
-		return fmt.Errorf("no current watch for %s", typeURL)
-	}
 
 	// Track in the type subcription the nonce and objects returned to the client.
 	w.sub.SetReturnedResources(resp.GetReturnedResources())
@@ -148,6 +152,42 @@ func (s *streamWrapper) send(resp cache.Response) error {
 	}
 
 	return s.stream.Send(out)
+}
+
+func responseMatchesCurrentSubscription(resp cache.Response, sub stream.Subscription) bool {
+	if sub.IsWildcard() {
+		return true
+	}
+
+	returnedResources := resp.GetReturnedResources()
+	if len(returnedResources) == 0 {
+		return true
+	}
+
+	for name := range returnedResources {
+		if _, ok := sub.SubscribedResources()[name]; ok {
+			continue
+		}
+
+		matchedPrefix := false
+		for prefix := range sub.SubscribedPrefixes() {
+			if strings.HasPrefix(name, prefix) {
+				matchedPrefix = true
+				break
+			}
+		}
+		if matchedPrefix {
+			continue
+		}
+
+		// In ordered ADS all resource types share one response channel, so a
+		// response from a superseded watch can be queued after the client has
+		// unsubscribed from those resources. Envoy treats that type as unwatched;
+		// drop the stale response instead of sending it on the stream.
+		return false
+	}
+
+	return true
 }
 
 // Shutdown closes all open watches, and notifies API consumers the stream has closed.

--- a/pkg/server/v3/server_test.go
+++ b/pkg/server/v3/server_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -608,6 +609,62 @@ func TestAggregatedHandlers(t *testing.T) {
 			t.Fatalf("got %d messages on the stream, not %d", count, expectedCount)
 		}
 	}
+}
+
+type staleSotwResponseWatcher struct {
+	staleResponse cache.Response
+	watchCount    int
+}
+
+func (config *staleSotwResponseWatcher) CreateWatch(_ *discovery.DiscoveryRequest, _ cache.Subscription, out chan cache.Response) (func(), error) {
+	config.watchCount++
+	if config.watchCount == 2 {
+		out <- config.staleResponse
+	}
+	return func() {}, nil
+}
+
+func (config *staleSotwResponseWatcher) CreateDeltaWatch(_ *discovery.DeltaDiscoveryRequest, _ cache.Subscription, _ chan cache.DeltaResponse) (func(), error) {
+	return func() {}, nil
+}
+
+func (config *staleSotwResponseWatcher) Fetch(context.Context, *discovery.DiscoveryRequest) (cache.Response, error) {
+	return nil, errors.New("missing")
+}
+
+func TestAggregatedHandlersDropStaleResponseAfterUnsubscribe(t *testing.T) {
+	secretResource, err := anypb.New(secret)
+	require.NoError(t, err)
+
+	initialReq := &discovery.DiscoveryRequest{
+		Node:          node,
+		TypeUrl:       rsrc.SecretType,
+		ResourceNames: []string{secretName},
+	}
+	config := &staleSotwResponseWatcher{
+		staleResponse: &cache.PassthroughResponse{
+			Request: initialReq,
+			DiscoveryResponse: &discovery.DiscoveryResponse{
+				VersionInfo: "1",
+				TypeUrl:     rsrc.SecretType,
+				Resources:   []*anypb.Any{secretResource},
+			},
+			ReturnedResources: map[string]string{secretName: "1"},
+		},
+	}
+
+	resp := makeMockStream(t)
+	resp.recv <- initialReq
+	resp.recv <- &discovery.DiscoveryRequest{
+		Node:    node,
+		TypeUrl: rsrc.SecretType,
+	}
+	close(resp.recv)
+
+	s := server.NewServer(t.Context(), config, server.CallbackFuncs{}, sotw.WithOrderedADS(), sotw.WithLogger(log.NewTestLogger(t)))
+	require.NoError(t, s.StreamAggregatedResources(resp))
+	assert.Equal(t, 2, config.watchCount)
+	assert.Empty(t, resp.sent)
 }
 
 func TestAggregateRequestType(t *testing.T) {


### PR DESCRIPTION
# Description

In ordered ADS, all type watches share a response channel. A response from a superseded watch can be queued after Envoy has updated the same type subscription, such as SDS teardown replacing a named Secret watch with an empty Secret watch.

Filter responses against the current subscription before sending them so stale responses are dropped instead of reaching clients as unwatched resources. 

#<issue>

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Go Toolchain:

# Checklist:

- [ ] I have made corresponding changes to the changelog
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I've added sufficient test coverage for my change. If not, please explain why.
