### PR TITLE
ci: enable Gemini Code Assist reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,7 @@
+code_review:
+  disable: false
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: false
+    include_drafts: false

--- a/.github/workflows/command.yml
+++ b/.github/workflows/command.yml
@@ -1,0 +1,30 @@
+name: Command
+
+permissions:
+  contents: read
+
+on:
+  issue_comment:
+    types:
+    - created
+
+jobs:
+  # ACK /gemini commands with a rocket emoji reaction.
+  # The actual review/summary is handled natively by the Gemini Code Assist GitHub App.
+  gemini:
+    name: ACK Gemini command
+    runs-on: ubuntu-24.04
+    if: >-
+      ${{
+         github.event.issue.pull_request
+         && startsWith(github.event.comment.body, '/gemini')
+         && github.actor != 'gemini-code-assist[bot]'
+      }}
+    permissions:
+      pull-requests: write
+    steps:
+    - name: React with rocket emoji
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9  # v5.0.0
+      with:
+        comment-id: ${{ github.event.comment.id }}
+        reactions: rocket

--- a/.github/workflows/command.yml
+++ b/.github/workflows/command.yml
@@ -15,7 +15,7 @@ jobs:
     name: ACK Gemini command
     runs-on: ubuntu-24.04
     if: >-
-      ${{
+      
          github.event.issue.pull_request
          && startsWith(github.event.comment.body, '/gemini')
          && github.actor != 'gemini-code-assist[bot]'


### PR DESCRIPTION
Adding Gemini Code Assist repository configuration (copy of one used by Envoy) and an issue_comment workflow that acknowledges /gemini commands with a reaction.